### PR TITLE
fix: corregir warnings de build, PWA prompt y copyright

### DIFF
--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import Link from 'next/link';
 import { useCookieConsent } from '../../store/cookieConsent';
 import { useRouter } from 'next/navigation';
@@ -261,8 +261,7 @@ export default function Footer({
 
   const footerClassName = `bg-black border-t border-zinc-800 ${className ?? 'mt-16'}`;
 
-  const { openPreferences, status } = useCookieConsent();
-  const [showCookieMenu, setShowCookieMenu] = useState(false);
+  const { openPreferences } = useCookieConsent();
 
   return (
     <footer className={footerClassName}>
@@ -521,7 +520,7 @@ export default function Footer({
         <div className="max-w-7xl mx-auto px-4 pt-1.5 pb-8 md:pb-4">
           {/* Mobile */}
           <div className="md:hidden text-left space-y-2 mb-6">
-            <div className="text-zinc-400 text-sm">© 2025 AIFinder</div>
+            <div className="text-zinc-400 text-sm">© 2026 AIFinder</div>
             <div className="space-y-1">
               {legalLinks.map((link) => (
                 <Link
@@ -537,7 +536,6 @@ export default function Footer({
             <div className="pt-2">
               <button
                 onClick={() => {
-                  setShowCookieMenu(false);
                   openPreferences();
                 }}
                 className="inline-flex items-center gap-2 text-zinc-400 hover:text-white transition-colors"
@@ -558,7 +556,7 @@ export default function Footer({
           {/* Desktop */}
           <div className="hidden md:flex flex-col md:flex-row justify-between items-center relative">
             <div className="flex items-center mb-4 md:mb-0">
-              <span className="text-zinc-400 text-sm">© 2025 AIFinder</span>
+              <span className="text-zinc-400 text-sm">© 2026 AIFinder</span>
             </div>
             <div className="flex items-center space-x-4">
               {legalLinks.map((link) => (
@@ -573,7 +571,6 @@ export default function Footer({
               <div className="relative">
                 <button
                   onClick={() => {
-                    setShowCookieMenu(false);
                     openPreferences();
                   }}
                   className="text-zinc-400 hover:text-white transition-colors"

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -34,6 +34,7 @@ export default function Footer({
   const { setShowAddAITool } = useAddAIToolContext();
   const { setShowFeedback: contextSetShowFeedback } = useFeedbackContext();
   const { setShowBugReport: contextSetShowBugReport } = useBugReportContext();
+  const { openPreferences } = useCookieConsent();
   // ActiveNav puede no estar disponible en tests; navegamos con router como fallback
 
   // Usar contextos directamente para asegurar que funcione en todas las páginas
@@ -260,8 +261,6 @@ export default function Footer({
   ];
 
   const footerClassName = `bg-black border-t border-zinc-800 ${className ?? 'mt-16'}`;
-
-  const { openPreferences } = useCookieConsent();
 
   return (
     <footer className={footerClassName}>

--- a/src/components/Footer/__tests__/Footer.test.tsx
+++ b/src/components/Footer/__tests__/Footer.test.tsx
@@ -144,7 +144,7 @@ describe('Footer', () => {
   it('should render copyright notice', () => {
     renderWithProvider(React.createElement(Footer, defaultProps));
 
-    expect(screen.getAllByText('© 2025 AIFinder')).toHaveLength(2);
+    expect(screen.getAllByText('© 2026 AIFinder')).toHaveLength(2);
   });
 
   it('should render settings button in desktop', () => {

--- a/src/components/Navigation/Sidebar.tsx
+++ b/src/components/Navigation/Sidebar.tsx
@@ -88,11 +88,6 @@ const mainSectionsDesktop = [
   { key: 'articulos', label: 'Artículos', icon: NewspaperIcon },
   { key: 'herramientas', label: 'Herramientas', icon: WrenchScrewdriverIcon },
 ];
-const mainSectionsMobile = [
-  ...mainSectionsDesktop,
-  { key: 'addtool', label: 'Añadir una IA', icon: PlusCircleIcon },
-];
-
 export default function Sidebar({ onNavigate }: { onNavigate?: () => void } = {}) {
   const router = useRouter();
   const { activeCategory, setActiveCategory } = useAppContext();

--- a/src/components/PWA/PWAInstallPrompt.tsx
+++ b/src/components/PWA/PWAInstallPrompt.tsx
@@ -46,6 +46,7 @@ export default function PWAInstallPrompt() {
     }
     setDeferredPrompt(null);
     setShowInstallPrompt(false);
+    sessionStorage.setItem('pwaPromptDismissed', '1');
   };
 
   const handleDismiss = () => {

--- a/src/components/PWA/PWAInstallPrompt.tsx
+++ b/src/components/PWA/PWAInstallPrompt.tsx
@@ -16,6 +16,10 @@ export default function PWAInstallPrompt() {
   const [showInstallPrompt, setShowInstallPrompt] = useState(false);
 
   useEffect(() => {
+    // No mostrar si el usuario ya lo cerró en esta sesión
+    const dismissed = sessionStorage.getItem('pwaPromptDismissed');
+    if (dismissed) return;
+
     const handler = (e: Event) => {
       e.preventDefault();
       setDeferredPrompt(e as BeforeInstallPromptEvent);
@@ -46,6 +50,7 @@ export default function PWAInstallPrompt() {
 
   const handleDismiss = () => {
     setShowInstallPrompt(false);
+    sessionStorage.setItem('pwaPromptDismissed', '1');
   };
 
   if (!showInstallPrompt) return null;

--- a/src/components/PWA/PWAInstallPrompt.tsx
+++ b/src/components/PWA/PWAInstallPrompt.tsx
@@ -11,13 +11,15 @@ interface BeforeInstallPromptEvent extends Event {
   prompt(): Promise<void>;
 }
 
+const PWA_DISMISS_KEY = 'pwaPromptDismissed';
+
 export default function PWAInstallPrompt() {
   const [deferredPrompt, setDeferredPrompt] = useState<BeforeInstallPromptEvent | null>(null);
   const [showInstallPrompt, setShowInstallPrompt] = useState(false);
 
   useEffect(() => {
     // No mostrar si el usuario ya lo cerró en esta sesión
-    const dismissed = sessionStorage.getItem('pwaPromptDismissed');
+    const dismissed = sessionStorage.getItem(PWA_DISMISS_KEY);
     if (dismissed) return;
 
     const handler = (e: Event) => {
@@ -35,23 +37,31 @@ export default function PWAInstallPrompt() {
 
   const handleInstallClick = async () => {
     if (!deferredPrompt) return;
-    deferredPrompt.prompt();
-    const { outcome } = await deferredPrompt.userChoice;
-    if (process.env.NODE_ENV !== 'production') {
-      if (outcome === 'accepted') {
-        console.log('Usuario aceptó la instalación PWA');
-      } else {
-        console.log('Usuario rechazó la instalación PWA');
+    try {
+      await deferredPrompt.prompt();
+      const { outcome } = await deferredPrompt.userChoice;
+      if (process.env.NODE_ENV !== 'production') {
+        if (outcome === 'accepted') {
+          console.log('Usuario aceptó la instalación PWA');
+        } else {
+          console.log('Usuario rechazó la instalación PWA');
+        }
       }
+    } catch (error) {
+      if (process.env.NODE_ENV !== 'production') {
+        console.error('Error en el prompt de instalación PWA:', error);
+      }
+    } finally {
+      setDeferredPrompt(null);
+      setShowInstallPrompt(false);
+      sessionStorage.setItem(PWA_DISMISS_KEY, '1');
     }
-    setDeferredPrompt(null);
-    setShowInstallPrompt(false);
-    sessionStorage.setItem('pwaPromptDismissed', '1');
   };
 
   const handleDismiss = () => {
+    setDeferredPrompt(null);
     setShowInstallPrompt(false);
-    sessionStorage.setItem('pwaPromptDismissed', '1');
+    sessionStorage.setItem(PWA_DISMISS_KEY, '1');
   };
 
   if (!showInstallPrompt) return null;

--- a/src/components/PWA/PWAStartupRedirect.tsx
+++ b/src/components/PWA/PWAStartupRedirect.tsx
@@ -53,6 +53,7 @@ export default function PWAStartupRedirect() {
         window.scrollTo({ top: 0, behavior: 'auto' });
       }
     });
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- solo debe ejecutarse una vez al montar (inicio de sesión PWA)
   }, []);
 
   return null;

--- a/src/components/PWA/__tests__/PWAInstallPrompt.test.tsx
+++ b/src/components/PWA/__tests__/PWAInstallPrompt.test.tsx
@@ -54,4 +54,30 @@ describe('PWAInstallPrompt', () => {
     expect((evt as any).prompt).toHaveBeenCalled();
     expect(screen.queryByText('Instalar AIFinder')).toBeNull();
   });
+
+  test('does not show prompt if already dismissed in this session', async () => {
+    sessionStorage.setItem('pwaPromptDismissed', '1');
+    render(React.createElement(PWAInstallPrompt));
+    await dispatchBeforeInstallPrompt();
+    expect(screen.queryByText('Instalar AIFinder')).toBeNull();
+  });
+
+  test('persists dismissal in sessionStorage when dismissed via Más tarde', async () => {
+    render(React.createElement(PWAInstallPrompt));
+    await dispatchBeforeInstallPrompt();
+    await screen.findByText('Instalar AIFinder');
+    fireEvent.click(screen.getByText('Más tarde'));
+    expect(sessionStorage.getItem('pwaPromptDismissed')).toBe('1');
+  });
+
+  test('persists dismissal in sessionStorage after install flow', async () => {
+    render(React.createElement(PWAInstallPrompt));
+    const evt = await dispatchBeforeInstallPrompt();
+    await screen.findByText('Instalar AIFinder');
+    await act(async () => {
+      fireEvent.click(screen.getByText('Instalar'));
+      await evt.userChoice;
+    });
+    expect(sessionStorage.getItem('pwaPromptDismissed')).toBe('1');
+  });
 });

--- a/src/components/PWA/__tests__/PWAInstallPrompt.test.tsx
+++ b/src/components/PWA/__tests__/PWAInstallPrompt.test.tsx
@@ -8,6 +8,10 @@ import { render, screen, fireEvent, act } from '@testing-library/react';
 import PWAInstallPrompt from '../PWAInstallPrompt';
 
 describe('PWAInstallPrompt', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
   async function dispatchBeforeInstallPrompt(overrides?: Partial<any>) {
     const event: any = new Event('beforeinstallprompt');
     (event as any).prompt = jest.fn(async () => undefined);

--- a/src/components/views/HomeContainer.tsx
+++ b/src/components/views/HomeContainer.tsx
@@ -215,6 +215,7 @@ export default function HomeContainer({
         setActiveCategory(foundCategory.name);
       }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- sincronizar categoría padre cuando cambia la subcategoría activa
   }, [activeSubcategory]);
 
   if (!isClient) {


### PR DESCRIPTION
## Summary
- **Corregir warnings de ESLint en build**: Silenciar `react-hooks/exhaustive-deps` en `PWAStartupRedirect` y `HomeContainer` con comentarios explicativos (dependencias omitidas intencionalmente para ejecutar solo al montar)
- **Eliminar código muerto**: Variables `status`, `showCookieMenu` en Footer; `mainSectionsMobile` en Sidebar; imports `useState`/`useEffect` no utilizados
- **Persistir dismiss del PWA install prompt**: Guardar en `sessionStorage` cuando el usuario cierra el prompt para que no reaparezca al navegar entre páginas
- **Actualizar copyright**: De 2025 a 2026 en el footer (mobile y desktop)

## Archivos modificados
- `src/components/Footer/Footer.tsx` — Eliminar variables/imports sin usar, actualizar copyright
- `src/components/Navigation/Sidebar.tsx` — Eliminar `mainSectionsMobile` sin usar
- `src/components/PWA/PWAInstallPrompt.tsx` — Persistir dismiss en sessionStorage
- `src/components/PWA/PWAStartupRedirect.tsx` — Añadir eslint-disable con justificación
- `src/components/views/HomeContainer.tsx` — Añadir eslint-disable con justificación

## Test plan
- [ ] Verificar que `npm run build` pasa sin errores (los warnings de Footer/Sidebar/PWAStartupRedirect/HomeContainer se eliminaron)
- [ ] Verificar que el PWA install prompt no reaparece al navegar entre páginas tras cerrarlo
- [ ] Verificar que el copyright muestra "© 2026 AIFinder" en mobile y desktop
- [ ] Verificar que la funcionalidad de cookies sigue funcionando en el footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * PWA install prompt now respects session-scoped dismissals and won't reappear within the same session.

* **Refactor**
  * Simplified mobile navigation for a unified layout.
  * Streamlined cookie consent/preferences handling in the footer and removed redundant local cookie UI state.

* **Tests**
  * Added/updated PWA prompt tests to cover session-based dismissal and clear session storage between tests.
  * Updated footer test for 2026 copyright.

* **Chores**
  * Minor lint/comment adjustments to clarify effect-run intent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->