### PR TITLE
feat(contenido): precios reales, comparativas en profundidad y auditoría del catálogo

### DIFF
--- a/src/app/comparativa/[slug]/page.tsx
+++ b/src/app/comparativa/[slug]/page.tsx
@@ -7,6 +7,7 @@ import { getSiteUrl } from '../../../utils/siteUrl';
 import { findToolBySlug, toolSlug } from '../../../utils/tools';
 import { findComparisonBySlug, getAllComparisons } from '../../../utils/comparisons';
 import { isComparisonPublished, NOINDEX_ROBOTS } from '../../../utils/publishing';
+import { discontinuedTools } from '../../../data/discontinued';
 
 type Props = {
   params: Promise<{ slug: string }>;
@@ -97,6 +98,12 @@ export default async function ComparisonPage({ params }: Props) {
     { tool: toolB, name: comparison.b },
   ];
 
+  // Si una de las dos ha cerrado, la comparativa deja de ser una decisión real
+  const retired = [comparison.a, comparison.b]
+    .filter((name) => discontinuedTools[name])
+    .map((name) => ({ name, note: discontinuedTools[name].note }));
+  const stillAlive = discontinuedTools[comparison.a] ? comparison.b : comparison.a;
+
   return (
     <>
       <script
@@ -126,6 +133,33 @@ export default async function ComparisonPage({ params }: Props) {
         <h1 className="text-3xl md:text-4xl font-extrabold leading-tight mb-6">
           {comparison.title}
         </h1>
+
+        {retired.length > 0 && (
+          <div
+            role="note"
+            className="mb-8 rounded-xl border border-amber-700/60 bg-amber-950/30 p-5"
+          >
+            <p className="font-bold text-amber-200 mb-2">
+              {retired.map((r) => r.name).join(' y ')}{' '}
+              {retired.length > 1 ? 'ya no están disponibles' : 'ya no está disponible'}
+            </p>
+            {retired.map((r) => (
+              <p key={r.name} className="text-zinc-300 leading-relaxed mb-2">
+                {r.note}
+              </p>
+            ))}
+            <p className="text-zinc-400 text-sm mt-3">
+              Mantenemos la comparativa como referencia histórica, pero si estás eligiendo hoy,{' '}
+              <Link
+                href={`/herramienta/${toolSlug(stillAlive)}`}
+                className="text-blue-400 hover:underline"
+              >
+                mira la ficha de {stillAlive}
+              </Link>{' '}
+              o sus alternativas.
+            </p>
+          </div>
+        )}
 
         <div className="grid grid-cols-2 gap-4 mb-8">
           {contenders.map(({ tool, name }) => (
@@ -184,6 +218,24 @@ export default async function ComparisonPage({ params }: Props) {
             </table>
           </div>
         </section>
+
+        {comparison.sections?.map((section) => (
+          <section key={section.title} className="mb-8">
+            <h2 className="text-2xl font-bold mb-3">{section.title}</h2>
+            {section.paragraphs?.map((paragraph) => (
+              <p key={paragraph} className="text-zinc-300 leading-relaxed mb-4">
+                {paragraph}
+              </p>
+            ))}
+            {section.bullets && section.bullets.length > 0 && (
+              <ul className="list-disc pl-5 space-y-2 text-zinc-300">
+                {section.bullets.map((bullet) => (
+                  <li key={bullet}>{bullet}</li>
+                ))}
+              </ul>
+            )}
+          </section>
+        ))}
 
         <section className="mb-8">
           <h2 className="text-2xl font-bold mb-3">Veredicto</h2>

--- a/src/app/herramienta/[slug]/page.tsx
+++ b/src/app/herramienta/[slug]/page.tsx
@@ -10,6 +10,8 @@ import { getPricingText } from '../../../utils/toolUtils';
 import { findToolBySlug, getAllTools, getRelatedTools, getToolDetail } from '../../../utils/tools';
 import { getComparisonsForTool } from '../../../utils/comparisons';
 import { isToolPublished, NOINDEX_ROBOTS } from '../../../utils/publishing';
+import { getToolPricing, PRICING_LAST_CHECKED } from '../../../utils/pricing';
+import { discontinuedTools } from '../../../data/discontinued';
 
 type Props = {
   params: Promise<{ slug: string }>;
@@ -76,6 +78,8 @@ export default async function ToolPage({ params }: Props) {
   const baseUrl = getSiteUrl();
   const related = getRelatedTools(tool);
   const toolComparisons = getComparisonsForTool(tool.name);
+  const pricing = getToolPricing(tool.name);
+  const discontinued = discontinuedTools[tool.name];
   const categorySlug = slugify(tool.category);
   const subcategorySlug = slugify(tool.subcategory);
 
@@ -89,12 +93,17 @@ export default async function ToolPage({ params }: Props) {
     operatingSystem: 'Web',
     url: tool.url,
     image: `${baseUrl}${tool.image}`,
-    offers: {
-      '@type': 'Offer',
-      price: tool.pricing === 'paid' ? undefined : '0',
-      priceCurrency: 'EUR',
-      category: getPricingText(tool.pricing),
-    },
+    // Una herramienta cerrada no tiene oferta que anunciar
+    ...(discontinued
+      ? {}
+      : {
+          offers: {
+            '@type': 'Offer',
+            price: tool.pricing === 'paid' ? undefined : '0',
+            priceCurrency: 'EUR',
+            category: getPricingText(tool.pricing),
+          },
+        }),
   };
 
   const breadcrumbJsonLd = {
@@ -199,21 +208,57 @@ export default async function ToolPage({ params }: Props) {
           </div>
         </header>
 
-        {tool.url && (
-          <a
-            href={tool.url}
-            target="_blank"
-            rel="noopener noreferrer nofollow"
-            className="inline-block mb-8 px-4 py-2 rounded-lg bg-white text-black font-semibold hover:bg-zinc-200 transition-colors"
+        {discontinued ? (
+          <div
+            role="note"
+            className="mb-8 rounded-xl border border-amber-700/60 bg-amber-950/30 p-5"
           >
-            Visitar {tool.name}
-          </a>
+            <p className="font-bold text-amber-200 mb-2">{tool.name} ya no está disponible</p>
+            <p className="text-zinc-300 leading-relaxed">{discontinued.note}</p>
+            <p className="text-zinc-400 text-sm mt-3">
+              Mantenemos esta ficha como referencia.{' '}
+              <a
+                href={discontinued.sourceUrl}
+                target="_blank"
+                rel="noopener noreferrer nofollow"
+                className="text-blue-400 hover:underline"
+              >
+                Consulta el anuncio oficial
+              </a>{' '}
+              o baja hasta las alternativas.
+            </p>
+          </div>
+        ) : (
+          tool.url && (
+            <a
+              href={tool.url}
+              target="_blank"
+              rel="noopener noreferrer nofollow"
+              className="inline-block mb-8 px-4 py-2 rounded-lg bg-white text-black font-semibold hover:bg-zinc-200 transition-colors"
+            >
+              Visitar {tool.name}
+            </a>
+          )
         )}
 
         <section className="mb-8">
           <h2 className="text-2xl font-bold mb-3">¿Qué es {tool.name}?</h2>
           <p className="text-zinc-300 leading-relaxed">{detail.intro}</p>
         </section>
+
+        {/* La captura de la herramienta: antes se pisaba con el logo por el `||`. */}
+        <figure className="mb-8">
+          <Image
+            src={tool.image}
+            alt={`Captura de ${tool.name}`}
+            width={1200}
+            height={675}
+            sizes="(max-width: 768px) 100vw, 900px"
+            style={{ width: '100%', height: 'auto' }}
+            className="rounded-xl border border-zinc-800"
+          />
+          <figcaption className="text-zinc-500 text-sm mt-2">Interfaz de {tool.name}.</figcaption>
+        </figure>
 
         <section className="mb-8">
           <h2 className="text-2xl font-bold mb-3">¿Para qué sirve {tool.name}?</h2>
@@ -252,16 +297,97 @@ export default async function ToolPage({ params }: Props) {
           </div>
         </section>
 
-        <section className="mb-8">
-          <h2 className="text-2xl font-bold mb-3">Precio de {tool.name}</h2>
-          <p className="text-zinc-300 leading-relaxed">{detail.pricingNote}</p>
-        </section>
+        {/* Sin bloque de precios si la herramienta ha cerrado: contradiría el aviso. */}
+        {!discontinued && (
+          <section className="mb-8">
+            <h2 className="text-2xl font-bold mb-3">Precio de {tool.name}</h2>
+
+            {pricing ? (
+              <>
+                {pricing.freeTier && (
+                  <p className="text-zinc-300 leading-relaxed mb-4">
+                    <strong className="text-white">Plan gratuito:</strong> {pricing.freeTier}
+                  </p>
+                )}
+
+                {pricing.plans.length > 0 && (
+                  <div className="overflow-x-auto mb-4">
+                    <table className="min-w-full text-left border-collapse border border-zinc-800">
+                      <thead>
+                        <tr className="bg-zinc-900/60">
+                          <th className="px-4 py-2 border border-zinc-800 text-zinc-200">Plan</th>
+                          <th className="px-4 py-2 border border-zinc-800 text-zinc-200">Precio</th>
+                          <th className="px-4 py-2 border border-zinc-800 text-zinc-200">
+                            Para quién
+                          </th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {pricing.plans.map((plan, index) => (
+                          <tr
+                            key={plan.name}
+                            className={index % 2 === 0 ? 'bg-black' : 'bg-zinc-900/40'}
+                          >
+                            <td className="px-4 py-2 border border-zinc-800 text-zinc-200 font-semibold">
+                              {plan.name}
+                            </td>
+                            <td className="px-4 py-2 border border-zinc-800 text-zinc-300 whitespace-nowrap">
+                              {plan.price}
+                            </td>
+                            <td className="px-4 py-2 border border-zinc-800 text-zinc-300">
+                              {plan.notes}
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                )}
+
+                <p className="text-zinc-300 leading-relaxed">{pricing.notes}</p>
+
+                <p className="text-zinc-500 text-sm mt-3">
+                  Precios consultados en {PRICING_LAST_CHECKED} en{' '}
+                  <a
+                    href={pricing.sourceUrl}
+                    target="_blank"
+                    rel="noopener noreferrer nofollow"
+                    className="text-blue-400 hover:underline"
+                  >
+                    la web oficial de {tool.name}
+                  </a>
+                  . Pueden cambiar sin previo aviso.
+                </p>
+              </>
+            ) : (
+              <>
+                <p className="text-zinc-300 leading-relaxed">{detail.pricingNote}</p>
+                {tool.url && (
+                  <p className="text-zinc-500 text-sm mt-3">
+                    No hemos verificado tarifas concretas de {tool.name}.{' '}
+                    <a
+                      href={tool.url}
+                      target="_blank"
+                      rel="noopener noreferrer nofollow"
+                      className="text-blue-400 hover:underline"
+                    >
+                      Consulta su web oficial
+                    </a>{' '}
+                    para conocer los precios vigentes.
+                  </p>
+                )}
+              </>
+            )}
+          </section>
+        )}
 
         {related.length > 0 && (
           <section className="mb-8">
             <h2 className="text-2xl font-bold mb-3">Alternativas a {tool.name}</h2>
             <p className="text-zinc-300 leading-relaxed mb-4">
-              Otras herramientas de {tool.subcategory} que puedes comparar con {tool.name}:
+              {discontinued
+                ? `Si usabas ${tool.name}, estas herramientas de ${tool.subcategory} cubren lo mismo:`
+                : `Otras herramientas de ${tool.subcategory} que puedes comparar con ${tool.name}:`}
             </p>
             <ToolGrid tools={related} />
           </section>

--- a/src/data/ai-tools.ts
+++ b/src/data/ai-tools.ts
@@ -54,7 +54,7 @@ export const aiCategories: AICategory[] = [
             image: '/images/llama-web.webp',
             description: 'Modelo open source',
             pricing: 'free',
-            url: 'https://llama.meta.com',
+            url: 'https://developer.meta.com/ai/',
           },
           {
             name: 'Qwen',
@@ -69,7 +69,7 @@ export const aiCategories: AICategory[] = [
             logo: '/logos/mistral-movil.png',
             image: '/images/mistral-web.webp',
             description: 'Modelo open source',
-            pricing: 'free',
+            pricing: 'freemium',
             url: 'https://mistral.ai',
           },
           {
@@ -162,8 +162,8 @@ export const aiCategories: AICategory[] = [
             logo: '/logos/stablediffusion-movil.png',
             image: '/images/stablediffusion-web.webp',
             description: 'Modelo open source',
-            pricing: 'free',
-            url: 'https://stablediffusionweb.com/',
+            pricing: 'freemium',
+            url: 'https://stability.ai/stable-image',
           },
           {
             name: 'Adobe Firefly',
@@ -186,8 +186,8 @@ export const aiCategories: AICategory[] = [
             logo: '/logos/flux-movil.png',
             image: '/images/flux-web.webp',
             description: 'Arte generativo',
-            pricing: 'free',
-            url: 'https://flux1.ai/es',
+            pricing: 'freemium',
+            url: 'https://bfl.ai',
           },
           {
             name: 'Ideogram',
@@ -343,7 +343,7 @@ export const aiCategories: AICategory[] = [
             logo: '/logos/colossyam-movil.jpeg',
             image: '/images/colossyam-web.webp',
             description: 'Voz y video IA',
-            pricing: 'paid',
+            pricing: 'freemium',
             url: 'https://colossyan.com',
           },
         ],
@@ -364,7 +364,7 @@ export const aiCategories: AICategory[] = [
             logo: '/logos/veo-movil.png',
             image: '/images/veo-web.webp',
             description: 'Video IA',
-            pricing: 'free',
+            pricing: 'paid',
             url: 'https://deepmind.google/models/veo/',
           },
           {
@@ -373,7 +373,7 @@ export const aiCategories: AICategory[] = [
             image: '/images/runway-web.webp',
             description: 'Edición de video',
             pricing: 'freemium',
-            url: 'https://runwayml.com',
+            url: 'https://runway.com',
           },
           {
             name: 'Pika Labs',
@@ -388,7 +388,7 @@ export const aiCategories: AICategory[] = [
             logo: '/logos/Synthesia-movil.png',
             image: '/images/Synthesia-web.webp',
             description: 'Avatares IA',
-            pricing: 'paid',
+            pricing: 'freemium',
             url: 'https://synthesia.io',
           },
           {
@@ -396,7 +396,7 @@ export const aiCategories: AICategory[] = [
             logo: '/logos/colossyam-movil.jpeg',
             image: '/images/colossyam-web.webp',
             description: 'Voz y video IA',
-            pricing: 'paid',
+            pricing: 'freemium',
             url: 'https://colossyan.com',
           },
           {
@@ -449,7 +449,7 @@ export const aiCategories: AICategory[] = [
             logo: '/logos/githubcopilto-movil.png',
             image: '/images/githubcopilot-web.webp',
             description: 'Asistente de código',
-            pricing: 'paid',
+            pricing: 'freemium',
             url: 'https://github.com/features/copilot',
           },
           {
@@ -474,14 +474,14 @@ export const aiCategories: AICategory[] = [
             image: '/images/cursor-web.webp',
             description: 'Editor IA',
             pricing: 'freemium',
-            url: 'https://cursor.sh',
+            url: 'https://cursor.com',
           },
           {
             name: 'Tabnine',
             logo: '/logos/tabnine-movil.png',
             image: '/images/tabnine-web.webp',
             description: 'Autocompletado IA',
-            pricing: 'freemium',
+            pricing: 'paid',
             url: 'https://www.tabnine.com',
           },
           {
@@ -490,7 +490,7 @@ export const aiCategories: AICategory[] = [
             image: '/images/codium-web.webp',
             description: 'Testing IA',
             pricing: 'freemium',
-            url: 'https://www.codium.ai',
+            url: 'https://www.qodo.ai',
           },
           {
             name: 'AskTheCode',
@@ -717,7 +717,7 @@ export const aiCategories: AICategory[] = [
             logo: '/logos/autogpt-movil.jpeg',
             image: '/images/autogpt-web.webp',
             description: 'Agente autónomo',
-            pricing: 'free',
+            pricing: 'freemium',
             url: 'https://agpt.co',
           },
           {
@@ -725,7 +725,7 @@ export const aiCategories: AICategory[] = [
             logo: '/logos/agentgpt-movil.png',
             image: '/images/agentgpt-web.webp',
             description: 'Agente autónomo',
-            pricing: 'free',
+            pricing: 'freemium',
             url: 'https://agentgpt.reworkd.ai',
           },
           {
@@ -791,7 +791,7 @@ export const aiCategories: AICategory[] = [
             logo: '/logos/n8n-movil.png',
             image: '/images/n8n-web.webp',
             description: 'Automatización',
-            pricing: 'free',
+            pricing: 'freemium',
             url: 'https://n8n.io',
           },
           {
@@ -1045,7 +1045,7 @@ export const aiCategories: AICategory[] = [
             logo: '/logos/githubcopilto-movil.png',
             image: '/images/githubcopilot-web.webp',
             description: 'Asistente código',
-            pricing: 'paid',
+            pricing: 'freemium',
             url: 'https://github.com/features/copilot',
           },
           {
@@ -1061,7 +1061,7 @@ export const aiCategories: AICategory[] = [
             logo: '/logos/tabnine-movil.png',
             image: '/images/tabnine-web.webp',
             description: 'Asistente código',
-            pricing: 'freemium',
+            pricing: 'paid',
             url: 'https://www.tabnine.com',
           },
           {
@@ -1078,7 +1078,7 @@ export const aiCategories: AICategory[] = [
             image: '/images/cursor-web.webp',
             description: 'Asistente código',
             pricing: 'freemium',
-            url: 'https://cursor.sh',
+            url: 'https://cursor.com',
           },
           {
             name: 'Bolt',
@@ -1099,7 +1099,7 @@ export const aiCategories: AICategory[] = [
             image: '/images/codium-web.webp',
             description: 'Testing IA',
             pricing: 'freemium',
-            url: 'https://www.codium.ai',
+            url: 'https://www.qodo.ai',
           },
           {
             name: 'Testim',
@@ -2002,14 +2002,14 @@ export const aiCategories: AICategory[] = [
             image: '/images/llama-web.webp',
             description: 'Modelo open source',
             pricing: 'free',
-            url: 'https://llama.meta.com',
+            url: 'https://developer.meta.com/ai/',
           },
           {
             name: 'Mistral',
             logo: '/logos/mistral-movil.png',
             image: '/images/mistral-web.webp',
             description: 'Modelo open source',
-            pricing: 'free',
+            pricing: 'freemium',
             url: 'https://mistral.ai',
           },
           {
@@ -2175,7 +2175,7 @@ export const aiCategories: AICategory[] = [
             logo: '/logos/crewai-movil.png',
             image: '/images/crewai-web.webp',
             description: 'Agente cognitivo',
-            pricing: 'free',
+            pricing: 'freemium',
             url: 'https://www.crewai.com',
           },
           {
@@ -2183,7 +2183,7 @@ export const aiCategories: AICategory[] = [
             logo: '/logos/langgraph-movil.png',
             image: '/images/langgraph-web.webp',
             description: 'Agente cognitivo',
-            pricing: 'free',
+            pricing: 'freemium',
             url: 'https://www.langchain.com/langgraph',
           },
         ],
@@ -2325,7 +2325,7 @@ export const aiCategories: AICategory[] = [
             logo: '/logos/writesonic-movil.png',
             image: '/images/writesonic-web.webp',
             description: 'Marketing IA',
-            pricing: 'freemium',
+            pricing: 'paid',
             url: 'https://writesonic.com',
           },
           {

--- a/src/data/comparisons.ts
+++ b/src/data/comparisons.ts
@@ -2,7 +2,7 @@ import type { Comparison } from '../types/tool';
 
 /**
  * Comparativas cara a cara (/comparativa/[slug]).
- * Pares curados por volumen de búsqueda real, no todas las combinaciones posibles.
+ * Pares curados por volumen de busqueda real, no todas las combinaciones.
  */
 export const comparisons: Comparison[] = [
   {
@@ -65,6 +65,54 @@ export const comparisons: Comparison[] = [
       'Trabajas con documentos, informes o bases de código largos y necesitas que no se pierda el hilo.',
       'Prefieres respuestas más matizadas y menos propensas a rellenar con obviedades.',
       'Programas en sesiones largas y valoras la coherencia del razonamiento sobre el número de funciones.',
+    ],
+    sections: [
+      {
+        title: 'La diferencia real: una plataforma frente a un instrumento de trabajo',
+        paragraphs: [
+          'OpenAI y Anthropic no persiguen el mismo producto. ChatGPT crece hacia los lados: cada temporada suma modalidades, conectores, agentes y funciones pensadas para que no tengas que salir de la aplicación. Es una estrategia de plataforma, con la lógica de una tienda de aplicaciones: mucha superficie y mucha gente distinta usándola para cosas muy distintas. Claude crece hacia dentro: refina un núcleo estrecho formado por conversación larga, documentos, edición de texto y programación, y casi todo lo que añade sirve a ese núcleo en lugar de abrir uno nuevo.',
+          'Esa decisión se nota desde el primer mensaje. ChatGPT responde por defecto de forma resolutiva y muy maquetada, con listas y titulares, porque atiende a un público enorme que pregunta de todo. Claude tiende a un registro más continuo y menos troceado, hace más preguntas cuando el encargo es ambiguo y admite antes que algo no lo sabe. Ninguno de los dos comportamientos es mejor en abstracto: uno va bien cuando quieres una respuesta rápida y cerrada, el otro cuando el resultado va a pasar por un revisor humano.',
+          'La consecuencia práctica es que la elección no va de potencia bruta, va de dónde pones el trabajo. Si el asistente es lo que abres para resolver encargos sueltos y variados, la amplitud de ChatGPT rinde más. Si es el sitio donde escribes, revisas y programas durante horas, la profundidad de Claude compensa la falta de funciones accesorias. Muchos equipos llegan a esa conclusión tarde, después de pagar meses por capacidades que nunca abren.',
+        ],
+      },
+      {
+        title: 'Dónde gana cada uno: escritura sostenida frente a tareas con herramientas',
+        paragraphs: [
+          'Claude saca ventaja clara en los encargos largos y con criterio. Reescribir un informe de treinta páginas manteniendo la voz del autor, revisar un contrato sin aplanar los matices, seguir una guía de estilo con veinte reglas o continuar una sesión de refactorización sin perder de vista decisiones tomadas una hora antes. En esas tareas el problema no es generar texto, es no romper lo que ya funciona, y ahí la coherencia a lo largo de toda la conversación pesa más que cualquier otra cosa.',
+          'ChatGPT gana en cuanto la tarea necesita salir del texto. Buscar datos actuales y citarlos, generar la imagen que acompaña al artículo, analizar una hoja de cálculo y devolver el gráfico, transcribir una reunión, dictar por voz o encadenar pasos con servicios externos. Son cosas que Claude no hace o hace peor, y que en un flujo real ahorran más tiempo que una prosa algo mejor. Si tu encargo típico mezcla formatos, cambiar de aplicación cada dos pasos acaba costando más de lo que parece.',
+        ],
+      },
+      {
+        title: 'Precios: qué estás pagando exactamente en cada caso',
+        paragraphs: [
+          'Los dos siguen el mismo esquema: capa gratuita con límites que se reinician por ventanas de uso, suscripción individual mensual, un escalón superior para uso intensivo y planes por asiento para equipos. La API se factura aparte, por tokens, y no entra en la suscripción. Lo que cambia no es tanto la cifra como qué compras: en ChatGPT pagas un paquete de capacidades (imagen, voz, búsqueda, análisis de datos, automatizaciones); en Claude pagas sobre todo más volumen y mejor modelo para trabajar con texto y código.',
+          'Por eso el cálculo depende de tu uso real. Si aprovechas dos o tres modalidades, la suscripción de ChatGPT sustituye a varias herramientas sueltas y sale a cuenta; si solo escribes, pagas funciones que no abres nunca. Con Claude ocurre lo contrario: rinde mucho por euro cuando la jornada es texto y código, y se queda corto si esperabas que además te generase imágenes. Para desarrolladores, el coste por tokens varía según el modelo y el tamaño del contexto, así que conviene medirlo con tus propios prompts.',
+        ],
+        bullets: [
+          'Uso variado y multimodal en una sola aplicación: la suscripción de ChatGPT concentra más valor.',
+          'Escritura, edición y programación a diario: Claude aprovecha mejor cada euro.',
+          'Integración vía API: compara el coste real con tus prompts, no con la tarifa publicada.',
+        ],
+      },
+      {
+        title: 'Cómo se comportan en español',
+        paragraphs: [
+          'Los dos escriben un español correcto, pero no idéntico. Claude produce una sintaxis menos calcada del inglés y cae con menos frecuencia en las muletillas típicas del texto generado, así que el resultado necesita menos limpieza antes de publicarlo. ChatGPT tiende por defecto a un español neutro de sabor latinoamericano: aparecen computadora, celular o carro si no le indicas otra cosa. Se corrige diciendo de forma explícita español de España en las instrucciones personalizadas o en el proyecto, y a partir de ahí lo mantiene bastante bien.',
+          'Fuera del texto escrito la ventaja cambia de lado: la voz en español de ChatGPT funciona con soltura y su búsqueda localiza fuentes españolas sin problema. Pero si tu trabajo es publicar en castellano bajo una marca, lo que decide es lo primero: el borrador de Claude suele llegar más cerca del listo para publicar, y esa diferencia, medida en minutos de edición por pieza, se acumula rápido.',
+        ],
+      },
+      {
+        title: 'Usar las dos a la vez: cómo repartir el trabajo sin pagar de más',
+        paragraphs: [
+          'Combinarlas funciona si el reparto es claro. Lo habitual es usar ChatGPT como puerta de entrada para todo lo que necesita herramientas (buscar, analizar datos, generar una imagen, transcribir) y Claude como mesa de trabajo donde se produce el texto o el código definitivo. El orden importa: recopilar en uno y redactar en el otro funciona bien; ir alternando párrafo a párrafo mezcla dos estilos de escritura y se nota en el resultado final.',
+          'El problema es el coste: dos suscripciones individuales suman y para la mayoría no se justifican. Una salida razonable es pagar la que uses más horas y quedarte con la capa gratuita de la otra para lo puntual. Si el uso profesional en ambas es constante, entonces sí compensa, pero conviene decidirlo a nivel de equipo para que no acabe cada persona pagando las dos por su cuenta.',
+        ],
+        bullets: [
+          'ChatGPT: búsqueda, datos, imagen, voz y automatizaciones.',
+          'Claude: redacción final, edición, documentos largos y sesiones de código.',
+          'Lo que conviene evitar: reescribir el mismo texto en ambos, porque el estilo mezclado se nota.',
+        ],
+      },
     ],
     faqs: [
       {
@@ -140,6 +188,49 @@ export const comparisons: Comparison[] = [
       'Consultas mucha información reciente y valoras el respaldo del buscador.',
       'Trabajas con vídeo, imágenes y contenido multimodal de forma habitual.',
       'Tu empresa ya paga Google Workspace y quiere aprovechar la IA incluida sin sumar otra suscripción.',
+    ],
+    sections: [
+      {
+        title: 'El fondo del asunto: un destino frente a una capa sobre tu software',
+        paragraphs: [
+          'ChatGPT es un sitio al que vas. Google ha hecho lo contrario con Gemini: en lugar de pedirte que abras otra aplicación, lo ha metido donde ya trabajas, en Gmail, Documentos, Drive, el buscador, Android y el navegador. Esa es la diferencia estructural y explica casi todo lo demás. OpenAI tuvo que construir su propio ecosistema desde cero y lo ha hecho con conectores, aplicaciones y una API que se ha convertido en estándar; Google no lo necesitaba porque su ecosistema ya existía y solo tenía que añadirle una capa.',
+          'También divergen en la apuesta técnica. Google ha empujado con fuerza el contexto muy grande y la multimodalidad nativa: entender vídeo, audio largo y documentos extensos sin trocearlos forma parte del diseño del modelo, no es un añadido. OpenAI ha invertido más en la capa de producto que rodea al modelo: memoria, agentes, herramientas, integraciones y un ciclo de iteración conversacional muy pulido. Son dos formas distintas de responder a la misma pregunta sobre dónde está el valor real.',
+          'En la práctica, la primera pregunta que deberías hacerte no es cuál razona mejor, sino dónde vive tu información. Si tu empresa está sobre Workspace, Gemini ve tus correos, tus documentos y tu calendario sin que le pegues nada. Si estás en Microsoft 365 o trabajas con archivos sueltos, esa ventaja se evapora y los dos compiten en igualdad de condiciones. Es la pregunta que más decisiones resuelve y la que casi nadie se hace primero, porque se tiende a comparar respuestas sueltas en lugar de mirar dónde está el trabajo real.',
+        ],
+      },
+      {
+        title: 'El criterio decisivo: acceso a tu contexto frente a calidad conversacional',
+        paragraphs: [
+          'Gemini gana en todo lo que consiste en digerir material. Resumir un vídeo largo, procesar una grabación de una reunión de dos horas, revisar un documento muy extenso de una sola pasada o cruzar información de varios archivos de tu Drive son tareas donde llega antes y con menos fricción. Añade a eso las consultas de actualidad y las locales, donde el acceso al índice de Google marca diferencia frente a cualquier búsqueda integrada.',
+          'ChatGPT gana en la parte de producir. Sigue mejor una instrucción larga con muchas condiciones, mantiene el tono a lo largo de una conversación de iteraciones sucesivas y aguanta mejor las sesiones de programación. Las respuestas de Gemini tienden a salir más enumerativas y a repetir estructura, algo que se nota cuando lo que quieres es prosa y no un esquema. Para redactar, argumentar o afinar un texto pieza a pieza, ChatGPT sigue siendo el más cómodo de los dos.',
+        ],
+      },
+      {
+        title: 'Precios: la suscripción que quizá ya estás pagando',
+        paragraphs: [
+          'Aquí la diferencia de estructura es más importante que la de precio. ChatGPT es una línea nueva en tu tarjeta: capa gratuita con límites y suscripción propia si quieres más. Gemini viene empaquetado con otras cosas que mucha gente ya paga, sea el almacenamiento de Google One o las licencias de Workspace de la empresa. Cuando la IA llega dentro de un plan que ya tenías, el coste incremental para ti es cercano a cero, y eso cambia por completo la conversación.',
+          'Para un particular que ya paga almacenamiento de Google, la pregunta no es cuál es más barato sino si ChatGPT aporta lo suficiente como para justificar una segunda cuota. Para una empresa en Workspace, activar la IA por asiento suele ser administrativamente más simple que gestionar suscripciones sueltas. Y si vas a integrar por API, ambos ofrecen capa gratuita o modelos ligeros muy baratos para prototipar: ahí la decisión se juega en qué modelo aguanta tu caso concreto, no en la tarifa.',
+        ],
+        bullets: [
+          'Ya pagas Google One o Workspace: Gemini entra sin coste adicional relevante.',
+          'Trabajas fuera del ecosistema Google: la ventaja de precio de Gemini desaparece.',
+          'Uso profesional intensivo de escritura o código: ChatGPT justifica mejor su propia cuota.',
+        ],
+      },
+      {
+        title: 'Rendimiento en español',
+        paragraphs: [
+          'Los dos manejan el castellano con solvencia y ninguno comete errores gramaticales llamativos. La diferencia está en el acabado y en las fuentes. Gemini se apoya en el índice de Google, así que para preguntas sobre España, trámites, actualidad o negocios locales devuelve información más pegada al terreno y con enlaces que puedes abrir. ChatGPT escribe un español algo más natural y menos telegráfico, aunque por defecto tira a un neutro latinoamericano si no le pides expresamente español de España.',
+          'En integración cotidiana Gemini tiene otra baza: redactar un correo en castellano dentro de Gmail o resumir un documento en Drive sin copiar y pegar ahorra pasos reales. Si tu trabajo es publicar textos cuidados, sigue compensando redactar en ChatGPT; si es despachar correo y documentos en español todos los días, Gemini se integra mejor en esa rutina y te ahorra el trasiego constante de copiar y pegar entre pestañas, que es donde se pierde la mayor parte del tiempo.',
+        ],
+      },
+      {
+        title: '¿Tiene sentido usar los dos?',
+        paragraphs: [
+          'Sí, y en este par el reparto es bastante limpio porque casi no se solapan. Gemini para todo lo que toque tus datos de Google y para lo que exija información actual con fuente: correo, documentos, vídeos, consultas locales. ChatGPT para producir: escribir, programar, transformar material y montar automatizaciones. Muchos profesionales acaban aquí de forma natural, sin habérselo planteado, porque Gemini ya venía puesto en las herramientas del trabajo.',
+          'El aviso es económico. Si tu empresa ya paga Workspace con IA incluida y tú además tienes ChatGPT a título personal, revisa si de verdad usas las dos o si una está ahí por inercia. Y si mantienes ambas, evita duplicar el mismo documento en las dos: acabas con dos versiones divergentes y sin saber cuál era la buena. Define desde el principio cuál es la herramienta donde vive el documento definitivo.',
+        ],
+      },
     ],
     faqs: [
       {
@@ -220,6 +311,49 @@ export const comparisons: Comparison[] = [
       'Trabajas con imágenes, vídeo o contenido multimodal con frecuencia.',
       'Ya pagas Google Workspace y quieres aprovechar la IA sin añadir otra suscripción.',
     ],
+    sections: [
+      {
+        title: 'Dos apuestas opuestas: profundidad estrecha frente a alcance horizontal',
+        paragraphs: [
+          'Anthropic y Google no compiten exactamente por lo mismo. Claude está construido como instrumento de trabajo para un perfil concreto: quien escribe, revisa documentos o programa durante horas. Su desarrollo se concentra en conversación larga, manejo de textos extensos, código y consistencia de criterio, y renuncia sin complejos a modalidades enteras. Gemini es una capa horizontal: nace dentro de un ecosistema de productos que usa medio mundo y su objetivo es estar presente en todos ellos, del correo al móvil.',
+          'La diferencia se ve en lo que cada uno hace y no hace. Gemini genera imágenes, entiende vídeo y audio de forma nativa y consulta la web de Google en tiempo real. Claude no genera imágenes y su relación con el mundo exterior es más limitada, pero a cambio ofrece un comportamiento muy estable en sesiones largas y una capacidad poco común para seguir instrucciones complejas sin ir desviándose a medida que avanza la conversación.',
+          'También difiere a quién venden. Anthropic apunta a profesionales y a empresas que integran el modelo en sus propios productos, con la API como pieza central. Google apunta al usuario que ya está dentro de su ecosistema y a las organizaciones que despliegan Workspace. Si esa distinción te suena abstracta, tradúcela así: uno quiere ser tu herramienta, el otro quiere ser una función más del software que ya usas.',
+        ],
+      },
+      {
+        title: 'Digerir material frente a producir resultado',
+        paragraphs: [
+          'Gemini es mejor entrada. Una grabación larga de una reunión, un vídeo de formación, un pliego de doscientas páginas, varias hojas de cálculo cruzadas o una consulta que requiere datos actuales con enlaces: en todo eso llega antes y con menos preparación por tu parte. Es el que menos trabajo te obliga a hacer para meter material heterogéneo dentro de la conversación, y eso en el día a día vale mucho.',
+          'Claude es mejor salida. Convertir esas notas en un informe que se pueda enviar a un cliente, reescribir un texto conservando la voz de quien lo firma, revisar un contrato señalando riesgos con matiz, o sostener una refactorización sin contradecir decisiones anteriores. Las respuestas de Gemini tienden a quedarse en el esquema y a repetir estructura; las de Claude salen con criterio y con menos aspecto de plantilla. Si el resultado lo va a leer alguien de fuera, la diferencia se nota.',
+        ],
+      },
+      {
+        title: 'Precios: coste incremental frente a cuota justificada',
+        paragraphs: [
+          'Las estructuras son distintas y por eso comparar cifras despista. Claude funciona como producto independiente: capa gratuita con límites, suscripción individual, escalón superior para uso intensivo y API por tokens facturada aparte. Gemini viene empaquetado en planes que muchos usuarios ya pagan por otro motivo, sea almacenamiento personal o licencias corporativas. Cuando la IA llega dentro de algo que ya estaba en tu factura, su coste marginal para ti es prácticamente cero.',
+          'Eso significa que Claude tiene que justificar una cuota nueva, y la justifica solo en un caso: si escribes, editas o programas varias horas al día. Para un uso ocasional, Gemini cubre lo esencial sin sumar gasto. En integración por API el análisis cambia: Google ofrece niveles gratuitos y modelos ligeros muy baratos que hacen fácil prototipar a volumen, mientras que Claude se suele elegir cuando la tarea es compleja o el contexto muy largo y la calidad de la respuesta compensa el coste por token.',
+        ],
+        bullets: [
+          'Uso ocasional y ya estás en Google: Gemini sale prácticamente gratis.',
+          'Jornada completa de texto o código: la cuota de Claude se amortiza sola.',
+          'Producto propio: prototipa barato con modelos ligeros y reserva el modelo caro para lo difícil.',
+        ],
+      },
+      {
+        title: 'El castellano: registro frente a fuentes',
+        paragraphs: [
+          'Claude escribe el mejor español de los dos. Su prosa suena menos traducida, evita las fórmulas huecas que delatan un texto generado y mantiene el registro que le pidas, incluido el trato de tú o de usted, sin volver a cambiarlo a los tres párrafos. Gemini escribe correcto pero más plano y enumerativo: tiende a devolver listas donde le pedías un texto seguido, y eso obliga a reescribir más de lo que parece.',
+          'La ventaja de Gemini en español está en el acceso a información, no en la redacción. Para consultas sobre España, normativa, actualidad o datos locales trae fuentes en castellano que puedes abrir y comprobar. Lo sensato es aprovechar cada uno donde rinde: buscar y verificar con Gemini, redactar la versión definitiva con Claude. Si solo puedes usar uno y lo que entregas son textos en castellano, la decisión está tomada; si lo que necesitas es entender material ajeno en español, la balanza se inclina hacia el otro lado.',
+        ],
+      },
+      {
+        title: 'Repartirse el trabajo entre los dos',
+        paragraphs: [
+          'Es una de las combinaciones que mejor encajan porque sus fuertes casi no se solapan. Gemini hace de lector y documentalista: ingiere el vídeo, la grabación, el documento gordo o la búsqueda web y devuelve el material ordenado. Claude hace de redactor y revisor: coge ese material y produce la pieza final, con el tono y el criterio que necesitas. Pasar de Gemini a Claude funciona bien; el camino inverso aporta bastante menos.',
+          'El coste es el freno habitual. Si ya tienes Gemini incluido en un plan de Google, añadir Claude es una decisión sencilla de evaluar: mira cuántas horas a la semana dedicas a escribir o programar. Si son pocas, no lo pagues. Y si trabajas con material confidencial, revisa antes las condiciones de tratamiento de datos de cada plan, porque no son iguales entre las capas gratuitas y las de pago.',
+        ],
+      },
+    ],
     faqs: [
       {
         question: '¿Cuál es mejor, Claude o Gemini?',
@@ -298,6 +432,49 @@ export const comparisons: Comparison[] = [
       'Ya pagas una suscripción de X y quieres aprovechar el acceso incluido.',
       'Te resulta útil un asistente con un registro más suelto y menos corporativo.',
       'Analizas tendencias, conversación social o reacciones en tiempo real.',
+    ],
+    sections: [
+      {
+        title: 'Qué separa de verdad a estos dos asistentes',
+        paragraphs: [
+          'La diferencia de fondo no es de capacidad, es de propósito. ChatGPT está diseñado para ser una herramienta de uso general y de uso profesional, con un comportamiento predecible, unos límites claros y un ecosistema pensado para que empresas y desarrolladores construyan encima. Grok nace dentro de X y su razón de ser es otra: estar conectado a la conversación pública en tiempo real y responder con una personalidad deliberadamente más suelta, con menos filtros y más disposición a mojarse.',
+          'Esa decisión de producto tiene consecuencias en ambos sentidos. Grok ve lo que se está publicando ahora mismo en X, algo que ningún buscador integrado reproduce igual, y responde con un tono que a mucha gente le resulta más divertido y menos acartonado. A cambio, hereda los problemas de su fuente: lo que circula en una red social no está verificado, y un asistente que se apoya en ella puede repetir un bulo con la misma seguridad con la que repite un dato cierto.',
+          'También cambia el ritmo. xAI ha ido rápido y ha priorizado sacar versiones y capacidades por delante de la estabilidad del comportamiento; OpenAI lleva más tiempo puliendo la capa aburrida pero decisiva: documentación, cumplimiento, controles para empresa, previsibilidad. Si vas a montar un proceso encima del asistente, esa capa aburrida es exactamente lo que necesitas. Y si lo que buscas es un asistente para uso personal y para estar al día, puede que te sobre por completo y prefieras el otro enfoque.',
+        ],
+      },
+      {
+        title: 'Actualidad y tono frente a fiabilidad',
+        paragraphs: [
+          'Grok gana cuando la pregunta es qué está pasando. Seguir una polémica en marcha, ver cómo se está recibiendo un lanzamiento, resumir las reacciones a una noticia o entender un tema que solo existe en la conversación de X son tareas donde no tiene rival directo. También encaja mejor si buscas respuestas informales, sin advertencias constantes ni rodeos, o si quieres una opinión formulada sin tanto acolchado.',
+          'ChatGPT gana en todo lo que se parece a trabajo. Redactar un documento estructurado, mantener el hilo de una instrucción larga, programar durante una sesión entera, analizar un archivo o encadenar pasos con otras herramientas. La consistencia importa: si vas a firmar el resultado con el nombre de tu empresa, quieres un asistente que se comporte igual el lunes que el jueves. Grok es más impredecible en tono y en formato, y eso, que en uso personal es parte de la gracia, en uso profesional es un coste.',
+        ],
+      },
+      {
+        title: 'Precios: suscripción propia frente a acceso incluido en X',
+        paragraphs: [
+          'El modelo económico es distinto y conviene entenderlo antes de comparar cuotas. ChatGPT se vende solo: capa gratuita con límites, suscripción individual y planes de equipo, más la API por tokens facturada aparte. Grok llega principalmente empaquetado con las suscripciones de pago de X, además de sus propios planes y su API. Si ya pagas X, el acceso a Grok no es una decisión de gasto: ya lo tienes, y la pregunta pasa a ser si te aporta algo más allá de la red.',
+          'De ahí sale el reparto de perfiles. A quien vive en X por trabajo, sea gestionando comunidad, analizando conversación o siguiendo un sector, Grok le sale prácticamente gratis y le resuelve una necesidad concreta. A quien necesita un asistente para producir, la cuota de ChatGPT compra más: modalidades, integraciones y un ecosistema de desarrollo mucho más maduro. Pagar Grok aparte solo por sus capacidades generales es la opción que peor se justifica de las tres.',
+        ],
+      },
+      {
+        title: 'Cómo escriben en español',
+        paragraphs: [
+          'ChatGPT es claramente más fiable en castellano. Mantiene el registro, comete menos calcos y, si le pides español de España, lo sostiene a lo largo de la conversación. Grok se entiende sin problema, pero su español es más irregular: aparecen anglicismos innecesarios, estructuras traducidas y un humor que estaba pensado en inglés y que al castellano llega desactivado o directamente raro. Para texto que se vaya a publicar, ese acabado obliga a reescribir.',
+          'Donde Grok sí aporta en español es leyendo, no escribiendo. Puede rastrear qué se está diciendo en castellano en X sobre un tema, una marca o un acontecimiento, y eso ChatGPT no lo hace con la misma inmediatez ni con el mismo acceso a la conversación en curso. Sirve como termómetro del castellano que se habla en la red, no como redactor de lo que vas a publicar después, y esa distinción conviene tenerla clara antes de copiar nada de su respuesta.',
+        ],
+      },
+      {
+        title: 'Usarlos juntos: antena y banco de trabajo',
+        paragraphs: [
+          'El reparto natural es sencillo: Grok como antena y ChatGPT como banco de trabajo. Grok te dice qué se está hablando, qué reacciones hay y por dónde va el ambiente; ChatGPT convierte eso en un informe, un artículo, un guion o un plan de respuesta. Es una combinación que funciona especialmente bien en comunicación, marketing y análisis de mercado, donde el material de partida es literalmente la conversación pública.',
+          'La condición innegociable es verificar. Nada de lo que Grok recoge de X debería salir publicado sin comprobarlo en una fuente primaria, porque la velocidad de la red social es también su principal defecto. Y en sentido contrario, no esperes que ChatGPT tenga acceso a ese pulso en tiempo real por mucho que le pidas que busque: son piezas complementarias, no intercambiables, y confundirlas lleva a pedirle a cada una justo aquello que no sabe hacer.',
+        ],
+        bullets: [
+          'Grok: pulso de X, actualidad inmediata, tono informal, sondeo de reacciones.',
+          'ChatGPT: redacción, análisis, código, documentos y automatizaciones.',
+          'Regla fija: contrastar en fuente primaria cualquier dato que venga de la red social.',
+        ],
+      },
     ],
     faqs: [
       {
@@ -378,6 +555,49 @@ export const comparisons: Comparison[] = [
       'Sustituyes búsquedas en Google por preguntas directas con respuesta resumida.',
       'Trabajas en periodismo, análisis o documentación, donde citar la fuente es obligatorio.',
     ],
+    sections: [
+      {
+        title: 'No son la misma categoría de producto',
+        paragraphs: [
+          'Compararlos como si fueran dos chatbots equivalentes lleva a conclusiones equivocadas. Perplexity es un motor de respuestas: sustituye el ciclo de buscar, abrir diez pestañas y quedarte con tres, y su valor central son las citas. Cada afirmación viene con su enlace y puedes comprobarla en un clic. ChatGPT es un asistente generalista que además sabe buscar, pero cuya razón de ser es producir algo contigo: texto, código, análisis, transformaciones.',
+          'La arquitectura acompaña a esa diferencia. Perplexity no vive de tener el mejor modelo propio, vive de orquestar bien la búsqueda y de apoyarse en varios modelos por debajo según la tarea; su ingeniería está en recuperar buenas fuentes y resumirlas sin desviarse de lo que dicen. OpenAI trabaja al revés: el modelo es el producto y todo lo demás, incluida la búsqueda, son herramientas que ese modelo utiliza cuando le hacen falta.',
+          'Traducido a la práctica: Perplexity optimiza el camino más corto entre una pregunta y una respuesta con fuente; ChatGPT optimiza una conversación de la que sale trabajo terminado. Elegir mal significa pelearte con la herramienta para que haga algo que no es lo suyo: pedirle a Perplexity un artículo largo con voz propia acaba en un texto plano, y pedirle a ChatGPT una investigación con fuentes acaba en enlaces que hay que revisar uno por uno.',
+        ],
+      },
+      {
+        title: 'Verificabilidad frente a capacidad de producción',
+        paragraphs: [
+          'Perplexity gana en cualquier tarea de investigación. Averiguar qué dice una normativa y de dónde sale, comparar productos con especificaciones reales, encontrar una cifra actual sin fiarte de la memoria del modelo, hacer un barrido de fuentes sobre un tema o preparar el material previo a una reunión. Aporta algo que ChatGPT no da con la misma solidez: la trazabilidad. Ves de dónde viene cada dato y decides si esa fuente te vale.',
+          'ChatGPT gana en cuanto hay que fabricar algo con el material. Escribir el informe, reestructurar un texto, adaptar el tono a un público, generar el código, analizar el archivo, encadenar varios pasos o iterar quince veces sobre el mismo borrador. Perplexity responde bien, pero su prosa es funcional y telegráfica: sirve para informar, no para publicar. En cuanto pides una pieza larga y con voz propia, la distancia se nota enseguida.',
+        ],
+      },
+      {
+        title: 'Precios: pagas volumen de búsqueda o pagas capacidades',
+        paragraphs: [
+          'Las dos son freemium, pero la capa de pago desbloquea cosas distintas y ahí está la clave. En Perplexity la capa gratuita ya permite buscar con normalidad y lo que compras al pagar es sobre todo más consultas avanzadas y acceso a mejores modelos: pagas volumen de investigación. En ChatGPT la capa de pago desbloquea capacidades enteras, desde modalidades hasta herramientas y automatizaciones: pagas superficie de trabajo. Son dos cosas que no se comparan bien mirando solo la cuota.',
+          'Por perfiles queda bastante claro. Si tu día consiste en resolver dudas, documentarte y contrastar, la suscripción de Perplexity es de las que mejor relación aportan por euro y en muchos casos ni siquiera hace falta pasar de la capa gratuita. Si tu día consiste en entregar piezas terminadas, Perplexity se te queda corto por mucho que pagues. Conviene además revisar promociones: Perplexity se ha ofrecido incluida en planes de operadores y dispositivos, y quizá ya la tengas disponible.',
+        ],
+        bullets: [
+          'Perfil que investiga y contrasta a diario: Perplexity, incluso en capa gratuita.',
+          'Perfil que redacta, programa o entrega documentos: ChatGPT, sin discusión.',
+          'Antes de pagar Perplexity, comprueba si tu operador o tu banco la incluyen en algún plan.',
+        ],
+      },
+      {
+        title: 'Búsqueda y redacción en español',
+        paragraphs: [
+          'Perplexity responde en castellano y sabe traer fuentes españolas, desde medios hasta documentación oficial, pero tiene una tendencia clara: en temas técnicos o de nicho se va a fuentes en inglés y te resume en español lo que ha leído. Si necesitas específicamente material en castellano, hay que pedírselo de forma explícita en la consulta. Merece la pena hacerlo, porque para asuntos locales, trámites o normativa española la fuente correcta cambia por completo la respuesta.',
+          'En redacción no hay debate: ChatGPT escribe mucho mejor español. Lo de Perplexity es prosa de ficha, correcta y comprimida, pensada para informar rápido y para que puedas saltar al enlace. Sirve para entender un tema en tres minutos, no para redactar el texto que va a leer un cliente, y tampoco para adaptar el registro o mantener una voz de marca a lo largo de varias piezas.',
+        ],
+      },
+      {
+        title: 'La combinación más habitual: buscar en uno, escribir en el otro',
+        paragraphs: [
+          'Este es probablemente el par que mejor se complementa de todos. Perplexity para la fase de documentación, con sus enlaces y sus citas; ChatGPT para la fase de producción, cogiendo ese material ya contrastado y convirtiéndolo en lo que necesites. Mucha gente que se planteaba cuál de los dos pagar acaba usando la capa gratuita de Perplexity para buscar y la suscripción de ChatGPT para trabajar, que suele ser la ecuación más eficiente.',
+          'Una advertencia importante: que haya una cita no significa que el resumen sea fiel. Abre el enlace cuando el dato sea relevante, porque el matiz se pierde con facilidad al comprimir. Y no le pidas a ChatGPT que reescriba una respuesta de Perplexity sin darle también las fuentes, porque entonces estará reformulando afirmaciones que ya no puede comprobar y el resultado sonará más seguro de lo que en realidad está.',
+        ],
+      },
+    ],
     faqs: [
       {
         question: '¿Cuál es mejor, ChatGPT o Perplexity?',
@@ -452,6 +672,49 @@ export const comparisons: Comparison[] = [
       'Quieres desplegar en hardware modesto sin renunciar a calidad razonable.',
       'Tu organización requiere un proveedor europeo por cumplimiento o soberanía del dato.',
       'Prefieres tener también una API gestionada del propio fabricante, sin montarte la infraestructura.',
+    ],
+    sections: [
+      {
+        title: 'Dos formas distintas de entender lo abierto',
+        paragraphs: [
+          'Ambas familias se descargan y se ejecutan donde tú quieras, pero el proyecto que hay detrás no es el mismo. LLaMA es de Meta y su licencia es propia, no una licencia de código abierto reconocida: permite un uso muy amplio, incluido el comercial, pero impone condiciones de uso aceptable y restricciones para despliegues de escala enorme. Mistral es una empresa europea con un planteamiento mixto: parte de sus modelos salen bajo licencias realmente permisivas y otros son comerciales, con condiciones más cerradas.',
+          'La apuesta técnica también difiere. Meta ha jugado a la escala y a cubrir un abanico amplio de tamaños, apoyándose en una comunidad gigantesca que adapta, cuantiza y afina sus modelos para cualquier escenario. Mistral ha puesto el foco en la eficiencia: sacar el máximo rendimiento por parámetro, con modelos comparativamente pequeños que rinden por encima de lo que su tamaño sugiere y con arquitecturas pensadas para abaratar la inferencia.',
+          'Y hay un factor que en Europa pesa más de lo que parece: la soberanía. Mistral es francesa, ofrece despliegue en infraestructura europea y su discurso comercial se dirige a organizaciones con requisitos de cumplimiento y de residencia del dato. Meta no compite en ese terreno; compite en ubicuidad, que es una ventaja distinta pero igual de real cuando lo que necesitas es que tu modelo funcione en cualquier sitio y con cualquier herramienta.',
+        ],
+      },
+      {
+        title: 'Ecosistema frente a eficiencia',
+        paragraphs: [
+          'LLaMA gana por ecosistema y esa ventaja es difícil de exagerar. Encontrarás más variantes afinadas para dominios concretos, más versiones cuantizadas para hardware modesto, soporte inmediato en prácticamente cualquier motor de inferencia, más tutoriales, más recetas de entrenamiento y más gente que ya se ha peleado con tu problema. Cuando algo falla a las once de la noche, esa comunidad es la diferencia entre resolverlo en veinte minutos o perder el día.',
+          'Mistral gana en coste por tarea y en facilidad de puesta en producción. Sus modelos pequeños hacen muy bien el trabajo repetitivo y de alto volumen (clasificar, extraer, enrutar, resumir) con una latencia y un consumo que permiten servirlos sin una infraestructura desproporcionada. Además tiene API propia, así que puedes empezar alojado y migrar después a autoalojamiento dentro de la misma familia sin rehacer los prompts. Para producto, esa continuidad ahorra bastante trabajo.',
+        ],
+      },
+      {
+        title: 'Precios: aquí no compras licencias, compras infraestructura',
+        paragraphs: [
+          'En los modelos de pesos abiertos el coste cambia de naturaleza. No hay suscripción mensual por usuario: hay GPU, memoria, electricidad y horas de mantenimiento, o bien tarifa por tokens si los alquilas a un proveedor de inferencia. Es la diferencia importante frente a los modelos cerrados: el gasto escala con tu volumen técnico, no con el número de personas del equipo, y a partir de cierto uso eso sale claramente más barato. Por debajo de ese umbral, montar la infraestructura no compensa.',
+          'El reparto por perfiles es bastante nítido. Para prototipar y para cargas medianas, la API de Mistral evita la inversión inicial y permite pasar a autoalojado más adelante. Para autoalojar de verdad con el máximo de opciones, LLaMA ofrece más variantes ya empaquetadas y más proveedores compitiendo por servirlas. Y para cualquier producto que vayas a comercializar, lee la licencia concreta de la versión que uses antes de construir encima: dentro de una misma familia las condiciones cambian entre modelos.',
+        ],
+        bullets: [
+          'Volumen alto y constante: autoalojar pesos abiertos gana en coste frente a una API cerrada.',
+          'Volumen bajo o irregular: alquilar inferencia por tokens evita pagar hardware parado.',
+          'Requisitos de residencia del dato o cumplimiento europeo: Mistral parte con ventaja.',
+        ],
+      },
+      {
+        title: 'El español, el punto débil de los dos',
+        paragraphs: [
+          'Conviene decirlo sin rodeos: en castellano ninguna de las dos familias llega al nivel de los grandes modelos cerrados, y en los tamaños pequeños la distancia es evidente. Verás calcos del inglés, concordancias de género que se tuercen, tiempos verbales inconsistentes y un registro que suena a traducción. No es un problema puntual, es consecuencia de que la mayor parte del entrenamiento y del ajuste se ha hecho pensando en inglés.',
+          'Dentro de esa limitación, los modelos de Mistral suelen defenderse algo mejor en lenguas europeas, incluido el español, mientras que en LLaMA la calidad depende mucho de la variante concreta y del tamaño que puedas permitirte. La recomendación práctica es la misma en los dos casos: prueba con tus propios textos antes de decidir, y si el castellano es central en tu producto, cuenta con afinar el modelo o con revisar la salida en lugar de publicarla directamente.',
+        ],
+      },
+      {
+        title: 'Evaluar las dos no cuesta casi nada',
+        paragraphs: [
+          'A diferencia de las suscripciones de asistentes, aquí probar ambas es barato y es lo razonable. Una estrategia frecuente es asignar tareas por coste: un modelo pequeño de Mistral para el trabajo masivo y sencillo, y un LLaMA mayor para las peticiones que necesitan más calidad. También es habitual prototipar con la API alojada de Mistral y luego autoalojar la parte que maneja datos sensibles, sin cambiar de arquitectura.',
+          'Lo que no tiene sentido es mantener dos pilas técnicas completas por gusto. Cada familia añadida significa otro conjunto de prompts que ajustar, otro comportamiento que vigilar y otra licencia que revisar. Elige una como base, usa la otra para los casos donde gane de forma medible, y documenta cuál se usa dónde y por qué. Mantener dos familias sin criterio escrito termina en una mezcla que nadie se atreve a tocar meses después.',
+        ],
+      },
     ],
     faqs: [
       {
@@ -532,6 +795,49 @@ export const comparisons: Comparison[] = [
       'Te resulta más cómodo un asistente con tono coloquial y menos corporativo.',
       'Analizas tendencias y conversación social como parte de tu trabajo.',
     ],
+    sections: [
+      {
+        title: 'Dos culturas de empresa opuestas dentro del mismo sector',
+        paragraphs: [
+          'Pocas comparaciones muestran tan bien los dos extremos de la industria. Anthropic se fundó alrededor de la investigación en seguridad y esa prioridad se ve en el producto: un asistente que intenta ser predecible, que matiza cuando el terreno es delicado y que está pensado para sostener sesiones largas de trabajo sin sorpresas. xAI se mueve en la dirección contraria: velocidad de publicación, integración con X y una personalidad que presume de tener menos filtros y de no esquivar los temas incómodos.',
+          'No es una diferencia de marketing, cambia lo que puedes hacer con cada uno. Claude está construido para tareas donde el error tiene coste: documentos que se envían, código que se despliega, textos que firma una empresa. Grok está construido para estar al día y para entretener, apoyado en el acceso a lo que se publica en X en tiempo real, que es una capacidad que Claude sencillamente no tiene ni pretende tener.',
+          'También difiere el tipo de cliente que buscan. Anthropic apunta a profesionales y a empresas que integran el modelo en sus productos, con documentación, controles y una API pensada para producción. xAI apunta al usuario de X y a quien quiere un asistente conectado a la conversación pública. Si intentas usar cada uno en el terreno del otro, los dos decepcionan.',
+        ],
+      },
+      {
+        title: 'Fiabilidad frente a inmediatez',
+        paragraphs: [
+          'Claude gana con claridad en el trabajo de fondo. Documentos extensos, revisión de textos con criterio, análisis de contratos o informes, programación durante sesiones largas y cualquier encargo donde importe que la instrucción de hace cuarenta mensajes se siga respetando. Su ventaja no es que sepa más cosas, es que se comporta igual de una vez a otra, y esa constancia es exactamente lo que permite construir un proceso encima.',
+          'Grok gana en el presente. Qué se está diciendo ahora sobre un tema, cómo se está recibiendo un anuncio, qué reacciones ha generado una noticia, cuál es el tono de una conversación en marcha. En eso ninguna búsqueda integrada da lo mismo. El precio a pagar es la verificación: lo que circula en una red social no está comprobado, así que todo lo que salga de ahí necesita una segunda fuente antes de convertirse en una afirmación tuya.',
+        ],
+      },
+      {
+        title: 'Precios: una cuota que se justifica por horas frente a un acceso que ya tienes',
+        paragraphs: [
+          'Los modelos comerciales apenas se parecen. Claude se vende por su cuenta: capa gratuita con límites, suscripción individual, escalón superior para uso intensivo, planes para equipos y API por tokens al margen de todo lo anterior. Grok llega sobre todo dentro de las suscripciones de pago de X, con sus propios planes y su API aparte. Eso significa que para mucha gente Grok no es una decisión de gasto, porque ya viene incluido en algo que paga por otro motivo.',
+          'El cálculo, entonces, es distinto en cada caso. La cuota de Claude se justifica por horas de uso: si escribes, editas o programas la mayor parte de tu jornada, se amortiza sin discusión; si lo abres tres veces por semana, la capa gratuita basta. Grok se justifica si X forma parte de tu trabajo. Lo que peor encaja es pagar Grok aparte esperando un asistente profesional generalista, porque ahí no es donde compite.',
+        ],
+      },
+      {
+        title: 'Calidad del castellano',
+        paragraphs: [
+          'Aquí no hay empate. Claude es de los modelos que mejor escriben en español: sintaxis natural, registro estable, pocas fórmulas vacías y capacidad para mantener el español de España durante toda la conversación si se lo pides al principio. Grok se entiende perfectamente, pero su castellano es más basto: anglicismos evitables, estructuras traducidas y un humor concebido en inglés que al pasar al español pierde el sentido o suena forzado.',
+          'Para publicar contenido en castellano, la elección es evidente. Grok aporta en la otra dirección: rastrear qué se dice en español dentro de X sobre una marca, un sector o un asunto de actualidad es algo que Claude no puede hacer, y como fuente de material bruto tiene valor aunque el acabado del texto no lo tenga. Es decir: uno te dice qué se está diciendo en español y el otro te ayuda a decirlo bien.',
+        ],
+      },
+      {
+        title: '¿Merece la pena tener los dos?',
+        paragraphs: [
+          'Solo si tu trabajo toca de verdad la conversación pública. En ese caso el reparto es limpio: Grok escucha y Claude produce. Grok te da el pulso, los temas emergentes y las reacciones; Claude convierte eso en el informe, el comunicado, el artículo o el análisis que vas a entregar. Fuera de ese escenario, tener los dos es redundante, porque para casi todo lo demás Claude cubre el terreno completo y Grok no aporta nada que compense.',
+          'Si los combinas, pon una regla y respétala: nada que venga de X sale sin contrastar en fuente primaria. Y no le pases a Claude un resumen de Grok como si fuera un hecho establecido, porque entonces estarás pidiéndole que redacte con elegancia algo que quizá sea falso, que es la peor combinación posible de las dos herramientas. Marca siempre en el mensaje qué es dato comprobado y qué es material sin verificar.',
+        ],
+        bullets: [
+          'Grok: escucha de X, actualidad, reacciones, temas emergentes.',
+          'Claude: redacción final, análisis, documentos largos y código.',
+          'Regla innegociable: contrastar antes de publicar cualquier dato salido de la red social.',
+        ],
+      },
+    ],
     faqs: [
       {
         question: '¿Cuál es mejor, Claude o Grok?',
@@ -610,6 +916,49 @@ export const comparisons: Comparison[] = [
       'Necesitas que la imagen respete instrucciones concretas (elementos, composición, texto).',
       'Ya usas ChatGPT y prefieres no pagar ni gestionar otra herramienta aparte.',
       'Iteras conversando: pides un cambio, lo ves, pides otro.',
+    ],
+    sections: [
+      {
+        title: 'Un producto con criterio estético frente a una función integrada',
+        paragraphs: [
+          'Midjourney es una empresa que solo hace imágenes y eso se nota en el resultado: tiene un punto de vista estético incorporado. Aunque le pidas algo neutro, aplica decisiones sobre luz, composición, textura y paleta que no le has pedido y que suelen mejorar la imagen. Es un producto curado, con una mirada propia, y esa mirada es precisamente lo que estás comprando cuando pagas la suscripción.',
+          'DALL·E juega otro papel: es la generación de imágenes dentro de ChatGPT. No aspira a ser la más bonita, aspira a ser la más cómoda. Describes lo que quieres con lenguaje natural, en la misma conversación donde estabas escribiendo el artículo o preparando la publicación, y lo corriges hablando, sin aprender parámetros ni sintaxis de prompt. La generación deja de ser una herramienta aparte y pasa a ser un paso más del flujo en el que ya estabas.',
+          'De ahí sale la diferencia real: uno optimiza el resultado y el otro optimiza el proceso. Midjourney te pide entrar en su terreno, entender sus referencias y sus ajustes, y a cambio te da imágenes que se sostienen solas. DALL·E te pide muy poco y te devuelve algo correcto y obediente, que en muchos contextos es exactamente lo que hacía falta.',
+        ],
+      },
+      {
+        title: 'Belleza frente a obediencia al encargo',
+        paragraphs: [
+          'Midjourney gana en todo lo que tiene que resultar atractivo por sí mismo: ilustración editorial, portadas, ambientes, conceptos visuales, imágenes que van a competir por la atención en un feed. Su iluminación y su sentido de la composición aparecen sin que los pidas, y la diferencia frente a cualquier alternativa se ve especialmente en los detalles y en la coherencia del conjunto. Si la imagen es la pieza principal, es la opción sensata.',
+          'DALL·E gana cuando lo importante es cumplir el encargo al pie de la letra. Escenas con elementos concretos en posiciones concretas, imágenes con texto legible integrado, esquemas sencillos, ilustraciones que acompañan a un contenido y que deben decir algo específico. Interpreta bien las instrucciones enrevesadas y las corrige por conversación, mientras que en Midjourney conseguir un detalle muy concreto puede llevarte varias tandas de intentos. Belleza contra precisión, básicamente.',
+        ],
+      },
+      {
+        title: 'Precios: capacidad de generación frente a coste marginal cero',
+        paragraphs: [
+          'Las estructuras no se parecen. Midjourney es una suscripción de pago sin una capa gratuita estable, con planes que se diferencian por volumen y velocidad de generación y con condiciones de uso comercial que conviene leer según el plan que contrates. DALL·E no se paga por separado: viene dentro de la suscripción de ChatGPT, con límites de uso, de modo que quien ya paga ChatGPT tiene generación de imágenes con coste incremental cero.',
+          'Eso reparte los perfiles casi solo. Si generas imágenes de forma continua y son parte de tu producto o de tu servicio, la suscripción de Midjourney se amortiza rápido porque la calidad de salida reduce el trabajo posterior de retoque. Si necesitas una ilustración de vez en cuando para un artículo, una presentación o una publicación, pagar una segunda suscripción es difícil de justificar cuando ya tienes DALL·E incluido en la herramienta que usas para escribir.',
+        ],
+        bullets: [
+          'Volumen alto y exigencia estética: Midjourney compensa la cuota.',
+          'Uso ocasional y ya pagas ChatGPT: DALL·E te sale sin coste adicional.',
+          'Imágenes con texto legible o briefs muy cerrados: DALL·E acierta antes.',
+        ],
+      },
+      {
+        title: 'Prompts en español y texto dentro de la imagen',
+        paragraphs: [
+          'Los dos aceptan instrucciones en castellano, pero no rinden igual. Midjourney vive en un entorno donde todo está en inglés: su documentación, su comunidad y, sobre todo, el vocabulario de estilo con el que la gente consigue resultados concretos. Escribir el prompt en inglés no es un capricho, cambia el resultado, porque muchos matices de estilo y de referencia visual solo funcionan con el término inglés exacto. DALL·E, al pasar por ChatGPT, admite el español con naturalidad porque reformula tu petición antes de generar.',
+          'En texto dentro de la imagen la diferencia también favorece a DALL·E: rotula con más fiabilidad y se defiende mejor con acentos y con la eñe, aunque ninguno de los dos es infalible. Para carteles, portadas o piezas con titular en castellano, cuenta con revisar la ortografía del resultado o con añadir el texto después en un editor, que además te permite controlar la tipografía y el interlineado en lugar de aceptar lo que decida el modelo.',
+        ],
+      },
+      {
+        title: 'Usar los dos en el mismo flujo',
+        paragraphs: [
+          'Encajan bien si respetas el orden. DALL·E sirve para explorar rápido dentro de la conversación en la que ya estás trabajando: probar encuadres, ver si una idea funciona, resolver la imagen de relleno de un artículo. Midjourney entra después, cuando una de esas ideas merece convertirse en pieza final y necesita el acabado que justifique ponerla en portada o en una campaña.',
+          'Hay un límite que conviene tener presente: no mezcles imágenes de los dos dentro de la misma pieza o de la misma campaña. Tienen personalidades visuales distintas y la mezcla se percibe aunque quien la mire no sepa explicar por qué. Elige una para cada conjunto y mantén la coherencia dentro de él, aunque eso te obligue a renunciar a alguna imagen suelta que te gustaba más.',
+        ],
+      },
     ],
     faqs: [
       {
@@ -690,6 +1039,49 @@ export const comparisons: Comparison[] = [
       'Vas a generar miles de imágenes y no quieres pagar por volumen.',
       'Quieres integrar la generación de imágenes en un producto o flujo automatizado propio.',
     ],
+    sections: [
+      {
+        title: 'Un producto cerrado frente a un ecosistema que montas tú',
+        paragraphs: [
+          'La comparación se entiende mejor si asumes que Stable Diffusion no es un producto, es un ecosistema. Hay familias de modelos, versiones con licencias distintas, checkpoints entrenados por terceros, adaptadores como los LoRA, extensiones y varias interfaces con filosofías opuestas: unas orientadas a usarlo rápido, otras a construir flujos por nodos donde controlas cada paso. Nadie te entrega ese conjunto montado; lo eliges tú, lo instalas tú y lo mantienes tú.',
+          'Midjourney es lo contrario: un servicio cerrado que decide por ti. No eliges modelo, no gestionas dependencias, no actualizas nada. Compras estabilidad y continuidad, con la contrapartida de que la estética del servicio evoluciona cuando ellos deciden, y un cambio de versión puede alterar el aspecto de lo que venías produciendo sin que puedas quedarte en la anterior. En un ecosistema abierto eso no pasa: si un modelo te funciona, lo conservas.',
+          'Esa diferencia arrastra otra que suele pasarse por alto: las licencias. En Stable Diffusion no hay una única condición de uso, cada versión y cada checkpoint de terceros viene con las suyas, y algunas limitan el uso comercial. Antes de construir un producto encima hay que revisarlo modelo por modelo, no dar por hecho que abierto significa libre para todo.',
+        ],
+      },
+      {
+        title: 'Reproducibilidad y control fino frente a acierto a la primera',
+        paragraphs: [
+          'Stable Diffusion gana en todo lo que exige repetir y controlar. Puedes fijar la semilla y reproducir un resultado, imponer la pose o la composición exacta mediante controles adicionales, retocar solo una zona de la imagen con precisión, y entrenar un adaptador con tu producto, tu personaje o tu estilo para mantener la coherencia a lo largo de una serie entera. Doscientas imágenes de catálogo con el mismo modelo y la misma luz es un trabajo para él, no para Midjourney.',
+          'Midjourney gana a la primera. Con dos líneas de prompt devuelve algo que ya está bien compuesto e iluminado, sin que tengas que entender nada del proceso. Para la imagen principal de una web, una portada o una exploración visual rápida, llegas a un resultado presentable en minutos, mientras que alcanzar ese mismo nivel en Stable Diffusion exige elegir el modelo correcto, ajustar parámetros y saber qué estás tocando.',
+        ],
+      },
+      {
+        title: 'Precios: el coste que no aparece en la factura',
+        paragraphs: [
+          'Decir que Stable Diffusion es gratis y Midjourney de pago describe mal el gasto real. En Stable Diffusion pagas hardware con suficiente memoria de vídeo, o alquiler de GPU por horas si no lo tienes, más electricidad, más el tiempo de instalación, actualización y resolución de incidencias. Para un profesional que factura por horas, esa última partida suele ser la más cara con diferencia, y no aparece en ningún recibo. Midjourney, a cambio, ofrece un coste mensual previsible y cero mantenimiento.',
+          'El punto de equilibrio depende del volumen y del tipo de encargo. Con volúmenes bajos o medios, Midjourney gana casi siempre en coste total, porque la suscripción es más barata que las horas que dedicarías a montar y sostener una instalación propia. Stable Diffusion se impone cuando generas de forma masiva y sostenida, cuando necesitas integrar la generación dentro de tu propio producto o cuando el material no puede salir de tus equipos y una suscripción en la nube directamente no es una opción.',
+        ],
+        bullets: [
+          'Volumen bajo o medio sin equipo potente: Midjourney sale más barato en coste total.',
+          'Producción masiva, integración en producto o material confidencial: Stable Diffusion.',
+          'Cuenta siempre tus horas de instalación y mantenimiento como parte del precio.',
+        ],
+      },
+      {
+        title: 'Escribir prompts en español',
+        paragraphs: [
+          'Los dos están entrenados sobre descripciones mayoritariamente en inglés, así que el prompt en castellano rinde peor en ambos casos. La caída es más acusada en Stable Diffusion, donde el componente que interpreta el texto es más limitado y donde todo el vocabulario útil que ha desarrollado la comunidad, los términos de estilo, de encuadre, de iluminación, existe solo en inglés. La recomendación práctica es escribir los prompts en inglés y reservar el castellano para pensar la idea.',
+          'Tampoco esperes que ninguno de los dos escriba texto fiable en español dentro de la imagen. Las tildes y la eñe se tuercen con frecuencia y los rótulos largos salen deformados. Si la pieza lleva un titular en castellano, lo razonable es generar la imagen sin texto y añadirlo después en un editor, que además te da control tipográfico y te permite reutilizar la misma imagen con distintos titulares.',
+        ],
+      },
+      {
+        title: 'Convivencia: exploración en uno, producción en el otro',
+        paragraphs: [
+          'El reparto que funciona en estudios es claro. Midjourney para la fase de exploración y de moodboard, donde lo que necesitas es generar muchas direcciones visuales atractivas en poco tiempo y enseñárselas a un cliente. Stable Diffusion para la fase de producción, cuando ya hay una dirección elegida y hace falta consistencia, repetición controlada, retoques finos o generar a escala sin coste por imagen.',
+          'Ahora bien, mantener los dos flujos solo tiene sentido si ya cuentas con el equipo y con el conocimiento técnico para el segundo. Si no los tienes, montarlos para complementar a Midjourney es una inversión de tiempo considerable que la mayoría de proyectos no recupera. Empieza por uno, y añade el otro cuando una limitación concreta y repetida te lo esté pidiendo.',
+        ],
+      },
+    ],
     faqs: [
       {
         question: '¿Cuál es mejor, Midjourney o Stable Diffusion?',
@@ -768,6 +1160,50 @@ export const comparisons: Comparison[] = [
       'Generas imágenes en volumen y quieres coste marginal cercano a cero',
       'Quieres control fino: inpainting, ControlNet, composición guiada, seeds reproducibles',
       'La privacidad importa y prefieres que las imágenes no salgan de tu equipo',
+    ],
+    sections: [
+      {
+        title: 'La diferencia de fondo: producto terminado frente a modelo en bruto',
+        paragraphs: [
+          'DALL·E no te entrega el modelo, te entrega una experiencia. Antes de generar nada, el sistema suele reinterpretar y ampliar lo que has escrito para convertirlo en una descripción más rica y coherente. Por eso una frase floja produce una imagen decente: hay una capa de lenguaje trabajando entre tú y el generador. El precio de esa comodidad es que pierdes trazabilidad: no sabes exactamente qué se ha pedido al modelo y reproducir dos veces el mismo resultado es prácticamente imposible.',
+          'Stable Diffusion hace justo lo contrario: te deja a solas con el motor. Eliges el checkpoint, el sampler, el número de pasos y la semilla, y con esos mismos valores obtienes la misma imagen mañana y dentro de un año. Esa reproducibilidad es lo que convierte a Stable Diffusion en una herramienta de producción y no solo de exploración, porque permite iterar sobre un resultado concreto en lugar de volver a tirar los dados en cada intento.',
+          'De ahí salen dos públicos distintos. DALL·E encaja cuando la imagen es un accesorio de otro trabajo: una entrada de blog, una diapositiva, un mockup para enseñar una idea. Stable Diffusion encaja cuando la imagen es el trabajo y hay que responder ante alguien por ella: un cliente que pide el mismo personaje en seis escenas, una tienda con cientos de fichas, un estilo que debe repetirse sin desviarse.',
+        ],
+      },
+      {
+        title: 'Dónde gana cada uno en tareas reales',
+        paragraphs: [
+          'DALL·E destaca cuando la escena es compleja de describir pero solo la necesitas una vez. Pídele una ilustración con varios elementos relacionados entre sí, una metáfora visual para un artículo o una composición con una idea abstracta detrás, y suele entender la intención sin que tengas que traducirla a jerga de fotografía. También es más tolerante con instrucciones desordenadas, escritas como se lo contarías a una persona. Ese es su terreno: la primera imagen aceptable, con cero configuración.',
+          'Stable Diffusion gana en todo lo que implique repetición y corrección. Consistencia de personaje entre imágenes, un estilo de marca aplicado a cuarenta piezas, corregir solo una zona del encuadre sin tocar el resto, guiar la composición a partir de un boceto o una pose concreta. También manda cuando el filtro de contenido de un servicio cerrado se convierte en un obstáculo: marcas, personas reconocibles o temáticas que DALL·E bloquea sin explicación, y que en local simplemente no existen como problema.',
+        ],
+        bullets: [
+          'Imagen única para un post o una presentación: DALL·E',
+          'Mismo personaje o mismo estilo en muchas imágenes: Stable Diffusion con modelos afinados',
+          'Retocar una parte concreta de una imagen ya generada: Stable Diffusion con inpainting',
+          'Escena conceptual difícil de describir: DALL·E entiende mejor la intención',
+        ],
+      },
+      {
+        title: 'Qué sale más rentable según lo que generes',
+        paragraphs: [
+          'Las estructuras de coste no son comparables. DALL·E funciona como servicio: hay una capa gratuita con límites y, a partir de ahí, pagas una cuota del ecosistema de OpenAI o el uso por API. El coste es predecible y no depende de tu equipo. Stable Diffusion no cobra licencia por los modelos, pero traslada el gasto a otro sitio: una tarjeta gráfica capaz, electricidad, y sobre todo tu tiempo de montaje y aprendizaje, que es el coste más caro y el que nadie apunta.',
+          'El punto de equilibrio depende del volumen. Si generas unas decenas de imágenes al mes, montar Stable Diffusion no se amortiza nunca: pasarás más horas instalando nodos que diseñando. Si generas cientos o miles, o necesitas producir por lotes de madrugada sin supervisión, el coste marginal cercano a cero de Stable Diffusion lo compensa todo. Existe un punto intermedio muy razonable: usar Stable Diffusion a través de servicios de terceros que cobran por créditos, sin hardware propio ni instalación.',
+        ],
+      },
+      {
+        title: 'Cómo se comportan con instrucciones en español',
+        paragraphs: [
+          'Aquí hay una diferencia clara y poco comentada. DALL·E acepta instrucciones en español con normalidad porque la capa de lenguaje que hay delante se encarga de interpretarlas y reescribirlas, así que puedes trabajar en castellano sin penalización perceptible. Stable Diffusion depende de codificadores de texto entrenados sobre todo con material en inglés: escribir en español funciona a medias, se pierden matices y muchos términos de estilo, encuadre o iluminación directamente no se reconocen. La recomendación práctica es escribir los prompts en inglés.',
+          'Con el texto dentro de la imagen la cosa empeora para los dos. Las tildes, la eñe y los signos de apertura de interrogación se rompen con frecuencia, y Stable Diffusion falla más que DALL·E. Si necesitas un rótulo en castellano correcto, lo sensato es generar la imagen sin texto y añadir la tipografía después en un editor, donde además controlas la fuente y puedes hacer versiones para otros idiomas.',
+        ],
+      },
+      {
+        title: 'Usar los dos: cuándo compensa y cuándo es perder el tiempo',
+        paragraphs: [
+          'El reparto que mejor funciona es por fases del encargo. DALL·E para la fase de exploración: sacar rápido cinco direcciones visuales distintas, enseñárselas a un cliente o a tu equipo y cerrar cuál es la buena, sin gastar tiempo técnico en una idea que puede caerse en la primera reunión. Stable Diffusion para la fase de producción: reproducir esa dirección aprobada con un modelo afinado, fijar semilla, generar las variantes definitivas y corregir con inpainting lo que no cuadre.',
+          'Ahora la parte honesta: mantener dos flujos tiene un coste real. Lo que sale de DALL·E no se puede reproducir tal cual en Stable Diffusion, así que la imagen aprobada sirve de referencia, no de original, y siempre habrá una desviación de estilo entre lo que enseñaste y lo que entregas. Si tu volumen es bajo, quédate con DALL·E y ahórrate la complejidad. La combinación solo compensa cuando la fase de producción es larga.',
+        ],
+      },
     ],
     faqs: [
       {
@@ -848,6 +1284,50 @@ export const comparisons: Comparison[] = [
       'Tu empresa exige claridad sobre el origen de los datos de entrenamiento y el uso comercial',
       'Prefieres una herramienta en español y con soporte corporativo',
     ],
+    sections: [
+      {
+        title: 'Un modelo con criterio propio frente a una pieza de infraestructura',
+        paragraphs: [
+          'Midjourney es un producto de autor. El modelo tiene una opinión sobre qué es una imagen bonita y la aplica siempre: contraste, profundidad de campo, una luz que favorece. Puedes atenuar ese carácter con parámetros de estilo, pero no desactivarlo del todo. Es una ventaja enorme cuando no tienes una dirección de arte cerrada, porque el modelo la pone por ti, y un estorbo cuando el brief es literal y cualquier embellecimiento te aleja de lo que el cliente ha aprobado.',
+          'Firefly parte de una premisa opuesta: no aspira a sorprender, aspira a ser predecible y a no romper nada. Está pensado como una función más dentro de un documento que ya existe, con sus capas, sus máscaras y su resolución de entrega. A eso se suma el argumento con el que Adobe entra en las empresas: entrenamiento sobre material licenciado, credenciales de contenido y garantías contractuales sobre el uso comercial de lo generado.',
+          'El resultado son dos compradores distintos. Midjourney vende inspiración a quien tiene que llenar una página en blanco y responde ante su propio criterio. Firefly vende continuidad de flujo y tranquilidad jurídica a quien ya tiene el encargo cerrado, el archivo abierto y un departamento legal que pregunta de dónde ha salido cada píxel. Por eso la elección suele decidirse antes de mirar una sola imagen generada: depende de si tu problema es encontrar la idea o entregarla sin sobresaltos.',
+        ],
+      },
+      {
+        title: 'El criterio decisivo: cuánto retoque queda después',
+        paragraphs: [
+          'La pregunta útil no es cuál genera imágenes más bonitas, sino cuánto trabajo hay entre la generación y la entrega. Si el encargo parte de una fotografía real que hay que arreglar, ampliar o limpiar, Firefly gana sin competencia: trabaja sobre tu imagen, respeta la iluminación existente y devuelve el resultado en una capa que puedes enmascarar. Adaptar una creatividad a formatos verticales, quitar un objeto del fondo o extender un encuadre son tareas donde Midjourney ni siquiera juega.',
+          'Cuando la imagen se genera entera desde cero, la balanza se invierte. Midjourney produce piezas con fuerza visual que Firefly rara vez alcanza: los resultados de Firefly tienden a lo correcto y algo plano, con un aire reconocible de banco de imágenes. Para ilustración editorial, portadas, moodboards o cualquier pieza que tenga que llamar la atención en un scroll, Midjourney ahorra horas. Para la foto de producto del cliente, no hay nada que discutir.',
+        ],
+        bullets: [
+          'Retocar, ampliar o limpiar una foto real: Firefly dentro de Photoshop',
+          'Ilustración o concepto desde cero con impacto visual: Midjourney',
+          'Adaptar una pieza a varios formatos sin recortar mal: Firefly',
+          'Explorar veinte direcciones estéticas en una tarde: Midjourney',
+        ],
+      },
+      {
+        title: 'Coste fijo frente a coste ya pagado',
+        paragraphs: [
+          'Midjourney es una suscripción mensual escalonada, sin capa gratuita real, donde lo que compras es capacidad de generación rápida. Es un gasto nuevo en tu contabilidad y, si dejas de pagar, pierdes el acceso a la herramienta. Firefly funciona con créditos generativos que ya vienen incluidos en las suscripciones de Adobe: si tu estudio paga Creative Cloud, el coste percibido de Firefly es cero hasta que agotas la asignación mensual, momento en el que la generación se ralentiza o compras más créditos.',
+          'Eso define dos perfiles muy claros. Un ilustrador o director de arte autónomo sin Adobe contratado paga Midjourney a precio completo, pero lo rentabiliza porque genera mucho y la calidad estética es su producto. Un diseñador en plantilla que ya trabaja con Creative Cloud no debería pagar Midjourney para tareas de retoque, porque Firefly ya está pagado y encima le ahorra exportar e importar. Comprueba siempre las tarifas y la asignación de créditos vigente en las webs oficiales.',
+        ],
+      },
+      {
+        title: 'Trabajar en español con cada uno',
+        paragraphs: [
+          'Midjourney no está localizado y sus prompts rinden claramente mejor en inglés. No es solo cuestión de comprensión: buena parte del vocabulario que controla el resultado, los términos de encuadre, óptica, iluminación y estilo, es léxico inglés que no tiene equivalente eficaz en castellano. Escribir en español funciona para lo básico y se queda corto en cuanto quieres precisión. Firefly acepta instrucciones en español con más soltura y su interfaz está traducida, aunque en resultados el inglés sigue teniendo cierta ventaja.',
+          'Donde Firefly gana de verdad en el mercado español es fuera del modelo: soporte en castellano, facturación y contratos con una filial local, y documentación en español para justificar el uso comercial ante un cliente o un departamento de compras. Para rotular en castellano, ninguno de los dos es fiable con tildes y eñes, así que el texto se sigue poniendo en Illustrator o InDesign.',
+        ],
+      },
+      {
+        title: 'Combinarlos sin romper el flujo',
+        paragraphs: [
+          'El reparto habitual en estudio es claro: Midjourney genera la imagen base o el concepto, y esa imagen entra en Photoshop, donde Firefly la amplía a otros formatos, elimina lo que sobra y unifica el acabado. Midjourney aporta la idea y el impacto; Firefly aporta la resolución de entrega, el control por capas y las adaptaciones. Es un flujo probado y no requiere nada especial más que exportar en la máxima calidad que permita tu plan.',
+          'Hay dos avisos que conviene tener presentes. El primero es de coherencia: la estética marcada de Midjourney se diluye en cuanto Firefly rellena zonas grandes, así que las expansiones amplias suelen delatarse. El segundo es contractual: si el cliente exige trazabilidad sobre el origen del material generado, meter Midjourney en la cadena puede invalidar precisamente la garantía por la que estás usando Firefly. Pregúntalo antes de empezar, no en la entrega.',
+        ],
+      },
+    ],
     faqs: [
       {
         question: '¿Cuál es mejor, Midjourney o Adobe Firefly?',
@@ -927,6 +1407,50 @@ export const comparisons: Comparison[] = [
       'Quieres ejecutar el modelo en local o en tu propia infraestructura',
       'Generas en volumen y quieres controlar el coste por imagen',
     ],
+    sections: [
+      {
+        title: 'Producto cerrado frente a familia de modelos',
+        paragraphs: [
+          'Midjourney es un producto con una estética incorporada de serie. El modelo interpreta lo que le pides y lo eleva: mejora la luz, ordena la composición y añade una capa de acabado que no has solicitado. Esa mano invisible es su mayor virtud comercial y también su límite, porque no puedes apagarla. Todo lo que sale de Midjourney comparte un aire de familia reconocible, y llega un punto en el que ese aire se convierte en una firma que tal vez no quieras en tu marca.',
+          'FLUX no es un producto sino una familia de modelos con varias variantes y licencias distintas: algunas permisivas, alguna restringida a uso no comercial y otra accesible solo por API. Eso significa que la misma tecnología puede llegarte de tres formas incompatibles entre sí, y que antes de usarla profesionalmente tienes que leer qué variante concreta estás ejecutando. A cambio obtienes algo que Midjourney no ofrece: la posibilidad de meter el generador dentro de tu propio sistema.',
+          'La consecuencia práctica es de rol, no de calidad. Midjourney está hecho para que una persona se siente delante y trabaje. FLUX está hecho para que un sistema genere sin que haya nadie delante. Si tu proceso implica una persona valorando cada imagen, Midjourney encaja. Si implica un servidor produciendo mientras duermes, FLUX es el único de los dos que puede hacerlo.',
+        ],
+      },
+      {
+        title: 'Obediencia al prompt frente a gusto propio',
+        paragraphs: [
+          'El criterio que decide este par es cuánto te importa que la imagen sea exactamente la que has descrito. Pide una escena con tres objetos concretos sobre una mesa, un color de prenda específico y una mirada dirigida a un punto determinado: FLUX tiende a respetar el recuento y las relaciones espaciales, mientras que Midjourney reinterpreta y te devuelve algo más bonito pero que no cumple el brief. Cuando el prompt viene de un cliente y hay que defenderlo, esa literalidad vale más que la belleza.',
+          'En el otro sentido, Midjourney sigue ganando cuando el brief es vago o puramente atmosférico. Ambientes, texturas, luz de película, retratos con carácter: consigue en dos intentos lo que en FLUX exige un prompt muy trabajado. FLUX aporta además dos ventajas concretas que se notan en producción: maneja mejor el texto legible dentro de la imagen y falla menos en los detalles que tradicionalmente delataban a estos modelos, como las manos o los objetos con simetría.',
+        ],
+        bullets: [
+          'Brief literal con elementos contables y posiciones: FLUX',
+          'Ambiente, luz y carácter visual sin instrucciones precisas: Midjourney',
+          'Cartel o pieza con texto legible integrado: FLUX',
+          'Generación automatizada desde tu propio código: FLUX, Midjourney no juega',
+        ],
+      },
+      {
+        title: 'Suscripción previsible frente a coste variable',
+        paragraphs: [
+          'Midjourney cobra una suscripción mensual con escalones según cuánta generación rápida necesites, y no tiene capa gratuita real. Su virtud es la previsibilidad: sabes lo que vas a pagar aunque generes el triple este mes. FLUX se presenta con tres estructuras simultáneas: descargar los pesos y pagar solo tu hardware, llamar a una API y pagar por imagen generada, o usar servicios de terceros que lo revenden por créditos. Cada una tiene un perfil de rentabilidad distinto.',
+          'Si trabajas a diario y de forma manual, con volumen alto pero estable, la suscripción de Midjourney suele salir más barata que pagar por imagen. Si tu consumo es irregular, con semanas muertas y picos de campaña, la API de FLUX evita pagar por meses en los que no generas nada. Y si produces en volumen industrial de forma continuada, ejecutar FLUX en hardware propio o alquilado es lo único que escala sin que el coste crezca al mismo ritmo.',
+        ],
+      },
+      {
+        title: 'Qué esperar escribiendo en castellano',
+        paragraphs: [
+          'Ninguno de los dos está pensado para trabajar en español y ambos rinden mejor en inglés, pero no fallan igual. Midjourney depende mucho de un vocabulario técnico muy anglosajón, con términos de estilo y óptica que actúan casi como comandos, y traducirlos al castellano los desactiva. FLUX responde mejor a frases descriptivas largas y naturales, lo que reduce algo la penalización de escribir en otro idioma, aunque sigue siendo recomendable pasar el prompt final al inglés.',
+          'La diferencia relevante para el mercado español está en el texto rotulado. Si necesitas que la imagen incluya una palabra en castellano con tilde o con eñe, FLUX acierta con bastante más frecuencia que Midjourney, que suele devolver caracteres deformados o inventados. Aun así no es fiable al cien por cien: revisa siempre la ortografía del resultado y, si la pieza es para cliente, plantéate poner la tipografía tú en un editor vectorial.',
+        ],
+      },
+      {
+        title: 'Repartirse el trabajo entre los dos',
+        paragraphs: [
+          'El reparto lógico es exploración y producción. Midjourney para definir la dirección de arte de una campaña: sacar referencias, cerrar paleta, tono y encuadre con quien tenga que aprobarlo. FLUX para producir después el lote definitivo, con prompts fijos, semillas controladas y, si hace falta, lanzado desde un script que genere las cincuenta variantes de producto o de formato mientras tú haces otra cosa. Cada uno cubre una fase en la que el otro es claramente peor.',
+          'El punto débil de esta combinación es que el estilo de Midjourney no se transfiere. No existe un ajuste que haga que FLUX genere como Midjourney, así que la imagen aprobada solo sirve como referencia visual, y tendrás desviación. Hay dos formas de reducirla: usar la imagen de Midjourney como referencia de imagen dentro de FLUX, o entrenar un adaptador de estilo sobre FLUX si ese look va a repetirse durante meses. Para un encargo puntual, no compensa.',
+        ],
+      },
+    ],
     faqs: [
       {
         question: '¿Cuál es mejor, Midjourney o FLUX?',
@@ -1001,6 +1525,50 @@ export const comparisons: Comparison[] = [
       'Tus prompts son detallados y necesitas que se respeten con precisión',
       'Generas imágenes con texto (carteles, portadas, interfaces) y necesitas que sea legible',
       'Tienes hardware suficiente o vas a usarlo a través de un servicio',
+    ],
+    sections: [
+      {
+        title: 'Un ecosistema maduro frente a un modelo mejor',
+        paragraphs: [
+          'La comparación engaña porque no enfrenta a dos cosas del mismo tipo. Stable Diffusion, a estas alturas, es menos un modelo que un estándar: años de versiones sucesivas, interfaces consolidadas, extensiones para casi todo y un catálogo comunitario gigantesco de modelos afinados. Buena parte de ese ecosistema sigue anclado a las versiones más antiguas de la familia, precisamente porque son las que más gente puede ejecutar y para las que existe más material.',
+          'FLUX es un modelo, y además uno construido con una arquitectura posterior, más grande y entrenada específicamente para seguir instrucciones complejas. Se nota de inmediato: acierta más a la primera, entiende frases largas sin trocearlas y no necesita que le añadas una retahíla de palabras clave para que el resultado no sea mediocre. Lo que aún no tiene es el arsenal de herramientas de control ni la variedad de estilos afinados que rodea a Stable Diffusion.',
+          'Traducido a decisión: si valoras el punto de partida, FLUX está por delante y se nota desde la primera imagen. Si valoras hasta dónde puedes llevar el resultado modificándolo, Stable Diffusion sigue teniendo más recorrido, más herramientas y más gente que ya ha resuelto tu problema antes. Es la diferencia entre un coche que sale bueno de fábrica y otro peor de serie pero para el que existen piezas de todo tipo, manuales y talleres en cada esquina.',
+        ],
+      },
+      {
+        title: 'Calidad de serie frente a capacidad de moldear',
+        paragraphs: [
+          'FLUX gana con claridad en la imagen de una sola pasada. Retratos fotorrealistas creíbles, escenas con muchos elementos que hay que colocar en su sitio, composiciones con texto legible o piezas donde el prompt describe relaciones complicadas entre objetos. En todos esos casos obtienes un resultado utilizable sin buscar modelos de terceros ni encadenar pasos de refinado, algo que en Stable Diffusion exige montarte un flujo con varios nodos y saber qué hace cada uno.',
+          'Stable Diffusion gana en cuanto hay que salirse de lo genérico. Estilos de nicho muy concretos, personajes consistentes entrenados con tus propias imágenes, control estricto de pose, profundidad o líneas de contorno, y correcciones quirúrgicas sobre zonas de la imagen. Nada de eso es imposible en FLUX, pero el soporte es más joven y, sobre todo, entrenar adaptadores sobre FLUX consume bastante más memoria de vídeo y tiempo que hacerlo sobre las versiones ligeras de Stable Diffusion.',
+        ],
+        bullets: [
+          'Imagen buena a la primera con prompt largo: FLUX',
+          'Estilo de nicho o personaje propio entrenado por ti: Stable Diffusion',
+          'Control por pose, boceto o mapa de profundidad: Stable Diffusion',
+          'Carteles y piezas con texto dentro de la imagen: FLUX',
+        ],
+      },
+      {
+        title: 'Aquí no pagas licencia, pagas hardware',
+        paragraphs: [
+          'Ninguno de los dos cobra suscripción por usar el modelo, así que la comparación económica es de otra naturaleza: memoria de vídeo, tiempo por imagen y electricidad. Las versiones ligeras de Stable Diffusion funcionan con dignidad en tarjetas de gama media e incluso en portátiles con configuraciones reducidas o cuantizadas. Las variantes grandes de FLUX son bastante más exigentes y castigan al hardware modesto con tiempos por imagen que hacen inviable iterar, que es justo lo que más necesitas al principio.',
+          'De ahí salen tres decisiones razonables. Si generas poco y tu equipo es normal, usa FLUX a través de una API o de un servicio de terceros y olvídate del hardware. Si ya tienes una tarjeta gráfica decente y quieres experimentar sin pagar por imagen, Stable Diffusion te permite empezar hoy mismo. Y si vas a producir a diario durante meses, comprar hardware suficiente para mover FLUX en local se amortiza frente al coste acumulado de una API. Revisa además la licencia de la variante concreta antes de vender nada generado con ella.',
+        ],
+      },
+      {
+        title: 'Comportamiento con prompts y rótulos en español',
+        paragraphs: [
+          'Los dos entienden mejor el inglés, pero la brecha es distinta. Stable Diffusion depende de codificadores de texto antiguos y entrenados casi por completo con material anglosajón: en español reconoce palabras sueltas y poco más, y la mayoría de los términos que controlan estilo, óptica o encuadre simplemente no le dicen nada. FLUX incorpora un codificador de texto más grande y con más lenguaje natural detrás, así que tolera mucho mejor una frase escrita en castellano, aunque el inglés sigue dando resultados más precisos.',
+          'Para rotular en español la diferencia es todavía más marcada. FLUX escribe palabras con tilde y con eñe con un acierto razonable, mientras que Stable Diffusion arrastra desde siempre el problema del texto y en castellano falla casi siempre. Si tu trabajo incluye carteles, portadas o packaging con texto en español integrado, esta sola diferencia inclina la elección hacia FLUX antes que cualquier consideración de estilo.',
+        ],
+      },
+      {
+        title: 'Tenerlos a los dos en la misma máquina',
+        paragraphs: [
+          'Conviven sin problema porque las interfaces modernas cargan cualquiera de los dos, así que muchos usuarios eligen modelo por tarea dentro del mismo flujo. Un reparto que funciona bien: FLUX genera la imagen base cuando el prompt es complejo o lleva texto, y Stable Diffusion entra después para aplicar un estilo concreto con un adaptador entrenado, corregir una zona con inpainting o ampliar la resolución con los modelos de escalado, que en su ecosistema están mucho más rodados.',
+          'Lo que nadie cuenta es el coste operativo de esa convivencia. Cambiar de modelo a mitad de flujo obliga a descargar y recargar pesos, y en equipos con memoria justa eso convierte una iteración de segundos en una espera constante que rompe el ritmo de trabajo. Si tu hardware va apretado, elige uno y quédate con él. La combinación tiene sentido cuando el equipo aguanta ambos cómodamente o cuando el paso de estilización es imprescindible para tu resultado.',
+        ],
+      },
     ],
     faqs: [
       {
@@ -1081,6 +1649,50 @@ export const comparisons: Comparison[] = [
       'Prefieres probar la herramienta gratis antes de pagar nada',
       'Buscas bocetos de logotipo o composiciones tipográficas rápidas',
     ],
+    sections: [
+      {
+        title: 'La imagen como cuadro frente a la imagen como pieza de comunicación',
+        paragraphs: [
+          'Midjourney optimiza la imagen como obra: busca que funcione mirada en conjunto, con una composición atmosférica y una calidad de luz que sostenga la escena. No tiene ninguna noción de que esa imagen vaya a llevar un titular encima, un logo en una esquina o un pie de página, así que rellena todo el encuadre con información visual. Cuando después intentas colocar texto, descubres que no hay ni un espacio limpio donde ponerlo sin tapar algo importante.',
+          'Ideogram parte de otra pregunta: qué necesita una pieza gráfica para comunicar. Eso implica jerarquía visual, zonas de respiro y, sobre todo, tipografía que forme parte de la imagen en lugar de estar pegada encima. Su modelo entiende la relación entre lo que quieres escribir y dónde debe ir dentro de la composición, que es exactamente el problema que casi todos los generadores dejaron sin resolver durante años.',
+          'Por eso no compiten en calidad general sino en tipo de encargo. Midjourney es para quien produce imágenes que se miran. Ideogram es para quien produce piezas que se leen: carteles, portadas, creatividades para redes, bocetos de packaging, anuncios con un mensaje corto y directo. Un mismo diseñador puede necesitar los dos en semanas distintas sin que ninguno sea sustituto del otro, y elegir mal cuesta horas de retoque manual que no estaban presupuestadas.',
+        ],
+      },
+      {
+        title: 'El texto dentro de la imagen decide casi todo',
+        paragraphs: [
+          'Si la pieza lleva palabras, Ideogram ahorra un trabajo que en Midjourney directamente no existe. Un cartel con titular, una portada con subtítulo, una etiqueta con el nombre del producto, un rótulo pintado en una pared o unas letras en relieve sobre un objeto: todo eso sale de Ideogram legible y razonablemente bien colocado, mientras que Midjourney devuelve caracteres deformados que obligan a taparlo todo y rehacerlo a mano en un editor.',
+          'Si la pieza no lleva texto, la comparación se invierte sin matices. Midjourney tiene más rango estético, más carácter y más consistencia en escenas complejas: ilustración editorial, concept art, fotografía ambiental de producto o retratos con intención. Ideogram es más neutro y más plano, lo que en diseño gráfico es una virtud y en ilustración es una carencia. Y un aviso honesto sobre Ideogram: acierta con las letras, pero la tipografía que elige rara vez es la de tu marca, así que para identidad real habrá que rehacerla en vectorial.',
+        ],
+        bullets: [
+          'Titular, portada o creatividad con texto integrado: Ideogram',
+          'Ilustración, ambiente o escena sin palabras: Midjourney',
+          'Boceto rápido de logotipo o composición tipográfica: Ideogram',
+          'Identidad de marca definitiva: ninguno de los dos, redibuja en vectorial',
+        ],
+      },
+      {
+        title: 'Suscripción obligatoria frente a capa gratuita',
+        paragraphs: [
+          'Midjourney exige suscripción desde el primer minuto y sus planes se diferencian sobre todo por cuánta generación rápida incluyen: en los escalones bajos, cuando agotas ese margen, pasas a un modo lento que cambia por completo la experiencia de trabajo. Ideogram es freemium con un número limitado de generaciones que se renuevan, más planes de pago por encima. Esa diferencia importa mucho al empezar, porque puedes evaluar Ideogram con tus propias piezas antes de poner una tarjeta.',
+          'Por perfil: quien produce cinco creatividades semanales para redes cubre sus necesidades con la capa gratuita o el plan más barato de Ideogram, y pagar Midjourney sería tirar dinero. Quien genera cientos de variantes buscando una imagen concreta rentabiliza Midjourney sin discusión. Un detalle que conviene revisar antes de subir el brief de un cliente: en ambas plataformas los planes más económicos suelen implicar que tus generaciones queden visibles públicamente.',
+        ],
+      },
+      {
+        title: 'Rotular en castellano sin que se rompa',
+        paragraphs: [
+          'En los dos casos el prompt rinde mejor en inglés, pero con Ideogram hay un truco que funciona muy bien: describe la escena y el estilo en inglés y pon entre comillas la cadena exacta que debe aparecer, en castellano. El modelo trata ese texto como literal y lo respeta bastante, incluso con palabras que no existen en inglés. Es la forma más fiable de conseguir un titular en español sin renunciar a la precisión del prompt.',
+          'Dicho esto, las tildes, la eñe y los signos de apertura siguen siendo el punto flaco: el acierto baja de forma apreciable respecto al texto en inglés y hay que revisar carácter a carácter antes de dar nada por bueno. Genera varias opciones y quédate con la que salga ortográficamente correcta. Con Midjourney ni siquiera merece la pena intentarlo en castellano: el texto habrá que ponerlo aparte.',
+        ],
+      },
+      {
+        title: 'Combinarlos en un flujo de diseño real',
+        paragraphs: [
+          'El reparto evidente es fondo e ilustración en Midjourney, y titular o tipografía integrada en Ideogram cuando el texto tiene que formar parte del material: letras sobre una superficie, un cartel dentro de la escena, un nombre grabado en un producto. Si el texto simplemente va encima de la imagen, hay una tercera vía que suele ser mejor que ambas: generar la imagen limpia en Midjourney y montar la tipografía en Figma o Illustrator.',
+          'Esa tercera vía es la que recomendaría a cualquiera que trabaje con clientes. Controlas la fuente corporativa, el interletraje y las versiones para otros idiomas, y puedes cambiar el titular sin regenerar nada. Ideogram deja de ser prescindible justo cuando el texto no puede ir superpuesto porque debe seguir la perspectiva, la textura o la iluminación de la escena. Ahí sí, ninguna otra opción te lo resuelve en un solo paso.',
+        ],
+      },
+    ],
     faqs: [
       {
         question: '¿Cuál es mejor, Midjourney o Ideogram?',
@@ -1160,6 +1772,50 @@ export const comparisons: Comparison[] = [
       'Produces mucho contenido para redes o marketing y prima la velocidad',
       'Trabajas en equipo con plantillas y kit de marca compartidos',
     ],
+    sections: [
+      {
+        title: 'Un motor para quien sabe diseñar y una capa para quien no tiene por qué saber',
+        paragraphs: [
+          'Firefly está construido sobre una suposición: el usuario sabe lo que quiere y solo necesita que la máquina ejecute una parte concreta. Por eso vive dentro de Photoshop o Illustrator, devuelve resultados en capas y se integra con selecciones y máscaras. No decide nada por ti, y de hecho asume que vas a corregir lo que devuelva. Es una herramienta profunda y estrecha: hace pocas cosas comparado con lo que promete su competencia, pero las hace donde ya estabas trabajando.',
+          'Canva Magic Studio hace la suposición contraria: el usuario no sabe diseñar y su objetivo es publicar algo presentable hoy. Más que un modelo, es una orquestación de funciones sobre un sistema de plantillas, con generación de imagen, redacción de textos, montaje de presentaciones, edición de vídeo y traducción de diseños apoyándose en modelos de terceros. Es ancho y superficial, y esa superficialidad es intencionada: cada función está limitada para que sea imposible equivocarse mucho.',
+          'Por eso el comprador es distinto. Firefly lo compra un departamento de diseño que ya tiene criterio y lo que quiere es velocidad sin perder control. Canva lo compra un equipo de marketing, una pyme o un centro educativo que necesita producir mucho y bien sin contratar a nadie ni formar a nadie. Los problemas aparecen cuando uno intenta hacer el trabajo del otro: Canva usado como herramienta de acabado profesional, o Adobe impuesto a gente que solo necesita una publicación para Instagram.',
+        ],
+      },
+      {
+        title: 'Quién se encarga del último diez por ciento',
+        paragraphs: [
+          'El criterio decisivo no es la calidad de la imagen generada, sino quién resuelve el último tramo, el que separa lo aceptable de lo entregable. Si el encargo parte de una fotografía real y hay que eliminar un elemento, extender el fondo o unificar la iluminación, Firefly gana sin discusión porque trabaja sobre píxeles reales con control por capas. Cuanto más se acerca el resultado a una fotografía creíble, más se nota la distancia entre las dos herramientas.',
+          'Cuando el trabajo es de volumen y montaje, Canva se impone con la misma claridad. Producir veinte piezas de campaña en ocho formatos, cambiar el titular en todas, traducirlas y dejarlas listas para publicar es algo que en Adobe exige plantillas, scripts o mucha paciencia, y que en Canva es cuestión de minutos con el kit de marca aplicado. Firefly no compite en producción en serie, igual que Canva no compite en precisión sobre una imagen concreta.',
+        ],
+        bullets: [
+          'Retoque y composición sobre foto real: Firefly en Photoshop',
+          'Muchas piezas en muchos formatos con el mismo mensaje: Canva',
+          'Vectores editables y control por capas: Firefly',
+          'Texto, presentación y vídeo resueltos en el mismo sitio: Canva',
+        ],
+      },
+      {
+        title: 'Créditos incluidos frente a plan plano por usuario',
+        paragraphs: [
+          'Las estructuras son distintas y eso cambia el cálculo. Adobe cobra la suscripción de sus aplicaciones e incluye una asignación mensual de créditos generativos que se consume con cada operación; al agotarla, la generación se ralentiza o hay que ampliar, según el plan. Canva mantiene una capa gratuita amplia y un plan de pago plano por usuario que incluye su asignación de funciones de IA. Uno se paga por herramienta profesional, el otro por persona del equipo.',
+          'Eso define bien la rentabilidad. Si tu estudio ya paga Creative Cloud, Firefly es coste hundido y usarlo no añade nada a la factura. Si eres una pyme con cinco personas que no son diseñadoras, licenciar Adobe para todas es desproporcionado y Canva sale muy por debajo. El escenario que se encarece es el intermedio: equipos que empiezan con Canva, chocan con su techo de control y acaban pagando también Adobe. Compara las tarifas y las asignaciones vigentes en cada web oficial.',
+        ],
+      },
+      {
+        title: 'Trabajo en español: dónde gana cada uno',
+        paragraphs: [
+          'Las dos están localizadas, pero la ventaja de Canva en español es real y va más allá de la interfaz: genera copys, guiones y textos de presentación en castellano con soltura, traduce diseños completos manteniendo la maquetación y su biblioteca de plantillas está adaptada a formatos y convenciones del mercado hispano. Para un equipo de marketing que trabaja en español todos los días, eso ahorra más tiempo que cualquier mejora en la calidad de imagen.',
+          'Firefly acepta instrucciones en español, aunque el inglés sigue dando resultados algo mejores. Su ventaja en el mercado español no es lingüística sino corporativa: soporte, facturación y documentación en castellano para justificar el uso comercial del material generado ante un cliente o un departamento de compras. En rotulación con tildes y eñes, las dos herramientas son igual de poco fiables, así que el texto se sigue poniendo por encima.',
+        ],
+      },
+      {
+        title: 'Convivencia sin duplicar el trabajo',
+        paragraphs: [
+          'El reparto que funciona es por nivel: las piezas maestras y todo lo que toque fotografía real o identidad de marca se resuelve en Adobe con Firefly, y esas piezas se suben a Canva como elementos del kit de marca para que el resto del equipo produzca las adaptaciones diarias sin poder romperlas. Diseño hace el original una vez, marketing genera las cien variantes. Cada herramienta trabaja donde es imbatible y nadie pisa el terreno del otro.',
+          'El riesgo real de usar las dos no es técnico sino organizativo: si cualquiera puede crear piezas maestras en Canva mientras diseño mantiene las suyas en Adobe, acabas con dos fuentes de verdad, dos versiones del logo y piezas que no casan entre sí. Antes de combinarlas, decide quién es el dueño de las plantillas y qué está permitido modificar en Canva. Sin esa regla, la ganancia de velocidad se paga en incoherencia de marca.',
+        ],
+      },
+    ],
     faqs: [
       {
         question: '¿Cuál es mejor, Adobe Firefly o Canva Magic Studio?',
@@ -1238,6 +1894,50 @@ export const comparisons: Comparison[] = [
       'No quieres montar el audio en un editor externo',
       'Trabajas en un equipo de RR. HH., formación o marketing corporativo',
       'Prefieres una herramienta orientada al resultado final, no al fichero de audio',
+    ],
+    sections: [
+      {
+        title: 'Una empresa de modelos de voz frente a una herramienta de producción',
+        paragraphs: [
+          'ElevenLabs es, ante todo, un laboratorio de modelos de voz que además tiene una interfaz web. Lo que compras es el motor: la calidad del habla, la expresividad, la clonación y una API sobre la que otros construyen productos. Su hoja de ruta avanza con el modelo, así que cada mejora se nota directamente en cómo suena el audio que generas, sin que cambie tu forma de trabajar. La edición y el montaje se asumen como problema tuyo, fuera de la plataforma.',
+          'Murf parte del extremo opuesto: es una herramienta de producción que necesita voces para funcionar. Lo que compras es el proceso, desde el guion escrito por bloques hasta la mezcla con música, la sincronización con las diapositivas o el vídeo y la revisión con el resto del equipo. Sus avances suelen ir por el lado del flujo de trabajo, no por el del realismo, porque su cliente no busca la mejor voz del mundo sino terminar un módulo formativo esta semana.',
+          'Esa diferencia explica quién acaba en cada una. Creadores y desarrolladores eligen ElevenLabs porque el audio es su materia prima, ya tienen editor y lo único que les falta es una voz que aguante la comparación con un locutor real. Equipos de formación, recursos humanos y marketing interno eligen Murf porque nadie de la plantilla sabe ni quiere aprender a montar audio, y lo que necesitan es cerrar un módulo completo sin depender de un proveedor externo.',
+        ],
+      },
+      {
+        title: 'Naturalidad sostenida frente a control por bloques',
+        paragraphs: [
+          'En narración larga la diferencia se oye enseguida. Un capítulo de audiolibro o un vídeo de veinte minutos exige que la voz mantenga coherencia de tono, respire donde toca y no se vuelva monótona: ElevenLabs sostiene mucho mejor esa distancia y sus pausas suenan intencionadas en lugar de mecánicas. Murf entrega un resultado correcto pero que se va aplanando conforme pasan los minutos, con esa cadencia de locución institucional que delata que no hay una persona detrás.',
+          'En cambio, un módulo de e-learning con treinta diapositivas de veinte segundos es otro problema completamente distinto. Ahí no importa tanto el matiz interpretativo como poder ajustar la velocidad de una frase concreta, marcar el énfasis en una palabra, cuadrar el audio con la animación y rehacer solo el bloque cuatro sin tocar el resto. Murf está diseñado exactamente para eso. En resumen: ElevenLabs da más techo con menos herramientas, Murf da más herramientas con menos techo.',
+        ],
+        bullets: [
+          'Audiolibro, pódcast o doblaje de larga duración: ElevenLabs',
+          'Curso, formación interna o vídeo corporativo por bloques: Murf',
+          'Voz integrada en una aplicación mediante API: ElevenLabs',
+          'Equipo sin perfil técnico que debe revisar y aprobar juntos: Murf',
+        ],
+      },
+      {
+        title: 'Pagar por caracteres o pagar por minutos y asientos',
+        paragraphs: [
+          'ElevenLabs cobra por caracteres generados, con una cuota gratuita mensual y escalones de volumen por encima. La clave de ese modelo es que cada regeneración cuesta: si eres de probar diez versiones de la misma frase hasta dar con la entonación buena, tu consumo real será muy superior al número de caracteres del guion final. Es un detalle que sorprende a mucha gente en el primer mes y conviene tenerlo en cuenta al estimar.',
+          'Murf estructura el precio por minutos u horas de audio y por número de asientos, normalmente con contratación anual. Ese modelo penaliza al usuario individual que produce mucho y favorece al equipo de cuatro o cinco personas que produce poco pero necesita acceso simultáneo, revisión compartida y una factura previsible que aprobar una vez al año. En ambas, la clonación de voz y algunos idiomas suelen estar reservados a planes superiores: comprueba las condiciones vigentes en sus webs oficiales.',
+        ],
+      },
+      {
+        title: 'Cómo suena el castellano en cada una',
+        paragraphs: [
+          'ElevenLabs va por delante en español y la diferencia es audible sin necesidad de fijarse: mejor entonación, ritmo más humano y un manejo de las pausas que no suena a lector automático. Además distingue con más criterio entre voces de español de España y variantes latinoamericanas, algo que importa mucho si tu contenido es para público peninsular y no quieres que suene a doblaje neutro. Murf tiene voces en castellano correctas, pero con una prosodia más plana y de locutor institucional.',
+          'El problema que comparten es el mismo de siempre: cifras, siglas, extranjerismos y nombres propios. Cantidades en euros, porcentajes, acrónimos de empresa o apellidos poco frecuentes se leen mal en ambas y hay que intervenir. Murf ofrece un diccionario de pronunciación explícito donde fijas cómo se dice cada término; en ElevenLabs se resuelve reescribiendo el texto tal y como debe sonar o usando sus propios diccionarios. Presupuesta ese trabajo de normalización: en proyectos largos no es menor.',
+        ],
+      },
+      {
+        title: 'Usar las dos: cuándo tiene sentido de verdad',
+        paragraphs: [
+          'El reparto técnico funciona: generas la locución en ElevenLabs por su calidad, exportas y la montas en Murf o directamente en tu editor de vídeo. Pero conviene ser honesto con las consecuencias. Si vas a montar el audio fuera de Murf, su propuesta de valor se evapora casi entera, porque lo que estás pagando es precisamente no tener que salir de la herramienta. Pagar dos suscripciones para usar solo el motor de una y solo la línea de tiempo de la otra rara vez compensa.',
+          'Donde sí tiene sentido mantener ambas es cuando produces dos tipos de contenido distintos. Un departamento que hace formación interna en volumen y además publica pódcast o vídeos de marca puede tener a Murf resolviendo lo primero con todo el equipo dentro y a ElevenLabs cubriendo lo segundo, donde la voz es el producto. Si solo haces uno de los dos tipos, elige la herramienta que corresponda y ahórrate la segunda factura.',
+        ],
+      },
     ],
     faqs: [
       {
@@ -1388,6 +2088,50 @@ export const comparisons: Comparison[] = [
       'Tu organización exige garantías de seguridad, consentimiento o detección de deepfakes',
       'Necesitas un despliegue a medida o condiciones contractuales específicas',
       'Trabajas en un sector regulado donde el cumplimiento pesa tanto como la calidad',
+    ],
+    sections: [
+      {
+        title: 'Producto de autoservicio frente a proveedor de infraestructura',
+        paragraphs: [
+          'ElevenLabs funciona como producto de consumo con API: te registras, clonas una voz en minutos, generas y escalas con una tarjeta. Todo su diseño está orientado a eliminar fricción entre la idea y el audio, y su inversión se concentra en el modelo y en la experiencia de uso. Es la opción natural cuando la decisión de compra la toma la misma persona que va a usar la herramienta, sin pasar por compras ni por legal.',
+          'Resemble AI juega otro partido. Su esfuerzo está en el perímetro que rodea al modelo: consentimiento verificable de la persona cuya voz se clona, marcado del audio generado, detección de voz sintética y opciones de despliegue que no obligan a que los audios salgan de la infraestructura del cliente. Nada de eso mejora cómo suena una frase, pero es exactamente lo que pregunta el cuestionario de seguridad de una empresa grande antes de firmar.',
+          'De ahí los dos compradores. Uno es un creador o un equipo de producto que quiere una voz funcionando hoy y valora la calidad por encima de todo. El otro es una organización para la que la voz clonada es un activo con riesgo asociado: si esa voz representa a la marca o a una persona concreta, quién puede usarla y cómo se demuestra el consentimiento deja de ser un detalle.',
+        ],
+      },
+      {
+        title: 'No es solo cómo suena, es a quién puedes enseñárselo',
+        paragraphs: [
+          'En naturalidad pura, ElevenLabs suele ganar y no tiene sentido disimularlo: para un audiolibro, un vídeo de YouTube o un pódcast, sus voces son más creíbles y su clonación necesita menos material para dar un resultado convincente. Si tu criterio es que el oyente no note que es sintético, y no tienes restricciones corporativas, la decisión está tomada antes de empezar a comparar el resto de funciones.',
+          'Resemble compensa por otro lado. Ofrece capacidades que en un entorno profesional valen mucho: editar una grabación real sustituyendo palabras manteniendo la voz del locutor original, llevar esa misma voz a varios idiomas sin volver a convocar a la persona, y todo ello con controles de acceso y trazabilidad sobre quién genera qué. Para una entidad financiera que quiere su voz de marca en la atención telefónica, esas garantías pesan más que un matiz de entonación.',
+        ],
+        bullets: [
+          'Contenido de creador o producto sin requisitos legales: ElevenLabs',
+          'Voz de marca corporativa que hay que auditar y proteger: Resemble AI',
+          'Sustituir palabras en una grabación ya existente: Resemble AI',
+          'Máxima naturalidad con el mínimo trámite: ElevenLabs',
+        ],
+      },
+      {
+        title: 'Autoservicio por consumo frente a contrato negociado',
+        paragraphs: [
+          'ElevenLabs es autoservicio de principio a fin: cuota gratuita, facturación por caracteres y escalones que subes tú mismo sin hablar con nadie. Puedes empezar hoy, estimar el coste con una hoja de cálculo y cancelar cuando quieras. Resemble combina planes de autoservicio con contratación empresarial donde el precio depende del volumen, del tipo de despliegue y del soporte, lo que implica una conversación comercial antes de saber cuánto vas a pagar realmente.',
+          'El punto de inflexión no es el volumen sino los requisitos. Por debajo de cierto consumo y sin exigencias legales, ElevenLabs es más barato y muchísimo más rápido de contratar. En cuanto entran en juego acuerdos de tratamiento de datos, residencia de la información, despliegue en tu propia nube o niveles de servicio comprometidos, la comparación deja de ser precio por carácter y pasa a ser coste total del proyecto, incluido el tiempo de tu equipo legal. Ahí el autoservicio no compite.',
+        ],
+      },
+      {
+        title: 'Español y voces multilingües a partir del mismo locutor',
+        paragraphs: [
+          'Las dos cubren el castellano, pero con propuestas distintas. ElevenLabs tiene más voces disponibles y una prosodia peninsular más convincente, así que si buscas una voz de catálogo lista para usar en español de España, encontrarás mejores opciones y antes. Es la ventaja de tener un catálogo grande y una comunidad que lo alimenta: puedes probar diez voces en una tarde hasta dar con la que encaja con el tono de tu contenido.',
+          'Resemble apuesta más por otra vía: clonar la voz de tu propio locutor y hacerla hablar en varios idiomas manteniendo su identidad. Para una empresa española que produce contenido en castellano, catalán, inglés y portugués con una misma voz corporativa, eso puede pesar más que el tamaño del catálogo. En ambas, revisa cómo leen cifras en euros, siglas y nombres propios: es donde se rompe la ilusión y donde tendrás que normalizar el texto de entrada.',
+        ],
+      },
+      {
+        title: 'Prototipar en una y producir en la otra',
+        paragraphs: [
+          'El reparto sensato es temporal más que funcional: prototipar en ElevenLabs, donde puedes tener una demo convincente en una tarde para enseñar al cliente o al comité, y producir en Resemble si el proyecto llega a producción con requisitos de seguridad, consentimiento o despliegue que la primera no cubre. Es un camino habitual y no tiene nada de malo, siempre que sepas desde el principio que el prototipo no es la versión definitiva.',
+          'Ahora la advertencia importante. Cambiar de proveedor a mitad de proyecto obliga a reclonar la voz y a volver a validar el resultado, y el timbre resultante no será idéntico, así que el material ya publicado dejará de casar con el nuevo. Si tu cliente es una empresa regulada, empieza directamente donde vas a acabar. Y no clones la misma voz en dos plataformas sin un consentimiento por escrito que cubra explícitamente ambas: es el tipo de detalle que solo aparece cuando ya es un problema.',
+        ],
+      },
     ],
     faqs: [
       {
@@ -1701,6 +2445,48 @@ export const comparisons: Comparison[] = [
       'Buscas efectos visuales rápidos sin montar un proyecto',
       'Prefieres un coste de entrada bajo para experimentar',
     ],
+    sections: [
+      {
+        title: 'Herramienta de producción frente a herramienta de creación rápida',
+        paragraphs: [
+          'Runway se dirige a quien entrega vídeo a un cliente. Su producto está pensado alrededor del proyecto: espacios de equipo, control sobre el encuadre y la cámara, herramientas para arreglar material existente y licencias claras para uso comercial. Todo eso añade fricción a cambio de previsibilidad, que es exactamente lo que pide alguien que tiene una fecha de entrega y una factura de por medio.',
+          'Pika creció en la dirección opuesta, con una comunidad que empezó pidiendo clips en un chat y con una identidad muy ligada a los efectos llamativos y reconocibles. Su gracia es que en un minuto tienes algo que funciona en redes: un objeto que se derrite, un personaje que se infla, una escena que estalla. No pretende sustituir a un editor, pretende que publiques hoy y que el vídeo llame la atención en los tres primeros segundos.',
+          'Elegir es sobre todo decidir a qué te dedicas, no cuál genera mejor imagen. Para una agencia, una marca o cualquier encargo audiovisual que se factura y se revisa, Runway ofrece el control y las garantías que ese trabajo exige. Para contenido social propio, humor visual y un volumen alto de publicaciones donde nadie va a mirar el clip en una pantalla grande, Pika hace el mismo trabajo más rápido y más barato, y esa ventaja se acumula semana tras semana.',
+        ],
+      },
+      {
+        title: 'Control y coherencia frente a velocidad por intento',
+        paragraphs: [
+          'Runway mantiene mejor la coherencia dentro del plano: el sujeto se deforma menos, el movimiento de cámara responde a lo que pides y el clip aguanta más segundos sin desbaratarse. También ofrece más resolución y más margen para trabajar el resultado después. En cuanto el vídeo se va a ver en una pantalla grande o junto a material rodado, esa diferencia deja de ser un matiz y se vuelve el motivo de la elección.',
+          'Pika gana en el terreno del coste por intento. Genera antes y consume menos, y en generación de vídeo eso importa mucho porque el trabajo real consiste en descartar. Diez pruebas rápidas para encontrar una idea valen más que dos pruebas lentas y perfectas cuando estás explorando. Para clips verticales de pocos segundos con un golpe visual claro, el resultado de Pika es suficiente y llega mucho antes. Para un plano que tiene que sostener una narración, se queda corto.',
+        ],
+      },
+      {
+        title: 'Qué modelo de precio conviene a cada perfil',
+        paragraphs: [
+          'Los dos venden créditos dentro de una suscripción, pero calibrados para públicos distintos. Pika se posiciona como opción asequible, con un escalón gratuito utilizable de verdad y planes de entrada pensados para un creador individual que publica a diario. Runway sube de precio por tramo, reserva la resolución alta y las funciones de edición a los planes superiores y ofrece cuentas de equipo con almacenamiento y permisos compartidos, que es lo que necesita un estudio.',
+          'La forma honesta de comparar es calcular el coste por clip publicado, no por clip generado. Si descartas nueve de cada diez intentos, un plan barato con generaciones rápidas puede salir mejor que uno caro con generaciones lentas, aunque cada resultado individual sea peor. Y al revés: si cada plano tiene que pasar por la aprobación de un cliente, pagar más por acertar antes y por poder arreglar el resultado compensa de sobra.',
+        ],
+        bullets: [
+          'Creador de contenido social con publicación diaria: Pika sale más rentable por volumen y rapidez.',
+          'Estudio, agencia o freelance con clientes: Runway, por control, resolución y licencia comercial sin dudas.',
+        ],
+      },
+      {
+        title: 'Trabajar en español con las dos',
+        paragraphs: [
+          'Ambas aceptan prompts en castellano y los entienden bien mientras describas objetos, acciones y ambientes cotidianos. La pérdida aparece con el vocabulario de cámara y de estilo visual, mucho más rico en inglés dentro de los datos con los que se entrenaron estos modelos. Lo práctico es redactar en español y dejar en inglés los términos de encuadre, óptica, iluminación y referencia estética.',
+          'Fuera del prompt, las dos son experiencias en inglés. Runway tiene documentación extensa que hay que leer para aprovechar sus funciones avanzadas, y ahí el idioma sí supone una barrera real para un equipo no técnico. Pika exige mucho menos texto, pero buena parte de lo que se aprende circula por su comunidad, también en inglés. Ninguna de las dos genera bien rótulos en español dentro de la imagen: las eñes y los acentos salen deformados, así que la tipografía conviene añadirla después.',
+        ],
+      },
+      {
+        title: 'Usar Pika para explorar y Runway para entregar',
+        paragraphs: [
+          'El reparto más razonable aprovecha la asimetría de coste entre las dos. Pika sirve como banco de pruebas: generas muchas variantes baratas hasta dar con la idea, el encuadre y el tipo de movimiento que funcionan, y una vez tienes esa referencia clara pasas a Runway para producir la versión definitiva y trabajarla después. Lo que ahorras no es dinero en créditos, es el tiempo de tirar generaciones caras a ciegas mientras todavía no sabes qué estás buscando exactamente.',
+          'Para un creador individual que solo publica en redes, mantener las dos suscripciones no compensa y Pika basta. Para un estudio, el coste añadido de Pika es marginal frente al tiempo de créditos de Runway que ahorra en la fase de exploración. Lo que no tiene sentido es alternar las dos dentro de la misma pieza final, porque el salto de calidad entre planos es evidente en el montaje.',
+        ],
+      },
+    ],
     faqs: [
       {
         question: '¿Cuál es mejor, Runway o Pika Labs?',
@@ -1779,6 +2565,48 @@ export const comparisons: Comparison[] = [
       'Necesitas traducir y doblar vídeos ya grabados con sincronía labial',
       'Trabajas en marketing internacional y localizas mucho contenido',
       'Quieres empezar con un plan gratuito antes de comprometerte',
+    ],
+    sections: [
+      {
+        title: 'Formación corporativa frente a marketing y creadores',
+        paragraphs: [
+          'Synthesia está construido alrededor del vídeo interno de empresa. Se nota en todo lo que rodea al avatar: plantillas de marca, biblioteca compartida, control de quién puede publicar, versiones de un mismo curso, actualización de un vídeo cambiando una línea de guion y exportación hacia plataformas de formación. Su cliente típico no es un creador, es un departamento que tiene que producir cincuenta vídeos coherentes entre sí y responder ante cumplimiento y ante legal por lo que aparece en pantalla.',
+          'HeyGen empuja en la dirección del marketing y del creador individual. Sus apuestas más fuertes son el avatar personal convincente hecho a partir de tu propia grabación, la traducción de un vídeo existente con la boca sincronizada al nuevo idioma y la generación rápida de piezas publicitarias con aspecto de vídeo casero. Itera antes, publica antes y asume más riesgo estético a cambio de resultados que llaman la atención en un feed.',
+          'Por eso la pregunta útil no es cuál genera avatares mejores, sino quién va a ver el vídeo y con qué expectativa. Si lo ve la plantilla de tu empresa dentro de un curso obligatorio, junto a otros cuarenta vídeos que deben parecer de la misma casa, Synthesia está construido para eso. Si lo ve un desconocido en un feed o un cliente potencial en otro idioma, y lo que importa es que no pase de largo en tres segundos, HeyGen encaja mejor con ese objetivo.',
+        ],
+      },
+      {
+        title: 'Realismo del avatar y sincronización labial',
+        paragraphs: [
+          'HeyGen suele ir por delante en avatares personales. El clon hecho a partir de tu grabación conserva mejor los gestos y la manera de moverse, y en el doblaje a otro idioma la boca acompaña al audio con bastante credibilidad, que es su función más difícil de igualar. Para un fundador que quiere aparecer en cinco idiomas sin volver a grabar, esa capacidad justifica por sí sola la elección.',
+          'Synthesia gana en el terreno de los avatares de catálogo y en el conjunto de la pieza. Sus presentadores predefinidos aguantan mejor un vídeo largo sin resultar inquietantes, y el resultado se percibe más como material corporativo bien hecho que como un experimento. Cuando hay que producir un curso de diez capítulos con la misma persona en pantalla, la misma tipografía y los mismos colores, Synthesia ofrece una consistencia que en HeyGen hay que construir a mano vídeo a vídeo.',
+        ],
+      },
+      {
+        title: 'Cómo pagan minutos, asientos y avatares',
+        paragraphs: [
+          'Las dos cobran suscripción con un tope de minutos de vídeo al mes, pero reparten lo caro en sitios distintos. En Synthesia el peso está en los asientos y en el plan de empresa, donde entran la gobernanza, las integraciones y el soporte, y el avatar personalizado es un extra que suele pertenecer a los tramos altos. En HeyGen los escalones de entrada son más accesibles para una persona sola, y el avatar propio y la traducción entran antes en la escalera de planes.',
+          'Para un equipo de formación de una empresa mediana, el coste de Synthesia se justifica porque sustituye grabaciones con estudio y locutor, y porque actualizar un vídeo caducado cuesta minutos. Para un autónomo, una pyme o un equipo de marketing pequeño, HeyGen entrega más valor por euro desde el primer mes. Calcula siempre sobre minutos publicados al año, no sobre la impresión que da el precio mensual del plan de entrada.',
+        ],
+        bullets: [
+          'Departamento de formación con catálogo de cursos y requisitos de marca: Synthesia.',
+          'Marketing, ventas o creador individual que necesita avatar propio y localización rápida: HeyGen.',
+        ],
+      },
+      {
+        title: 'Resultados en castellano',
+        paragraphs: [
+          'Las dos generan español correcto, pero hay que vigilar la variante. Muchas voces etiquetadas como español son latinoamericanas, y en un vídeo corporativo dirigido a plantilla española eso resta credibilidad desde la primera frase. Synthesia ofrece un catálogo más amplio de voces y acentos donde es más fácil encontrar castellano peninsular convincente. HeyGen tiene menos variedad, pero su sincronización labial en español aguanta mejor el primer plano, que es donde se detecta el doblaje mal encajado.',
+          'El guion importa tanto como la voz. Las frases largas con subordinadas, tan naturales al escribir en español, hacen que el avatar pierda el ritmo y suene a lectura. Conviene acortar, marcar las pausas, escribir las cifras como se dicen y desarrollar las siglas la primera vez. Ese trabajo de guion mejora el resultado en las dos herramientas más que cualquier ajuste técnico posterior.',
+        ],
+      },
+      {
+        title: 'Combinarlas tiene sentido en un caso concreto',
+        paragraphs: [
+          'El reparto que funciona es por función, no por gusto. Synthesia actúa como fábrica del catálogo de formación, con su plantilla de marca, su control de versiones y su capacidad de actualizar un vídeo caducado cambiando una línea del guion. HeyGen se reserva para localizar a otros idiomas las piezas que salen al exterior y para el vídeo de marketing donde interesa la cara real de alguien del equipo y no un presentador de catálogo. Son dos necesidades distintas y cada herramienta domina la suya.',
+          'El inconveniente principal no es el precio de las dos suscripciones, sino que el avatar no viaja entre plataformas: el clon que entrenas en una no existe en la otra, y si la persona cambia de aspecto hay que rehacerlo dos veces. Antes de duplicar herramientas, comprueba si con una sola cubres el ochenta por ciento de tus vídeos. En la mayoría de organizaciones, la respuesta es que sí.',
+        ],
+      },
     ],
     faqs: [
       {
@@ -1859,6 +2687,48 @@ export const comparisons: Comparison[] = [
       'Buscas una alternativa con planes potencialmente más ajustados',
       'Prefieres una herramienta más enfocada frente a una plataforma generalista',
     ],
+    sections: [
+      {
+        title: 'El mismo público, dos ideas distintas de qué es un vídeo formativo',
+        paragraphs: [
+          'Los dos apuntan a departamentos de formación y comunicación interna, así que la comparación no va de creadores contra empresas. Va de qué entiende cada uno por curso. Synthesia parte de la idea de vídeo corporativo bien acabado: presentador en pantalla, plantillas de marca, mucha voz y mucho idioma disponibles, y una máquina para producir en serie piezas coherentes entre sí y actualizarlas cuando cambia un procedimiento.',
+          'Colossyan parte de la idea de aprendizaje. Su terreno propio son las escenas con dos avatares que conversan, útiles para representar una situación entre un empleado y un cliente, y los vídeos con ramificación donde el alumno elige una respuesta y la historia continúa por un camino u otro. A eso suma cuestionarios y exportación hacia plataformas de formación en los formatos que espera un equipo de aprendizaje y desarrollo.',
+          'Traducido a la práctica, el criterio es qué esperas que haga el alumno después de ver el vídeo. Si basta con que se entere de algo, Synthesia hace ese trabajo con más músculo y con mejor acabado. Si tiene que aprender a decidir en una situación concreta, con casos, práctica y consecuencias, Colossyan trae de serie lo que en Synthesia habría que montar por fuera con la plataforma de formación, sumando complejidad y puntos donde algo puede romperse al actualizar el curso.',
+        ],
+      },
+      {
+        title: 'El criterio decisivo: qué tipo de curso produces',
+        paragraphs: [
+          'Para onboarding, comunicaciones de producto, avisos de cumplimiento y todo lo que consiste en explicar algo con claridad a mucha gente, Synthesia rinde mejor. Tiene más avatares y más voces entre las que elegir, plantillas que evitan que cada vídeo parezca de una empresa distinta y una operativa pensada para publicar decenas de piezas y mantenerlas al día sin rehacerlas.',
+          'Para formación en habilidades, atención al cliente, seguridad laboral o cualquier materia donde el alumno debe practicar un juicio, Colossyan tiene ventaja real. Un diálogo entre dos avatares en una escena de venta difícil comunica mucho más que un presentador enumerando buenas prácticas, y la ramificación permite que el alumno se equivoque y vea la consecuencia. Montar eso en otra herramienta implica trocear vídeos y coserlos en la plataforma de formación, con el mantenimiento que arrastra.',
+        ],
+      },
+      {
+        title: 'Precio: catálogo amplio frente a funciones de aprendizaje incluidas',
+        paragraphs: [
+          'Los dos venden suscripción con minutos de vídeo y asientos, pero el reparto de lo caro cambia. Synthesia concentra el valor en el volumen de avatares, voces e idiomas y en el plan de empresa, con gobernanza, integraciones y soporte, lo que encaja con una organización grande que centraliza compras. Colossyan compite metiendo antes las funciones de aprendizaje en planes más bajos, de modo que un equipo pequeño accede a interactividad y exportación sin negociar un contrato corporativo.',
+          'La cuenta suele decidirse por número de vídeos y por número de personas que los editan. Con pocos títulos pero muy trabajados y un equipo reducido, Colossyan sale mejor. Con muchos títulos, varios idiomas y gente de distintos departamentos publicando, Synthesia amortiza su coste porque reduce el trabajo de coordinación y de reelaboración, que es donde se va el presupuesto real de un catálogo formativo.',
+        ],
+        bullets: [
+          'Equipo pequeño de formación centrado en cursos con práctica e interactividad: Colossyan.',
+          'Organización con catálogo amplio, varios idiomas y requisitos de marca y control: Synthesia.',
+        ],
+      },
+      {
+        title: 'Rendimiento en español',
+        paragraphs: [
+          'Los dos producen castellano aceptable, y en los dos hay que revisar si la voz elegida es peninsular o latinoamericana antes de dar por bueno un curso destinado a plantilla en España. Synthesia parte con ventaja por catálogo: más voces entre las que buscar un tono adecuado y más facilidad para publicar la misma pieza en varios idiomas partiendo del mismo guion, algo que a una multinacional le ahorra semanas.',
+          'Colossyan cubre bien el español, aunque con menos variedad de voces, y su punto fuerte en el idioma está en otro sitio: en una conversación entre dos avatares el oído perdona más una entonación imperfecta, porque el diálogo aporta ritmo natural que un monólogo no tiene. En ambos casos, escribir el guion en frases cortas y marcando las pausas mejora el resultado más que cualquier ajuste de la herramienta.',
+        ],
+      },
+      {
+        title: '¿Tiene sentido mantener las dos?',
+        paragraphs: [
+          'Rara vez compensa. Los dos ocupan exactamente el mismo hueco en el presupuesto y en el flujo de trabajo, así que duplicarlos no cubre un vacío, solo reparte el mismo trabajo entre dos sitios. Y el catálogo formativo sufre cuando la mitad de los cursos tiene un estilo de avatar, de plantilla y de voz y la otra mitad otro distinto: el alumno percibe el material como improvisado aunque no sepa señalar por qué, y esa impresión resta autoridad a lo que se enseña.',
+          'La única combinación defendible es por tipo de contenido bien separado: Colossyan para los módulos de simulación y práctica, que se reconocen como formato aparte, y Synthesia para todo lo informativo y multilingüe. Aun así, antes de duplicar suscripciones conviene probar si la más completa de las dos cubre lo suficiente. En formación, la coherencia visual del catálogo suele valer más que la función extra que se echa de menos.',
+        ],
+      },
+    ],
     faqs: [
       {
         question: '¿Cuál es mejor, Synthesia o Colossyan?',
@@ -1934,6 +2804,48 @@ export const comparisons: Comparison[] = [
       'No te importa cambiar de editor a cambio de más capacidad',
       'Quieres probar sin pagar: su plan gratuito permite hacerse una idea real',
     ],
+    sections: [
+      {
+        title: 'Por qué uno puede cambiar el editor y el otro no',
+        paragraphs: [
+          'La diferencia de fondo no es de modelos, es de hasta dónde puede llegar cada producto. Copilot vive como capa añadida sobre editores que ya existen y que Microsoft debe mantener estables para millones de configuraciones distintas. Eso impone un ritmo: cada novedad tiene que convivir con extensiones ajenas, con equipos que actualizan tarde y con políticas de empresa. Gana en compatibilidad y pierde en libertad para reinventar la forma de trabajar.',
+          'Cursor es una bifurcación del propio editor, así que puede tocar piezas que Copilot no controla: cómo se muestran los cambios propuestos, cómo se indexa el repositorio, qué ocurre al pulsar el tabulador. Por eso estrena antes formas de trabajo que después se copian en todas partes, y por eso también rompe cosas de vez en cuando. La contrapartida real está en depender de un tercero para actualizaciones del editor y en que algunas extensiones propietarias de Microsoft no están disponibles fuera de sus productos.',
+          'Ese detalle, que suena a letra pequeña, decide bastantes migraciones en la práctica. Un equipo atado a herramientas oficiales de Microsoft, con depuradores y extensiones propias de su plataforma, se encuentra con huecos al pasarse a Cursor y acaba volviendo a mitad de camino. Otro que trabaje con lenguajes y extensiones de comunidad abierta casi no nota la diferencia y se lleva las ventajas sin pagar peaje. Antes de decidir, mira qué extensiones usáis a diario y comprueba si existen fuera del ecosistema oficial.',
+        ],
+      },
+      {
+        title: 'Autocompletado fiable frente a agente que edita el proyecto',
+        paragraphs: [
+          'En el uso minuto a minuto, Copilot brilla en lo discreto: sugerencias en línea que aciertan el patrón que estabas escribiendo y que no interrumpen. Es previsible, molesta poco y se aprende solo. Cursor apuesta por algo más ambicioso: predecir cuál es la siguiente edición y llevarte hasta ella aunque esté en otra parte del archivo, y ejecutar tareas completas sobre varios ficheros mostrando después los cambios para aprobarlos o rechazarlos uno a uno.',
+          'Eso se traduce en tareas concretas. Renombrar un concepto que aparece repartido por veinte archivos, escribir la batería de pruebas de un módulo entero o adaptar el código a un cambio de librería son encargos donde Cursor termina antes porque ve el proyecto y aplica los cambios. Copilot devuelve la ventaja fuera del editor: revisión de cambios en las peticiones de incorporación, trabajo desde el navegador sobre un repositorio y automatizaciones ligadas al propio flujo de la plataforma.',
+        ],
+      },
+      {
+        title: 'Gasto previsible frente a gasto proporcional al uso',
+        paragraphs: [
+          'Aunque los precios de partida se parezcan, lo que se agota es distinto y eso cambia la experiencia. Copilot vende asientos con una cuota de peticiones a los modelos más caros, de forma que una empresa sabe de antemano lo que va a pagar cada mes por persona. Cursor combina la suscripción con un consumo que depende del modelo elegido y de lo intensamente que uses el agente, y permite además usar tus propias claves de proveedor para pagar el consumo aparte.',
+          'El resultado es que Copilot encaja mejor donde alguien tiene que aprobar un presupuesto anual y no quiere sorpresas, y Cursor encaja mejor donde quien paga es quien programa y puede decidir en cada tarea si usa un modelo barato o quema créditos en algo difícil. Para un autónomo, esa flexibilidad se traduce en gastar poco casi todo el mes y mucho los dos días en que aborda algo grande.',
+        ],
+        bullets: [
+          'Empresa con muchos desarrolladores y compras centralizadas: el coste por asiento de Copilot es más fácil de defender.',
+          'Autónomo o equipo pequeño que quiere exprimir el agente: el consumo variable de Cursor rinde más por euro.',
+        ],
+      },
+      {
+        title: 'Trabajar en español dentro del editor',
+        paragraphs: [
+          'Los dos entienden instrucciones en castellano sin problema y responden en el mismo idioma en el que preguntas. La diferencia práctica está en cómo se fija esa preferencia para todo el equipo. En Cursor se declara en las reglas del proyecto, que se guardan en el repositorio y aplican a cualquiera que lo abra, lo que evita que cada persona tenga que repetir la instrucción. Copilot ofrece un mecanismo equivalente con instrucciones personalizadas asociadas al repositorio.',
+          'Conviene ser realista con los límites. Aunque respondan en español, los modelos tienden a volver al inglés en nombres de variables, mensajes de registro y comentarios generados en bloques largos, y hay que corregirlo a mano si tu equipo mantiene el código en castellano. La documentación y la comunidad de Cursor están casi por completo en inglés, mientras que Copilot llega traducido dentro de un editor que mucha gente ya tiene en español.',
+        ],
+      },
+      {
+        title: 'Cuándo conviene pagar los dos',
+        paragraphs: [
+          'Tener dos autocompletados compitiendo dentro del mismo editor es una mala idea y se nota enseguida en forma de sugerencias solapadas. Pero hay un reparto que sí funciona y que muchas empresas acaban adoptando sin planificarlo: Cursor como editor local para escribir código, y Copilot en el lado de la plataforma, revisando cambios en las peticiones de incorporación y respondiendo dudas sobre el repositorio desde el navegador.',
+          'Si vas por ese camino, desactiva el autocompletado de uno de los dos dentro del editor y deja escrito cuál manda en cada fase, porque si no cada persona acaba con una configuración distinta. Y asume el coste doble por asiento, que en un equipo grande deja de ser anecdótico muy rápido y hay que poder justificarlo. Para la mayoría de desarrolladores individuales, elegir uno y aprenderlo a fondo, incluidos sus atajos y su forma de gestionar el contexto, rinde bastante más que repartirse entre ambos.',
+        ],
+      },
+    ],
     faqs: [
       {
         question: '¿Cuál es mejor, GitHub Copilot o Cursor?',
@@ -2008,6 +2920,48 @@ export const comparisons: Comparison[] = [
       'Necesitas desplegar el asistente en tu propia infraestructura o VPC',
       'Te preocupan las garantías de licencia del código sugerido',
       'Trabajas en un sector regulado (banca, sanidad, defensa) con auditorías',
+    ],
+    sections: [
+      {
+        title: 'Capacidad máxima frente a control sobre dónde vive tu código',
+        paragraphs: [
+          'Copilot está diseñado para exprimir los mejores modelos disponibles, que viven en la nube y evolucionan cada pocos meses. La propuesta es sencilla: la máxima capacidad posible, integrada en el editor y en la plataforma donde ya está tu repositorio. A cambio, tu código viaja a un servicio externo y aceptas las condiciones que ese servicio establezca, revisables pero no negociables salvo en contratos grandes.',
+          'Tabnine vende justo lo contrario, y por eso sigue teniendo clientes pese a competir con un gigante. Su argumento es el control: dónde se ejecuta el modelo, incluida la opción de desplegarlo en la infraestructura del cliente o en su propia nube privada, con qué código se entrenó, apoyándose en repositorios de licencia permisiva, y qué se guarda de lo que escribes. Es una decisión que suele tomar el departamento de seguridad o el jurídico tanto como el equipo de desarrollo.',
+          'Esa diferencia arrastra otra puramente técnica. Un modelo que debe poder ejecutarse dentro de la infraestructura de un cliente es necesariamente más contenido que otro que corre en centros de datos gigantes, y eso se paga en capacidad de razonamiento y en longitud de lo que puede generar de una vez. Tabnine intenta compensarlo por otra vía: adaptar el modelo a los patrones concretos del código de tu organización, de modo que lo que pierde en potencia general lo recupera en conocimiento de tu casa.',
+        ],
+      },
+      {
+        title: 'Dónde se nota la diferencia al escribir código',
+        paragraphs: [
+          'Copilot gana con claridad en todo lo que exige generación larga o razonamiento: escribir una función completa a partir de una descripción, explicar un fragmento heredado que nadie entiende, proponer un refactor, redactar pruebas o encadenar varios pasos en modo agente. Si tu criterio es cuánto trabajo te quita al día, la comparación no está reñida y conviene decirlo sin rodeos.',
+          'Tabnine compite en el completado corto y repetitivo dentro de una base de código con convenciones propias. Cuando el modelo se ha ajustado a tus repositorios, acierta el nombre del ayudante interno, el orden de los parámetros y el patrón de manejo de errores que usáis, cosas que un modelo general desconoce. Añade dos ventajas del despliegue cercano: latencia baja y funcionamiento en entornos sin salida a internet, algo nada exótico en banca, sanidad o industria.',
+        ],
+      },
+      {
+        title: 'Lo que pagas y lo que compras con cada plan',
+        paragraphs: [
+          'Los dos cobran por asiento, pero venden cosas distintas dentro de ese precio. Copilot tiene un escalón gratuito con límites, planes individuales asequibles y tramos de empresa que suman administración, políticas y compromisos sobre propiedad intelectual del código sugerido. Tabnine sitúa su valor en los planes corporativos, donde entra el despliegue privado o local y el ajuste del modelo con vuestro código, y ese tipo de instalación conlleva un coste bastante superior por persona.',
+          'Por eso el análisis económico depende de a qué te dediques. Para un autónomo, una startup o cualquier equipo cuyo código no tenga restricciones especiales, Copilot ofrece más capacidad por euro y no hay mucho que discutir. Para una organización cuyo código no puede salir de su red, o que necesita justificar ante auditoría el origen de lo que se sugiere, el sobrecoste de Tabnine sustituye a un problema legal que no se resuelve con dinero.',
+        ],
+        bullets: [
+          'Sin restricciones de confidencialidad: Copilot, por capacidad y por precio.',
+          'Con requisitos de despliegue local, auditoría o procedencia del entrenamiento: Tabnine resuelve un problema que Copilot no aborda.',
+        ],
+      },
+      {
+        title: 'El idioma en la conversación con la herramienta',
+        paragraphs: [
+          'El español pesa poco en el completado de código, que es sobre todo reconocimiento de patrones, y ahí ambos se comportan igual. Donde sí aparece es en la parte conversacional: pedir que expliquen un módulo, redactar la descripción de un cambio o documentar una función para un equipo mixto. En eso Copilot va claramente por delante, porque se apoya en modelos generalistas grandes que redactan castellano natural y sostienen una explicación larga sin desbarrar.',
+          'Tabnine está más centrado en completar que en conversar, así que el idioma importa menos en su uso habitual, pero también significa que no esperes de él la misma calidad al pedirle una explicación en español. Si en tu equipo la documentación interna se escribe en castellano y quieres apoyo real para ello, ese es un punto concreto a favor de Copilot.',
+        ],
+      },
+      {
+        title: 'Convivencia poco recomendable',
+        paragraphs: [
+          'Mantener los dos activos en el mismo editor genera sugerencias que se pisan, retrasos al escribir y una experiencia claramente peor que la de cualquiera de los dos por separado. Aquí no existe el reparto natural que sí funciona en otras parejas de herramientas, donde una piensa y otra ejecuta, porque ambos ocupan exactamente el mismo hueco del flujo de trabajo: proponer la siguiente línea mientras escribes. Duplicar eso no suma capacidad, solo ruido y una factura mayor.',
+          'El único escenario con sentido es organizativo: una empresa que impone Tabnine por política en los repositorios sensibles y permite Copilot en los proyectos públicos o auxiliares donde esa restricción no aplica. Si es tu caso, separa los entornos por proyecto en lugar de dejar los dos encendidos a la vez, y deja explícito en la documentación interna qué herramienta corresponde a cada repositorio para que nadie tenga que adivinarlo.',
+        ],
+      },
     ],
     faqs: [
       {
@@ -2088,6 +3042,48 @@ export const comparisons: Comparison[] = [
       'Prefieres no cambiar de editor ni instalar nada',
       'Quieres un asistente sólido en español para tareas variadas',
     ],
+    sections: [
+      {
+        title: 'No compiten en el mismo plano',
+        paragraphs: [
+          'Cursor es un entorno de trabajo: indexa tu repositorio, sabe qué archivos existen, aplica cambios y te los muestra para aprobarlos o descartarlos. Claude es un asistente generalista con el que conversas, y esa conversación sirve tanto para programar como para redactar, analizar un documento o preparar una especificación. La diferencia de categoría explica por qué mucha gente que compara los dos acaba usando ambos sin darse cuenta.',
+          'Hay además un detalle que rara vez se menciona: Cursor ofrece modelos de varios proveedores, entre ellos los de Anthropic, así que en muchas sesiones estás usando Claude por dentro de Cursor. Comparar la calidad del modelo entre uno y otro tiene poco sentido; lo que se compara de verdad es el envoltorio, es decir, qué puede hacer cada herramienta con la respuesta que el modelo genera.',
+          'La otra pieza que conviene tener presente es que Anthropic tiene su propio agente de terminal, que sí actúa sobre los archivos del proyecto, ejecuta comandos y comprueba resultados. Con él en la ecuación, la frontera con Cursor se estrecha bastante y la elección deja de ser modelo contra editor para convertirse en algo más simple: si prefieres trabajar dentro de un editor gráfico, con los cambios resaltados y el ratón a mano, o en la línea de comandos describiendo lo que quieres y revisando después.',
+        ],
+      },
+      {
+        title: 'Ejecutar cambios frente a pensar el problema',
+        paragraphs: [
+          'Cursor gana cuando el trabajo consiste en tocar código que ya existe. Tiene el proyecto delante, propone las modificaciones donde corresponden, muestra las diferencias y permite ejecutar y comprobar sin salir de la ventana. Migrar una parte del código a otra librería, propagar un cambio de nombre por todo el proyecto o completar pruebas de un módulo son tareas donde el ciclo entero ocurre dentro del editor y eso ahorra mucho tiempo.',
+          'Claude gana cuando el problema es de comprensión o de diseño. Decidir cómo estructurar algo antes de escribirlo, entender un error que no tiene sentido, revisar con ojos frescos un fragmento que has escrito mal tres veces o valorar dos enfoques con sus contrapartidas. Y gana en todo lo que rodea al código sin ser código: documentación, correos técnicos, especificaciones, explicar a alguien no técnico qué implica un cambio. Cursor solo sirve para programar; Claude no.',
+        ],
+      },
+      {
+        title: 'Dos formas de pagar por el mismo motor',
+        paragraphs: [
+          'Claude se vende como suscripción plana con límites de uso por franjas, de modo que el coste es fijo y lo que varía es cuánto puedes exprimirlo antes de tocar techo. Cursor combina suscripción y consumo, y ese consumo depende del modelo que elijas en cada petición, con la opción de aportar tus propias claves de proveedor. La consecuencia es que en Cursor pagas por el uso del modelo aunque ya tengas contratada la suscripción de Claude por otro lado.',
+          'Traducido a decisiones: si programas a diario sobre un repositorio grande, el editor rentabiliza su precio porque el tiempo que ahorra aplicar cambios directamente es real. Si programas de forma intermitente y usas la IA sobre todo para pensar, revisar y escribir, la suscripción de Claude cubre eso y además todo el trabajo que no es código, y añadir Cursor aporta poco. Quien quiera un agente sobre archivos sin pagar por consumo puede usar el agente de terminal incluido en la suscripción.',
+        ],
+        bullets: [
+          'Desarrollo intensivo sobre proyectos existentes: Cursor amortiza el consumo variable.',
+          'Uso mixto entre programación, análisis y escritura: la suscripción de Claude cubre más terreno por el mismo dinero.',
+        ],
+      },
+      {
+        title: 'Cuál escribe mejor en castellano',
+        paragraphs: [
+          'Claude destaca en español escrito y esa es una ventaja concreta para el trabajo diario de un equipo en España: redactar la documentación de un módulo, explicar una incidencia a negocio, preparar el texto de una migración o revisar una especificación en castellano sin que suene a traducción automática. Sostiene además conversaciones largas sin perder el hilo, lo que ayuda cuando estás dándole vueltas a un diseño durante una hora.',
+          'Cursor hereda la calidad lingüística del modelo que selecciones, así que eligiendo un modelo de Anthropic obtienes prácticamente lo mismo dentro del editor. Su aportación propia es poder fijar en las reglas del proyecto que las respuestas, los comentarios y los mensajes de confirmación se escriban en español, y que esa preferencia se aplique a todo el equipo al abrir el repositorio. La interfaz y la documentación de Cursor, eso sí, están en inglés.',
+        ],
+      },
+      {
+        title: 'Usarlos juntos es lo habitual',
+        paragraphs: [
+          'El reparto natural es por fase del trabajo. Claude para entender el problema, decidir el enfoque, discutir alternativas, revisar un diseño antes de escribir nada y redactar todo lo que no es código; Cursor para ejecutar esos cambios sobre el repositorio con el contexto delante y comprobar que compilan. Mucha gente acaba trabajando así sin haberlo planteado nunca como estrategia, simplemente porque cada herramienta resuelve mejor una mitad del día y el trasvase entre ambas cuesta poco.',
+          'El riesgo está en copiar código de una ventana a otra. Cada vez que pegas un fragmento pierdes el contexto del resto del proyecto y aumentan las probabilidades de recibir una respuesta plausible pero equivocada. Conviene decidir cuál de las dos es la fuente de verdad sobre el estado del código y no pedir a la otra que opine sobre archivos que no ha visto enteros. Y contar con que son dos suscripciones, no una.',
+        ],
+      },
+    ],
     faqs: [
       {
         question: '¿Cuál es mejor, Cursor o Claude?',
@@ -2110,78 +3106,121 @@ export const comparisons: Comparison[] = [
     slug: 'github-copilot-vs-codium',
     a: 'GitHub Copilot',
     b: 'Codium',
-    title: 'GitHub Copilot vs Codium: diferencias, precios y cuál elegir',
+    title: 'GitHub Copilot vs Codium: escribir código frente a verificarlo',
     intro:
-      'GitHub Copilot y Codium son dos asistentes de IA para programar que se instalan como extensión en tu editor y te ayudan a escribir código, completar funciones y resolver dudas sin salir del IDE. Se comparan constantemente porque cubren el mismo hueco, pero parten de sitios distintos: Copilot nace dentro del ecosistema de GitHub y Microsoft, con integración profunda en el flujo de trabajo de repositorios, pull requests y Visual Studio, mientras que Codium se ha hecho un nombre ofreciendo asistencia de código con un plan gratuito muy generoso para desarrolladores individuales. Esa diferencia de origen marca el resto: uno vende integración corporativa, el otro accesibilidad.',
+      'GitHub Copilot y Codium aparecen juntos en muchas comparativas, pero no resuelven el mismo problema. Copilot es un asistente que escribe código: completa funciones, propone implementaciones y responde en el chat del editor. Codium, hoy conocido como Qodo tras su cambio de marca, trabaja sobre ese código una vez escrito: genera tests automáticamente, propone casos límite que difícilmente escribirías a mano y señala cuando lo que hace una función no coincide con lo que dice su documentación. Conviene no confundirlo con Codeium, que es otro producto y sí es un autocompletador. Aquí comparamos dos piezas complementarias y damos criterio por si solo puedes pagar una.',
     verdict:
-      'Si trabajas a diario en GitHub y quieres el asistente mejor integrado con tu repositorio, revisiones y ecosistema Microsoft, Copilot es la opción más sólida y la que menos fricción te va a dar. Si eres desarrollador individual, estudiante o llevas proyectos personales y no quieres pagar una suscripción para tener autocompletado con IA decente, Codium te cubre sin coste. Copilot gana en madurez e integración; Codium gana en relación calidad-precio.',
+      'Si tu cuello de botella es escribir código y salir del folio en blanco, Copilot es la compra evidente y la que notarás desde el primer día. Si escribes rápido pero tu deuda está en la cobertura de tests y en los fallos que aparecen en producción, Codium ataca justo ese punto. Con presupuesto para las dos, lo habitual es Copilot para producir y Codium para verificar antes del pull request.',
     table: {
       headers: ['Criterio', 'GitHub Copilot', 'Codium'],
       rows: [
         [
-          'Punto fuerte',
-          'Integración nativa con GitHub y el ecosistema Microsoft',
-          'Asistencia de código con un plan gratuito muy amplio',
+          'Qué hace',
+          'Escribe y completa código dentro del editor',
+          'Genera tests y analiza el código ya escrito',
+        ],
+        [
+          'Momento del flujo',
+          'Mientras programas',
+          'Al cerrar una función o antes de abrir el pull request',
+        ],
+        [
+          'Salida principal',
+          'Sugerencias de código y respuestas en chat',
+          'Suites de tests, casos límite y avisos de discrepancia con la documentación',
+        ],
+        [
+          'Integración con GitHub',
+          'Nativa: repositorios, issues y revisión de pull requests',
+          'Se integra en el editor y en la revisión de código como capa de análisis',
         ],
         [
           'Modelo de precios',
-          'De pago por suscripción, con acceso gratuito para ciertos perfiles (estudiantes, mantenedores de open source)',
-          'Freemium: capa gratuita generosa para uso individual y planes de pago para equipos',
+          'Suscripción, con acceso sin coste para perfiles como estudiantes o mantenedores de open source',
+          'Freemium: capa gratuita para uso individual y planes de pago por equipo',
         ],
         [
-          'Editores soportados',
-          'VS Code, Visual Studio, JetBrains, Neovim y otros',
-          'Amplio soporte de editores, incluidos VS Code y JetBrains',
+          'Identidad del producto',
+          'GitHub Copilot, de GitHub y Microsoft',
+          'CodiumAI, renombrada Qodo; codium.ai redirige hoy a qodo.ai',
         ],
         [
-          'Contexto del proyecto',
-          'Buena comprensión del repositorio y del historial del proyecto',
-          'Indexación del código base para dar respuestas más contextuales',
-        ],
-        [
-          'Uso en empresa',
-          'Planes de negocio y empresa con controles de administración',
-          'Planes de equipo, con opciones de despliegue más flexibles',
-        ],
-        [
-          'Curva de entrada',
-          'Muy baja si ya usas GitHub',
-          'Baja, aunque requiere crear cuenta y configurar la extensión',
-        ],
-        [
-          'Español',
-          'Entiende y responde en español sin problema',
-          'Entiende y responde en español sin problema',
+          'A quién le encaja',
+          'Quien necesita producir código más rápido',
+          'Quien necesita confiar en el código que ya tiene',
         ],
       ],
     },
     whenA: [
-      'Tu equipo vive en GitHub y quieres que el asistente entienda tus repositorios, issues y pull requests.',
-      'Trabajas en Visual Studio o en un entorno corporativo Microsoft y necesitas soporte y gobernanza.',
-      'Quieres el asistente más maduro y probado en producción, aunque tengas que pagar por él.',
-      'Eres estudiante o mantienes proyectos open source y puedes acceder al plan gratuito.',
+      'Tu problema es la velocidad de escritura: código repetitivo, arrancar funciones o moverte por un lenguaje que no dominas.',
+      'Trabajas a diario en GitHub y quieres el asistente que mejor entiende repositorios, issues y revisiones.',
+      'Necesitas un único asistente generalista que también sirva para chat, explicaciones y refactores.',
+      'Tu proyecto ya tiene una base de tests razonable y no es ahí donde duele.',
     ],
     whenB: [
-      'Programas por tu cuenta y no quieres pagar una suscripción mensual por autocompletado.',
-      'Buscas un asistente que indexe tu código base y dé sugerencias contextuales sin coste inicial.',
-      'Trabajas con editores variados y quieres una extensión ligera que se adapte.',
-      'Estás evaluando asistentes de IA y quieres probar uno a fondo antes de comprometerte.',
+      'Tienes código en producción con poca cobertura y escribir tests a mano se te acumula sin fin.',
+      'Los fallos que se te escapan son casos límite: entradas vacías, valores nulos, límites de rango.',
+      'Quieres que algo te avise cuando la implementación se ha desviado de lo que promete su documentación.',
+      'En tu equipo la revisión de pull requests es el cuello de botella y se comprueba todo a mano.',
+    ],
+    sections: [
+      {
+        title: 'En qué se diferencian de verdad',
+        paragraphs: [
+          'La diferencia no está en la calidad de las sugerencias, sino en qué momento del trabajo entra cada herramienta. GitHub Copilot vive mientras escribes: completa la línea que estás tecleando, propone el cuerpo de una función a partir de su nombre y responde en el chat del editor sin que salgas del archivo. Codium, rebautizado como Qodo tras su cambio de marca, actúa después: coge el código ya escrito, lo analiza y propone las pruebas que faltan, los casos límite que no habías considerado y los puntos donde el comportamiento real se aleja de la intención declarada.',
+          'Esa distinción explica por qué compararlos como alternativas lleva a conclusiones extrañas. Copilot es un generador: su valor se mide en cuánto código útil produce por unidad de tiempo. Codium es un verificador: su valor se mide en cuántos fallos detecta antes de que lleguen a producción. Puedes sustituir Copilot por otro autocompletador y seguir trabajando igual; renunciar a Codium significa quedarte sin la capa de pruebas automáticas o volver a escribirlas a mano. No resuelven el mismo problema con enfoques distintos, sino dos problemas encadenados.',
+        ],
+      },
+      {
+        title: 'Qué hace mejor cada uno',
+        paragraphs: [
+          'Copilot brilla en el trabajo de teclado: convertir una descripción en una implementación inicial, rellenar estructuras repetitivas, traducir un fragmento entre lenguajes o explicar una función heredada que nadie documentó. Codium brilla justo donde Copilot no se detiene: analiza una función concreta, deduce qué contratos implícitos tiene y genera una batería de pruebas con casos normales, límites y entradas inválidas. También señala discrepancias entre lo que el nombre o el comentario prometen y lo que el cuerpo de la función hace en realidad, que es una de las fuentes de error más caras.',
+        ],
+        bullets: [
+          'Copilot: escribir desde cero un endpoint, un formulario o un script de migración a partir de una indicación breve.',
+          'Copilot: entender código ajeno mediante preguntas en el chat del editor sin cambiar de contexto.',
+          'Codium: generar la suite de pruebas de una clase existente cubriendo casos límite que no aparecen en el camino feliz.',
+          'Codium: revisar un cambio antes del pull request y avisar de comportamientos no cubiertos o regresiones probables.',
+          'Codium: proponer mejoras de legibilidad y detectar contradicciones entre la documentación de una función y su implementación.',
+        ],
+      },
+      {
+        title: 'Precios: dos estructuras que no se comparan de tú a tú',
+        paragraphs: [
+          'Copilot sigue el modelo clásico de suscripción por usuario y mes, con planes individuales y de organización que añaden controles de administración y políticas de uso. Codium parte de una capa gratuita para desarrolladores individuales y escala a planes de equipo, y su consumo se asocia más al volumen de análisis y generación de pruebas que al simple hecho de tener el editor abierto. Comparar la cifra mensual de uno con la del otro no dice gran cosa, porque no estás pagando por lo mismo.',
+          'El criterio útil es otro: calcula qué te cuesta cada hora de escribir pruebas a mano y compárala con el plan de Codium, y qué te cuesta el tiempo de tecleo repetitivo frente al plan de Copilot. Ambos ofrecen formas de probar el producto antes de comprometerte y condiciones favorables para proyectos abiertos, pero las condiciones cambian con frecuencia. Consulta siempre las páginas oficiales de precios antes de presupuestar, sobre todo si vas a contratar licencias para todo un equipo.',
+        ],
+      },
+      {
+        title: 'Cómo funcionan en español',
+        paragraphs: [
+          'Los dos entienden indicaciones en castellano sin problema y responden con naturalidad. Copilot acepta que describas en español lo que quieres y genera el código correspondiente, y si tus comentarios están en castellano tiende a continuar en ese idioma, lo que ayuda a mantener coherencia en bases de código de equipos hispanohablantes. Conviene revisar los identificadores: al mezclar descripciones en español con convenciones en inglés, a veces propone nombres híbridos que luego chirrían al leer el archivo completo.',
+          'Codium se comporta parecido cuando explica hallazgos o justifica por qué añade un caso de prueba, y puede redactar esas explicaciones y la documentación asociada en castellano. Con los nombres de los tests el resultado es más irregular: suele apoyarse en las convenciones del framework, que son inglesas, así que puedes acabar con descripciones en español dentro de funciones nombradas en inglés. Si tu equipo tiene una guía de estilo sobre el idioma del código, indícala de forma explícita en la configuración o en la propia petición.',
+        ],
+      },
+      {
+        title: '¿Se pueden usar los dos a la vez?',
+        paragraphs: [
+          'Sí, y además es la combinación que muchos equipos acaban adoptando. No compiten por el mismo espacio en el editor: Copilot ocupa el autocompletado en línea mientras escribes y Codium se activa cuando pides pruebas, revisión o análisis de un fragmento ya terminado. No hay que desactivar uno para que el otro funcione, ni se solapan las sugerencias como ocurriría entre dos autocompletadores. El único coste real de tenerlos juntos es el de las dos suscripciones.',
+          'El reparto natural del flujo es sencillo. Escribes la funcionalidad apoyándote en Copilot, y cuando la implementación está estable pasas por Codium para generar las pruebas, revisar los casos límite y detectar lo que se ha quedado fuera. El segundo paso es precisamente el que compensa la principal debilidad del primero: el código generado a gran velocidad tiende a acumular supuestos no verificados, y una capa de pruebas automáticas encima es la forma más barata de que esos supuestos salgan a la luz antes del despliegue.',
+        ],
+      },
     ],
     faqs: [
       {
-        question: '¿Cuál es mejor, GitHub Copilot o Codium?',
+        question: '¿Codium es lo mismo que Codeium?',
         answer:
-          'Depende de dónde trabajes. Copilot es mejor si tu día a día pasa por GitHub y valoras la integración con repositorios y revisiones de código. Codium es mejor si eres desarrollador individual y quieres asistencia de IA sin pagar una suscripción. En calidad de sugerencias ambos son competentes; la diferencia real está en el ecosistema y el coste.',
-      },
-      {
-        question: '¿Codium es más barato que GitHub Copilot?',
-        answer:
-          'Sí, en la práctica. Codium ofrece una capa gratuita amplia para uso individual, mientras que Copilot requiere suscripción salvo para perfiles concretos como estudiantes o mantenedores de open source. Aun así, los planes de equipo de ambos son comparables, así que conviene revisar las páginas oficiales de precios antes de decidir.',
+          'No, y la confusión es constante porque los nombres se parecen mucho. Codeium es un autocompletador de código, hoy más conocido por su editor Windsurf. Codium es CodiumAI, una herramienta de generación de tests y análisis de integridad del código que ha pasado a llamarse Qodo. Son empresas y productos distintos, aunque los catálogos los mezclen a menudo.',
       },
       {
         question: '¿Puedo usar GitHub Copilot y Codium a la vez?',
         answer:
-          'Técnicamente puedes instalar ambas extensiones, pero no es recomendable: compiten por el mismo espacio de autocompletado y las sugerencias se solapan o se anulan entre sí. Lo habitual es activar una y desactivar la otra, o usar una para autocompletado en línea y la otra solo para el chat, si tu editor lo permite.',
+          'Sí, y es lo más razonable. No compiten por el mismo hueco: Copilot sugiere código mientras escribes y Codium trabaja sobre lo ya escrito generando tests y revisando comportamiento. Muchos equipos tienen ambos activos en el mismo editor sin que se pisen. La única pega real es sostener dos suscripciones a la vez.',
+      },
+      {
+        question: '¿Copilot no genera ya tests por sí solo?',
+        answer:
+          'Sí, puedes pedírselos y los escribe. La diferencia está en el enfoque: Copilot genera lo que le pides y da por bueno tu criterio, mientras que Codium está construido alrededor de esa tarea y busca por su cuenta casos límite y contradicciones entre lo que el código hace y lo que dice hacer. Si generar tests es algo puntual, Copilot te vale.',
       },
     ],
   },
@@ -2189,74 +3228,121 @@ export const comparisons: Comparison[] = [
     slug: 'tabnine-vs-codium',
     a: 'Tabnine',
     b: 'Codium',
-    title: 'Tabnine vs Codium: diferencias, precios y cuál elegir',
+    title: 'Tabnine vs Codium: autocompletado privado frente a tests automáticos',
     intro:
-      'Tabnine y Codium son asistentes de IA para escribir código que se integran como extensión en el editor y ofrecen autocompletado, generación de fragmentos y chat sobre el proyecto. Se comparan porque son las dos alternativas más citadas frente a los asistentes de las grandes plataformas, pero su enfoque no es el mismo. Tabnine lleva años posicionado en el terreno de la privacidad y el control: despliegues aislados, modelos que no se entrenan con tu código y opciones autoalojadas para empresas con requisitos estrictos. Codium apuesta por la accesibilidad, con una capa gratuita amplia y una experiencia pensada para el desarrollador individual.',
+      'Tabnine y Codium se comparan por costumbre, pero cubren fases distintas del trabajo. Tabnine es un asistente de autocompletado con la privacidad como argumento central: modelos que no se entrenan con tu código y opciones de despliegue en tu propia infraestructura para empresas con requisitos estrictos. Codium, renombrado Qodo tras su cambio de marca, no compite por el autocompletado: genera tests, busca casos límite y avisa cuando la implementación no cumple lo que promete su documentación. Uno te ayuda a escribir; el otro te dice si lo escrito aguanta. Conviene tenerlo claro antes de elegir, porque el nombre lleva a muchos a esperar otra cosa.',
     verdict:
-      'Si tu preocupación principal es que tu código no salga de tu infraestructura, Tabnine es la opción clara: su propuesta de privacidad y despliegue autoalojado es su razón de ser y pocos competidores la igualan. Si eres desarrollador individual o llevas un equipo pequeño sin requisitos de cumplimiento normativo, Codium te da más por menos dinero y es más cómodo de arrancar. Tabnine para entornos regulados; Codium para el resto.',
+      'Si trabajas en un sector regulado y lo importante es que el código no salga de tu red, Tabnine responde a esa exigencia y Codium no la sustituye. Si el código ya se escribe rápido pero nadie tiene tiempo de probarlo, Codium ataca el problema real. Con una sola suscripción, decide por dónde sangras: falta de velocidad al escribir o falta de confianza en lo escrito.',
     table: {
       headers: ['Criterio', 'Tabnine', 'Codium'],
       rows: [
         [
+          'Función principal',
+          'Autocompletado y generación de código en el editor',
+          'Generación de tests y análisis del código existente',
+        ],
+        [
           'Punto fuerte',
-          'Privacidad, control del código y despliegue autoalojado',
-          'Capa gratuita generosa y facilidad de uso',
+          'Privacidad y control: despliegue aislado y compromiso de no entrenar con tu código',
+          'Cobertura de tests y detección de casos límite que se escapan a mano',
+        ],
+        [
+          'Momento del flujo',
+          'Mientras escribes',
+          'Al terminar una función o antes de la revisión de código',
         ],
         [
           'Modelo de precios',
-          'Freemium: plan básico limitado y planes de pago para profesionales y empresa',
-          'Freemium: uso individual gratuito amplio y planes de pago para equipos',
+          'Freemium, con planes de empresa que incluyen despliegue autoalojado',
+          'Freemium, con capa gratuita para uso individual y planes por equipo',
         ],
         [
-          'Privacidad del código',
-          'Enfoque central: opciones de despliegue aislado y compromiso de no entrenar con tu código',
-          'Política de privacidad estándar en la nube; opciones más limitadas para autoalojado',
+          'Entornos regulados',
+          'Su razón de ser: pensado para banca, sanidad o defensa',
+          'Depende del plan contratado; revisa las condiciones antes de asumir nada',
         ],
         [
-          'Calidad de sugerencias',
-          'Sólida en autocompletado; el chat es competente pero menos ambicioso',
-          'Buenas sugerencias contextuales con indexación del repositorio',
+          'Identidad del producto',
+          'Tabnine, asistente de código veterano',
+          'CodiumAI, ahora Qodo; no confundir con Codeium',
         ],
         [
-          'Público objetivo',
-          'Empresas con requisitos de seguridad y cumplimiento',
-          'Desarrolladores individuales y equipos pequeños',
+          'Solapamiento entre ambos',
+          'Bajo: no genera suites de tests por iniciativa propia',
+          'Bajo: no compite por el autocompletado en línea',
         ],
-        [
-          'Editores soportados',
-          'Amplio: VS Code, JetBrains, Vim, Eclipse y más',
-          'Amplio: VS Code, JetBrains y otros',
-        ],
-        ['Español', 'Responde en español correctamente', 'Responde en español correctamente'],
       ],
     },
     whenA: [
-      'Trabajas en un sector regulado (banca, sanidad, defensa) y el código no puede salir de tu red.',
-      'Necesitas desplegar el asistente en tu propia infraestructura o en una nube privada.',
-      'Tu empresa exige garantías contractuales sobre el uso del código para entrenamiento.',
-      'Valoras un autocompletado rápido y predecible por encima de funciones de chat avanzadas.',
+      'El código no puede salir de tu red y necesitas un despliegue autoalojado o en nube privada.',
+      'Tu equipo pierde tiempo en código repetitivo y quieres autocompletado rápido y predecible.',
+      'Necesitas garantías contractuales sobre el uso de tu código para entrenar modelos.',
+      'Ya tenéis una cultura de tests asentada y el problema no está en la cobertura.',
     ],
     whenB: [
-      'Quieres empezar sin pagar y con una capa gratuita que aguante uso real.',
-      'Eres desarrollador individual o freelance y no tienes requisitos de cumplimiento normativo.',
-      'Buscas un chat sobre el código base que entienda el contexto de tu proyecto.',
-      'Prefieres una instalación rápida y una experiencia sin configuración compleja.',
+      'Tenéis módulos críticos sin tests y escribirlos a mano no entra nunca en la planificación.',
+      'Los errores que llegan a producción son casos límite que nadie pensó en probar.',
+      'Queréis detectar cuando el comportamiento real de una función se ha alejado de lo documentado.',
+      'La revisión de pull requests se alarga porque hay que comprobar a mano lo que hace cada cambio.',
+    ],
+    sections: [
+      {
+        title: 'En qué se diferencian de verdad',
+        paragraphs: [
+          'Tabnine y Codium se citan a menudo en la misma frase, pero ocupan tramos distintos del trabajo. Tabnine es un autocompletador: se integra en el editor, aprende de tus patrones y completa lo que estás tecleando, con un discurso centrado en la privacidad, el control del dato y la posibilidad de desplegarlo dentro de la infraestructura de la empresa. Codium, que pasó a llamarse Qodo tras su cambio de marca, no compite por ese hueco: su terreno es la generación de pruebas y el análisis de integridad del código que ya has escrito.',
+          'Dicho de otro modo, uno actúa antes de que el código exista y el otro después de que exista. Tabnine reduce el tiempo que tardas en producir una implementación; Codium reduce la probabilidad de que esa implementación falle en un caso que nadie previó. Elegir entre ellos como si fueran sustitutos deja siempre un hueco: o te quedas sin ayuda al escribir, o te quedas sin red de seguridad. La comparación honesta empieza reconociendo que resuelven fases distintas del mismo ciclo.',
+        ],
+      },
+      {
+        title: 'Qué hace mejor cada uno',
+        paragraphs: [
+          'Tabnine destaca en entornos donde el código no puede salir de casa: sugerencias en línea con modelos que no se entrenan con tu base de código y opciones de despliegue aislado o autoalojado para organizaciones con requisitos de cumplimiento estrictos. Codium destaca en la fase de verificación: dada una función o una clase, deduce su contrato implícito y genera pruebas que cubren el camino habitual, los límites y las entradas inválidas, además de señalar cuándo el comportamiento del código contradice lo que su nombre o su documentación prometen. Son fortalezas que no se solapan en ningún punto.',
+        ],
+        bullets: [
+          'Tabnine: completar código en un sector regulado sin que los fragmentos viajen a servicios externos.',
+          'Tabnine: adaptar las sugerencias al estilo y a las convenciones internas de un equipo grande.',
+          'Codium: crear la batería de pruebas de un módulo heredado que llegó sin ninguna cobertura.',
+          'Codium: revisar un cambio antes de abrir el pull request y avisar de casos no contemplados.',
+          'Codium: detectar discrepancias entre lo que documenta una función y lo que realmente ejecuta.',
+        ],
+      },
+      {
+        title: 'Precios: cómo se comparan estructuras distintas',
+        paragraphs: [
+          'Tabnine cobra por usuario y mes, con planes individuales y de empresa, y las modalidades autoalojadas se negocian aparte porque implican infraestructura y soporte. Codium mantiene una capa gratuita para desarrolladores individuales y planes de equipo cuyo consumo se relaciona con el volumen de análisis y generación de pruebas, no con las horas que pasas escribiendo. Poner ambas cifras mensuales una al lado de la otra no aporta nada útil, porque no estás comprando el mismo servicio ni la misma unidad de valor.',
+          'Para decidir con criterio, separa los dos gastos. Por el lado de Tabnine, la pregunta es cuánto vale evitar que tu código pase por servicios de terceros, y ahí el precio compite contra el coste de una auditoría o de un incidente. Por el lado de Codium, la pregunta es cuántas horas dedica tu equipo a escribir pruebas manualmente. Ambos productos ofrecen formas de probarlos antes de contratar y condiciones específicas para proyectos abiertos, pero conviene confirmar las cifras vigentes en sus páginas oficiales.',
+        ],
+      },
+      {
+        title: 'Cómo funcionan en español',
+        paragraphs: [
+          'Tabnine trabaja sobre todo a partir del contexto del propio archivo, así que si tus comentarios, identificadores y cadenas están en castellano, sus sugerencias tienden a seguir esa línea sin que tengas que pedírselo. Es un comportamiento cómodo en equipos hispanohablantes, aunque conviene tener una convención clara: si la base de código mezcla nombres en inglés con comentarios en español, las propuestas heredan esa mezcla y el resultado se lee peor de lo que debería.',
+          'Codium se desenvuelve bien en castellano cuando explica por qué añade un caso de prueba o cuando redacta documentación sobre un fragmento analizado. Con los nombres de los tests el criterio es más variable, porque los frameworks imponen convenciones en inglés y la herramienta suele respetarlas; puedes terminar con descripciones en español dentro de funciones nombradas en inglés. Si el equipo tiene una regla de estilo sobre el idioma del código y de los tests, indícala de forma explícita para que la aplique de manera consistente.',
+        ],
+      },
+      {
+        title: '¿Se pueden usar los dos a la vez?',
+        paragraphs: [
+          'Sí, sin conflicto y con una división de tareas bastante limpia. Tabnine ocupa el autocompletado en línea mientras escribes; Codium entra cuando pides pruebas, revisión o análisis de código ya terminado. No pelean por el mismo espacio del editor ni se anulan las sugerencias, como sí ocurriría si instalaras dos autocompletadores a la vez. La única fricción real es presupuestaria, y en organizaciones con exigencias de privacidad conviene revisar que el modelo de tratamiento de datos de cada uno encaja con las políticas internas.',
+          'El reparto habitual es escribir con Tabnine y verificar con Codium. Produces la implementación con ayuda del autocompletado, y cuando el código está estable lo pasas por la fase de pruebas antes de abrir el pull request. Esa segunda etapa compensa el punto débil de la primera: cuanto más rápido se escribe, más supuestos quedan sin comprobar. Si trabajas en un entorno regulado, la combinación tiene además una lectura práctica, porque una cobertura de pruebas sólida es una de las evidencias que más pesan en cualquier auditoría.',
+        ],
+      },
     ],
     faqs: [
       {
-        question: '¿Cuál es mejor, Tabnine o Codium?',
+        question: '¿Tabnine y Codium hacen lo mismo?',
         answer:
-          'Para empresas con requisitos de privacidad, Tabnine: su modelo de despliegue autoalojado y su política sobre el uso del código son su principal argumento. Para desarrolladores individuales, Codium suele salir ganando por su capa gratuita y su experiencia más fluida. No es una cuestión de calidad bruta, sino de qué problema quieres resolver.',
+          'No. Tabnine te sugiere código mientras escribes y Codium trabaja sobre el código que ya existe, generando tests y señalando comportamientos que no cuadran con la documentación. Puedes tener los dos instalados sin conflicto porque no compiten por el mismo hueco del editor. Si solo puedes pagar uno, elige según dónde tengas el problema.',
       },
       {
-        question: '¿Tabnine es más caro que Codium?',
+        question: '¿Codium ahora se llama Qodo?',
         answer:
-          'Ambos son freemium, pero la capa gratuita de Codium es más generosa para uso individual, mientras que la de Tabnine es más limitada y empuja antes a un plan de pago. Los planes empresariales de Tabnine, que incluyen autoalojado, están en otra liga de precio. Consulta las webs oficiales, porque estos planes cambian con frecuencia.',
+          'Sí. CodiumAI cambió su marca a Qodo y su web original, codium.ai, redirige a qodo.ai. Muchos catálogos y artículos siguen usando el nombre antiguo, así que te encontrarás las dos formas por ahí. El producto es el mismo de siempre: generación de tests y análisis de integridad del código, no autocompletado.',
       },
       {
-        question: '¿Tabnine entrena sus modelos con mi código?',
+        question: '¿Merece la pena Codium si ya uso Tabnine para todo?',
         answer:
-          'Tabnine ha hecho de la no utilización del código del cliente para entrenamiento uno de sus puntos de venta, y ofrece despliegues aislados para reforzarlo. Aun así, las condiciones concretas dependen del plan contratado, así que revisa los términos oficiales y la documentación de privacidad antes de asumir nada en un entorno sensible.',
+          'Depende de si tus tests están al día. Tabnine puede escribirte un test si se lo pides, pero no busca por su cuenta los casos que fallan ni compara la implementación con lo documentado. Si tu cobertura es baja o los bugs se te escapan por entradas raras, Codium cubre algo que Tabnine no hace.',
       },
     ],
   },
@@ -2320,6 +3406,47 @@ export const comparisons: Comparison[] = [
       'Necesitas enseñar algo a un cliente o a un inversor esta misma tarde.',
       'No eres programador o no quieres pelearte con dependencias y entornos.',
       'Vas a desechar el prototipo después: lo importante es la velocidad, no la mantenibilidad.',
+    ],
+    sections: [
+      {
+        title: 'Un editor para tu código frente a un taller que fabrica la aplicación',
+        paragraphs: [
+          'Cursor es un entorno de desarrollo completo, derivado de VS Code, que se instala en tu máquina y trabaja sobre tus archivos, tu control de versiones y tus dependencias. Da igual si el proyecto tiene una semana o diez años: parte de lo que ya existe. Bolt vive en el navegador y funciona al revés: describes lo que quieres y te genera una aplicación funcional desde cero, con su estructura, sus dependencias y una vista previa que se levanta al instante sin que hayas configurado nada.',
+          'Esa diferencia condiciona todo lo demás. Cursor asume que sabes programar y que el asistente es un acelerador, así que te da control fino sobre el contexto, sobre qué archivos entran en la petición y sobre cómo se aplican los cambios. Bolt asume que quieres un resultado visible cuanto antes y toma decisiones por ti: elige la pila tecnológica, monta el andamiaje y te enseña algo que funciona. Uno optimiza el trabajo sostenido; el otro optimiza los primeros treinta minutos.',
+          'Por eso el par se rompe en cuanto el proyecto crece. Bolt brilla mientras la aplicación cabe en su modelo mental de proyecto autocontenido en el navegador; cuando aparecen integraciones específicas, migraciones de base de datos complicadas o una arquitectura que no eligió él, empieza a costar más pelearse con la herramienta que escribir el código. Cursor no tiene ese techo porque no impone estructura, pero tampoco te regala el primer prototipo: sigues siendo tú quien decide cómo se monta cada cosa.',
+        ],
+      },
+      {
+        title: 'Velocidad al arrancar frente a control cuando el proyecto es real',
+        paragraphs: [
+          'Para validar una idea, Bolt es difícil de superar. Un panel con datos de prueba, una landing con formulario, una pequeña herramienta interna para enseñar en una reunión: describes, esperas, ves el resultado y lo compartes. No hay instalación, no hay configuración de entorno y no hay que explicarle a nadie cómo levantarlo. Ese trayecto, que en local implica media hora de preparativos antes de escribir la primera línea útil, aquí se resuelve en minutos y con un enlace que funciona en cualquier navegador.',
+          'Para el trabajo de todos los días gana Cursor sin discusión. Refactorizar una función que se usa en veinte sitios, entender por qué falla un test, aplicar un cambio coherente en varios archivos o revisar un diff antes de subirlo son tareas que necesitan acceso al repositorio completo y a las herramientas locales. Bolt no compite ahí, y forzarlo suele acabar copiando código a mano de un lado a otro, que es exactamente el trabajo que se supone que la herramienta venía a evitar.',
+        ],
+        bullets: [
+          'Bolt encaja en: prototipos, pruebas de concepto, demos para clientes, aplicaciones pequeñas y autocontenidas.',
+          'Cursor encaja en: bases de código existentes, equipos con revisión de código, proyectos con pruebas y despliegue propio.',
+          'Ninguna de las dos sustituye saber leer el código que producen: la revisión sigue siendo tuya.',
+        ],
+      },
+      {
+        title: 'Suscripción con uso medido frente a consumo por créditos',
+        paragraphs: [
+          'Cursor sigue el modelo de suscripción mensual con una cantidad de uso incluida y la posibilidad de seguir consumiendo por encima, además de una capa gratuita limitada para probar. Es un gasto previsible: sabes lo que pagas cada mes y el coste marginal de un día intenso es asumible. Bolt funciona por créditos que se consumen según lo que le pides, así que el gasto no depende del calendario sino de cuánto generes, y una tarde de iteraciones sobre una aplicación grande puede vaciar la asignación mucho antes de lo previsto.',
+          'En la práctica, si programas a diario, Cursor sale a cuenta casi seguro: el coste por hora de uso baja cuanto más lo usas. Bolt compensa cuando el uso es puntual e intenso, por ejemplo una agencia que monta prototipos para clientes o alguien que valida ideas de vez en cuando. El error habitual es intentar mantener con créditos un proyecto en evolución continua, porque cada corrección vuelve a pagar la generación completa y el coste se dispara sin que el resultado mejore mucho.',
+        ],
+      },
+      {
+        title: 'Trabajar en español con cada una',
+        paragraphs: [
+          'Las dos entienden peticiones en castellano sin problema, pero el impacto es distinto. En Cursor el idioma solo afecta al chat y a los comentarios, así que puedes trabajar en español con total normalidad y el código sigue las convenciones del proyecto. En Bolt, como genera la interfaz completa desde tu descripción, pedirlo en español suele dar textos de interfaz en castellano correctos, aunque conviene revisar detalles que se cuelan traducidos de forma literal, formatos de fecha y moneda, y algún botón que aparece en inglés porque venía en la plantilla de partida.',
+        ],
+      },
+      {
+        title: 'Del prototipo al proyecto: usarlas en cadena',
+        paragraphs: [
+          'Este es de los pocos pares donde combinarlas no es un apaño, sino el flujo natural. Bolt para la primera versión, cuando lo importante es tener algo que enseñar y decidir si la idea aguanta. Después, exportar el proyecto, abrirlo en Cursor y seguir desde ahí con control de versiones, pruebas y despliegue propio. El punto de corte suele estar claro: en cuanto empieces a pedirle a Bolt cambios quirúrgicos en un archivo concreto en lugar de funcionalidades nuevas, ya has salido de su terreno.',
+        ],
+      },
     ],
     faqs: [
       {
@@ -2399,6 +3526,43 @@ export const comparisons: Comparison[] = [
       'Te interesa personalizar la experiencia de búsqueda y las fuentes que prioriza.',
       'Buscas una alternativa al líder del sector, ya sea por precio o por diversificar.',
       'Te gusta explorar modos y agentes distintos según el tipo de consulta.',
+    ],
+    sections: [
+      {
+        title: 'Un buscador con respuestas frente a una caja de herramientas de búsqueda',
+        paragraphs: [
+          'Perplexity ha apostado por una única experiencia muy pulida: preguntas, obtienes una respuesta redactada y ves de dónde sale cada afirmación. Todo el producto empuja hacia ahí, incluidas las funciones de seguimiento y las investigaciones más largas. La consecuencia es una herramienta con poquísimas decisiones que tomar, que cualquiera entiende en el primer minuto y que ha convertido la cita de fuentes en su seña de identidad frente a los buscadores tradicionales.',
+          'You.com ha ido en dirección contraria: ofrecer modos, modelos y configuraciones para que cada usuario se monte su flujo. Puedes cambiar el modelo que responde, elegir entre modos orientados a investigación, a escritura o a código, y montar agentes propios con instrucciones fijas. Es más potente si sabes qué quieres, y también más confuso si esperabas simplemente escribir una pregunta, porque la primera pantalla te pide decisiones que en Perplexity no existen.',
+          'Detrás hay dos apuestas de negocio distintas. Perplexity persigue ser el sitio al que vas por defecto cuando tienes una duda, compitiendo directamente con el hábito de buscar. You.com se ha ido moviendo hacia el terreno empresarial y de interfaz de programación, vendiendo acceso a búsqueda con fundamento para que otras aplicaciones la incorporen. Eso explica que su producto de consumo se sienta menos cuidado: cada vez es menos el centro de la empresa.',
+        ],
+      },
+      {
+        title: 'Calidad de la respuesta y fiabilidad de las fuentes',
+        paragraphs: [
+          'En la pregunta típica de actualidad, Perplexity suele dar respuestas más limpias y mejor organizadas, con las citas colocadas donde toca y sin adornos. La síntesis es su punto fuerte: resume varias fuentes en un texto legible sin perder el hilo, y las preguntas de seguimiento mantienen bien el contexto. Cuando lo que necesitas es una respuesta breve, correcta y verificable sobre algo que ha pasado esta semana, es la opción que menos trabajo posterior te va a dar.',
+          'You.com gana cuando quieres decidir tú cómo se responde. Poder cambiar de modelo para la misma consulta permite contrastar enfoques, y los modos especializados ayudan en tareas concretas como redactar un texto largo o resolver una duda de programación. A cambio, la calidad es más irregular: según el modo elegido, la respuesta puede citar peor o alargarse sin necesidad. Es una herramienta que rinde en manos de alguien que la ajusta, no de alguien que abre y escribe.',
+        ],
+      },
+      {
+        title: 'Gratis, suscripción y lo que cambia al pagar',
+        paragraphs: [
+          'Las dos siguen el mismo esquema: nivel gratuito con límites en las consultas avanzadas y suscripción mensual que amplía el acceso a modelos potentes y a funciones de investigación. La diferencia está en qué compras. En Perplexity pagas sobre todo por volumen de búsquedas profundas y por acceso a los modelos mejores. En You.com pagas por acceso a un abanico de modelos de distintos proveedores desde una sola cuenta, que es un argumento sólido si de otro modo tendrías que contratar varias suscripciones.',
+          'Por perfiles: para quien busca información varias veces al día y quiere que sencillamente funcione, la suscripción de Perplexity se amortiza rápido y evita fricción. Para quien ya paga otro asistente conversacional y solo quiere añadir búsqueda con fuentes, el nivel gratuito de cualquiera de los dos puede bastar. You.com sale a cuenta sobre todo en el caso concreto de querer probar varios modelos sin multiplicar suscripciones, y cuando interesa el acceso por interfaz de programación para integrarlo en algo propio.',
+        ],
+      },
+      {
+        title: 'Consultas en español y fuentes en castellano',
+        paragraphs: [
+          'Perplexity responde en castellano con naturalidad y, más importante, tiende a citar medios y fuentes en español cuando la consulta lo es, algo clave para temas locales como normativa, trámites o actualidad nacional. You.com también responde en español, pero con más frecuencia se apoya en fuentes anglosajonas y traduce, lo que en preguntas sobre España puede llevarte a información genérica o directamente inaplicable.',
+          'Para consultas sobre impuestos, ayudas, plazos administrativos o cualquier asunto que dependa de la legislación española, conviene indicar el país de forma explícita en la pregunta con las dos herramientas. Ninguna asume por defecto que quien escribe en castellano está en España, y confundir información de otro país hispanohablante con la española es el error más frecuente y el más difícil de detectar si no revisas las fuentes citadas.',
+        ],
+      },
+      {
+        title: 'Usar las dos según el tipo de pregunta',
+        paragraphs: [
+          'Como las dos tienen nivel gratuito, mantenerlas a mano no cuesta nada. El reparto razonable es Perplexity como buscador por defecto para el día a día, y You.com cuando quieres una segunda opinión con otro modelo o cuando la respuesta que has obtenido te huele a incompleta. Pagar las dos suscripciones solo se justifica si el acceso multimodelo de You.com te sustituye otra cuenta que ya pagabas; en caso contrario, una de las dos acabará sin usarse a las pocas semanas.',
+        ],
+      },
     ],
     faqs: [
       {
@@ -2558,6 +3722,48 @@ export const comparisons: Comparison[] = [
       'Quieres ver y depurar el flujo visualmente, paso a paso, con los datos de cada módulo.',
       'Tienes perfil técnico o alguien en el equipo que disfrute optimizando escenarios.',
     ],
+    sections: [
+      {
+        title: 'Dos ideas distintas de qué es automatizar',
+        paragraphs: [
+          'Zapier parte de una premisa muy clara: la mayoría de automatizaciones útiles son cadenas cortas del tipo cuando pasa esto, haz aquello. Todo el producto está construido para que esa cadena se monte en cinco minutos sin ayuda técnica, con un catálogo de aplicaciones enorme y una interfaz que apenas te deja equivocarte. La contrapartida es que en cuanto la lógica se complica, la herramienta se vuelve incómoda y hay que recurrir a rodeos que ensucian el flujo y multiplican el consumo.',
+          'Make asume lo contrario: que los procesos reales de una empresa tienen condiciones, listas que recorrer, datos que transformar y cosas que fallan a mitad. Por eso ofrece un lienzo donde ves los módulos conectados, puedes abrir una rama, recorrer una colección de elementos o definir qué pasa cuando un paso devuelve error. Se parece más a programar de forma visual, con la curva de aprendizaje que eso implica y también con el techo mucho más alto.',
+          'La diferencia no es de funcionalidades sueltas sino de a quién quiere servir cada uno. Zapier está pensado para que la persona de marketing u operaciones automatice su parte sin depender de nadie. Make está pensado para quien se va a sentar un rato a diseñar el proceso, y a cambio le da control real sobre lo que ocurre. Elegir mal significa o pelearte con una herramienta demasiado rígida o abandonar otra que exigía más tiempo del que ibas a dedicarle.',
+        ],
+      },
+      {
+        title: 'Dónde se rompe cada una',
+        paragraphs: [
+          'Zapier funciona de maravilla mientras el flujo sea lineal: llega un formulario, se crea un contacto, se avisa por chat. Empieza a doler cuando hace falta tratar de forma distinta un pedido según su importe, procesar los cincuenta elementos de una respuesta uno por uno o reintentar un paso que ha fallado. Se puede hacer, pero a base de pasos intermedios y filtros que hacen el flujo difícil de leer y, sobre todo, mucho más caro porque cada paso ejecutado cuenta.',
+          'Make se rompe por el otro lado: la primera automatización cuesta más de montar y la interfaz intimida a quien no ha visto nunca un diagrama de este tipo. También hay integraciones de nicho que Zapier tiene y Make no, y eso puede decidir la comparación de golpe si esa aplicación concreta es imprescindible para ti. A cambio, cuando el flujo es complejo, poder ejecutar paso a paso y ver exactamente qué dato entra y sale de cada módulo ahorra horas de depuración a ciegas.',
+        ],
+        bullets: [
+          'Señales de que Zapier se te queda corto: filtros encadenados, pasos de código para transformar datos, el mismo flujo duplicado con variaciones.',
+          'Señales de que Make es exagerado: dos o tres automatizaciones simples, nadie en el equipo con tiempo para mantenerlas.',
+          'Aviso común: el coste no lo marca el número de flujos sino cuántas veces se ejecutan al mes.',
+        ],
+      },
+      {
+        title: 'Tareas frente a operaciones: por qué la factura no se compara directa',
+        paragraphs: [
+          'Zapier cuenta tareas, entendiendo por tarea cada acción que se ejecuta con éxito dentro de un flujo. Make cuenta operaciones, y cuenta también los módulos intermedios que Zapier a veces no factura. Sobre el papel parece que Make cobra más cosas, pero incluye tantas más por el mismo importe que en volúmenes medios y altos la factura sale bastante más baja. Esto hace que comparar los precios de portada no sirva de nada: hay que estimar ejecuciones mensuales reales y multiplicar por los pasos de cada flujo.',
+          'Por perfiles, el reparto es bastante nítido. Con pocas automatizaciones y volumen bajo, los niveles gratuitos de ambas cubren el uso y no hay debate. Con volumen medio y flujos sencillos, Zapier sigue siendo defendible por lo que ahorra en tiempo de configuración. En cuanto entras en miles de ejecuciones al mes o los flujos tienen muchos pasos, Make gana por un margen amplio y suficiente para justificar la curva de aprendizaje inicial.',
+        ],
+      },
+      {
+        title: 'Uso desde España: idioma, integraciones locales y datos',
+        paragraphs: [
+          'Las dos tienen interfaz en español y documentación traducida, aunque la de Zapier está más cuidada y su ayuda cubre más casos en castellano. Donde importa de verdad el factor local es en las integraciones: herramientas de facturación, pasarelas de pago o gestores usados en España aparecen antes en el catálogo de Zapier, mientras que en Make a menudo hay que resolverlas mediante llamadas genéricas a la interfaz de programación del servicio, algo perfectamente viable pero que ya requiere perfil técnico.',
+          'Otro punto que suele decidir en empresas españolas es dónde se procesan los datos. Make tiene raíz europea y eso simplifica las conversaciones sobre tratamiento de datos personales, algo a tener en cuenta si vas a mover información de clientes entre sistemas. No sustituye a revisar las condiciones concretas de cada servicio, pero en la práctica reduce fricción en organizaciones con un responsable de protección de datos exigente.',
+        ],
+      },
+      {
+        title: 'Convivir sin duplicar trabajo',
+        paragraphs: [
+          'Tener las dos es más habitual de lo que parece y funciona bien si el criterio de reparto está escrito. Lo razonable es dejar en Zapier las automatizaciones que monta cada equipo por su cuenta y que tocan aplicaciones de nicho, y llevar a Make los procesos centrales con lógica de verdad y volumen alto. Lo que no funciona es partir un mismo proceso entre las dos plataformas: cuando algo falla nadie sabe en cuál mirar, y la depuración se convierte en un ir y venir entre dos historiales distintos.',
+        ],
+      },
+    ],
     faqs: [
       {
         question: '¿Cuál es mejor, Zapier o Make?',
@@ -2637,6 +3843,48 @@ export const comparisons: Comparison[] = [
       'El volumen de ejecuciones es alto y la factura de Zapier se te ha ido de las manos.',
       'Quieres escribir código dentro de los flujos y no depender de lo que la plataforma permita.',
     ],
+    sections: [
+      {
+        title: 'Servicio cerrado frente a herramienta que puedes alojar tú',
+        paragraphs: [
+          'La diferencia de fondo no es de funcionalidades: es de propiedad. Zapier es un servicio en la nube que usas como cliente, con sus reglas, su facturación por uso y sus límites. n8n es un producto que puedes instalar en tu propio servidor, mirar por dentro y modificar, además de contratarse como servicio gestionado si no quieres administrarlo. Esa sola decisión arrastra consecuencias en coste, en privacidad, en flexibilidad y en cuánta gente hace falta para mantenerlo funcionando.',
+          'El diseño también parte de supuestos opuestos. Zapier asume un usuario sin perfil técnico y esconde toda la complejidad posible; el precio de eso es que cuando necesitas algo que no está contemplado, no hay puerta trasera. n8n asume que quien lo usa entiende de peticiones, datos estructurados y credenciales, y por eso deja ejecutar código dentro del flujo, conectarse a cualquier servicio con una petición genérica y manipular los datos sin pedir permiso a nadie.',
+          'Hay además una cuestión estratégica que conviene mirar de frente. Con Zapier tus procesos viven en una plataforma de la que es costoso salir, porque no hay forma limpia de llevarte los flujos. Con n8n, alojado por ti, la automatización es tuya y puede seguir funcionando aunque cambien los planes comerciales del fabricante. Para procesos que sostienen la operación de una empresa, esa diferencia pesa bastante más que veinte euros al mes en un sentido o en otro.',
+        ],
+      },
+      {
+        title: 'Qué puedes hacer con cada una cuando el flujo se complica',
+        paragraphs: [
+          'Zapier resuelve en minutos lo que representa el grueso de las automatizaciones de oficina: mover datos entre aplicaciones conocidas, avisar de algo, crear registros. Su catálogo es el más amplio que hay y eso significa que casi cualquier herramienta comercial ya está integrada y probada. Mientras te muevas dentro de ese terreno, es la opción que menos tiempo consume y la que cualquier compañero puede retocar sin llamarte a ti.',
+          'n8n empieza a destacar justo donde Zapier se atasca. Recorrer listas largas, transformar respuestas complejas, ejecutar un fragmento de código para limpiar datos, encadenar llamadas a servicios internos o montar un agente que consulte varias fuentes antes de decidir son cosas que en n8n son parte del funcionamiento normal. También integra modelos de lenguaje de forma nativa en el flujo, que hoy es uno de sus argumentos más fuertes frente a las plataformas tradicionales de automatización.',
+        ],
+        bullets: [
+          'n8n compensa si: tienes servidor propio o alguien que lo administre, mucho volumen, o servicios internos sin integración pública.',
+          'Zapier compensa si: el equipo no es técnico, necesitas integraciones comerciales poco comunes y el volumen es moderado.',
+          'Autoalojar no es gratis: cuesta tiempo de mantenimiento, actualizaciones y vigilar que no se caiga.',
+        ],
+      },
+      {
+        title: 'El coste real, no el de la portada',
+        paragraphs: [
+          'Zapier cobra por tareas ejecutadas, así que la factura crece con el uso de forma lineal y predecible hasta que deja de serlo. n8n autoalojado tiene coste de licencia cero en su modalidad abierta y solo pagas el servidor, lo que a volumen alto es una diferencia enorme: puedes ejecutar cientos de miles de operaciones por el precio de una máquina modesta. Su versión en la nube cobra por ejecución de flujo completo, no por paso, lo que también sale favorable en automatizaciones con muchos módulos.',
+          'El matiz honesto es que el ahorro no es gratis. Autoalojar significa actualizar, hacer copias de seguridad, vigilar que el servicio siga en pie y resolver tú los problemas cuando algo se rompe un viernes por la tarde. Si nadie del equipo va a asumir eso, el precio bajo es ficticio y acabarás con procesos críticos parados. La regla práctica: por debajo de cierto volumen, Zapier sale más barato en coste total; por encima, y con perfil técnico disponible, n8n no tiene rival.',
+        ],
+      },
+      {
+        title: 'Idioma y cumplimiento normativo desde España',
+        paragraphs: [
+          'Zapier ofrece interfaz y documentación en español, mientras que n8n se maneja principalmente en inglés, tanto en la interfaz como en su documentación y en la comunidad donde se resuelven las dudas. Para un equipo sin soltura en inglés eso es una barrera real que conviene no minimizar, porque la mayor parte del aprendizaje de n8n ocurre leyendo hilos y ejemplos ajenos.',
+          'A cambio, n8n gana claramente en la conversación sobre datos. Alojarlo en un servidor propio en Europa significa que la información de clientes no sale de tu infraestructura, lo que simplifica muchísimo el cumplimiento del reglamento europeo de protección de datos frente a un servicio estadounidense que procesa esos mismos datos en sus sistemas. En sectores como el sanitario, el legal o el financiero, ese argumento suele decidir la elección por encima de la comodidad.',
+        ],
+      },
+      {
+        title: 'Repartirlas por criticidad del proceso',
+        paragraphs: [
+          'La combinación que funciona es por tipo de proceso, no por tipo de usuario. En n8n, los procesos centrales, los que manejan datos sensibles y los de alto volumen, donde el ahorro y el control justifican el mantenimiento. En Zapier, las automatizaciones periféricas que monta cada departamento y las que dependen de una integración comercial que n8n no trae de serie. Un consejo práctico: no migres a n8n lo que ya funciona en Zapier solo por ahorrar; migra cuando la factura o una restricción de datos te lo pidan.',
+        ],
+      },
+    ],
     faqs: [
       {
         question: '¿Cuál es mejor, Zapier o n8n?',
@@ -2712,6 +3960,48 @@ export const comparisons: Comparison[] = [
       'Manejas datos sensibles y necesitas que no salgan de tu infraestructura.',
       'Quieres escribir código dentro de los flujos sin las limitaciones de una plataforma cerrada.',
     ],
+    sections: [
+      {
+        title: 'Mismo territorio, dos apuestas sobre el control',
+        paragraphs: [
+          'Este par es más parecido de lo que suele contarse: ambas son plataformas visuales pensadas para flujos con lógica de verdad, no para cadenas de dos pasos. Las dos permiten ramificar, recorrer listas, transformar datos y gestionar errores. La diferencia está en el modelo: Make es un servicio cerrado y muy pulido que usas como cliente; n8n es un producto de código abierto que puedes instalar donde quieras, revisar y extender, además de ofrecerse como servicio gestionado.',
+          'Eso se traduce en dos experiencias distintas. Make cuida mucho la interfaz, el catálogo de módulos ya preparados y la documentación, así que el camino desde la idea hasta el flujo funcionando es más corto y más agradable. n8n exige más de quien lo usa: más inglés, más comodidad con datos estructurados, más disposición a resolver con una llamada genérica lo que no viene integrado. A cambio da un control que Make, por definición, no puede ofrecer.',
+          'El otro eje que los separa es la inteligencia artificial. n8n ha construido buena parte de su propuesta reciente alrededor de flujos con modelos de lenguaje, agentes y memoria, y hoy es de las opciones más completas para montar ese tipo de procesos sin escribir una aplicación entera. Make también integra servicios de IA, pero de forma más convencional, como un módulo más dentro del flujo en lugar de como una capacidad central del producto.',
+        ],
+      },
+      {
+        title: 'Construir y depurar el mismo flujo en cada una',
+        paragraphs: [
+          'Para un proceso empresarial clásico, con condiciones y llamadas a servicios conocidos, Make suele terminarse antes. Sus módulos vienen resueltos, la autenticación con cada servicio está tratada y la ejecución paso a paso permite ver qué dato entra y sale de cada bloque sin trabajo adicional. Es una herramienta que perdona errores y en la que un compañero con conocimientos medios puede entrar a revisar un flujo ajeno sin que le expliques la arquitectura entera.',
+          'n8n gana cuando el flujo se sale del guion: servicios internos sin integración pública, transformaciones que piden código, encadenar varias llamadas condicionadas al resultado anterior o construir un asistente que consulte documentación propia antes de responder. También gana en control de versiones y en poder tratar los flujos como código que se despliega, algo que a un equipo de desarrollo le resulta natural y que en Make es más limitado por ser un servicio cerrado.',
+        ],
+      },
+      {
+        title: 'Operaciones facturadas frente a servidor propio',
+        paragraphs: [
+          'Make cobra por operaciones, contando cada módulo que se ejecuta, con planes escalonados según el volumen mensual. n8n en su versión autoalojada no tiene coste por uso: pagas la máquina donde corre y puedes ejecutar el volumen que aguante. Su versión gestionada cobra por ejecución de flujo completo en lugar de por paso, lo que en automatizaciones con muchos módulos cambia mucho el cálculo respecto a Make, que multiplica el coste por cada bloque que atraviesa el flujo.',
+          'El resultado por perfiles es bastante claro. Con volúmenes bajos o medios y sin perfil técnico dedicado, Make sale mejor porque el coste de operación humana es menor y la factura sigue siendo razonable. Con volúmenes altos, flujos de muchos pasos o necesidad de que los datos no salgan de tu infraestructura, n8n autoalojado es notablemente más barato, siempre que alguien asuma actualizaciones, copias de seguridad y vigilancia del servicio.',
+        ],
+        bullets: [
+          'Antes de decidir, estima ejecuciones al mes y multiplica por el número de módulos de cada flujo: ese número decide más que el precio de la portada.',
+          'Cuenta el tiempo de mantenimiento como coste real si vas a autoalojar n8n.',
+          'Si el bloqueo es normativo, el cálculo económico es secundario.',
+        ],
+      },
+      {
+        title: 'Español y datos europeos',
+        paragraphs: [
+          'Make tiene interfaz y documentación en español y una comunidad hispanohablante activa que publica ejemplos y plantillas, mientras que n8n se maneja en inglés casi por completo: la interfaz, la documentación y sobre todo el foro donde se resuelven las dudas reales, que es donde acaba aprendiendo cualquiera que lo use en serio. Para equipos españoles sin inglés técnico eso es una desventaja tangible de n8n, porque la parte difícil de su curva de aprendizaje no está en los tutoriales oficiales sino en leer cómo lo ha resuelto otro antes que tú.',
+          'En materia de datos, las dos parten de una posición cómoda para una empresa española. Make tiene origen europeo y procesa datos bajo el marco comunitario; n8n va un paso más allá si lo alojas tú, porque la información no sale de tu servidor en ningún momento. Si manejas datos personales de clientes o información sujeta a secreto profesional, n8n autoalojado sigue siendo la respuesta más sólida ante una auditoría.',
+        ],
+      },
+      {
+        title: 'Tener las dos: cuándo compensa de verdad',
+        paragraphs: [
+          'Solaparlas tiene poco sentido porque cubren el mismo terreno, y mantener dos plataformas implica duplicar credenciales, documentación y sitios donde mirar cuando algo falla a las tres de la mañana. El único reparto defendible es por sensibilidad de los datos o por volumen: n8n para los procesos que no pueden salir de tu infraestructura o que se ejecutan miles de veces al mes, y Make para el resto, donde la comodidad y el catálogo compensan. Si estás empezando, elige una y quédate con ella; el coste de mantener dos formas de hacer lo mismo se paga en cada incidencia.',
+        ],
+      },
+    ],
     faqs: [
       {
         question: '¿Cuál es mejor, Make o n8n?',
@@ -2786,6 +4076,48 @@ export const comparisons: Comparison[] = [
       'Necesitas automatizar procesos dentro de SharePoint, Teams, Outlook o Dataverse.',
       'Requieres gobernanza, control de accesos y auditoría alineados con tu directorio corporativo.',
       'Te interesa la automatización de escritorio (RPA) sobre aplicaciones antiguas sin API.',
+    ],
+    sections: [
+      {
+        title: 'Producto independiente frente a pieza del ecosistema Microsoft',
+        paragraphs: [
+          'Zapier existe para conectar cualquier cosa con cualquier cosa y no tiene preferencias: su negocio es tener el catálogo más amplio y que montar una automatización sea trivial. Power Automate existe, ante todo, para que la información circule dentro de Microsoft. Está pegado a Outlook, SharePoint, Teams, Excel y al resto de la plataforma, y su razón de ser es que una empresa que ya paga esas licencias no necesite un proveedor más para automatizar lo que ocurre entre sus propias herramientas.',
+          'Eso condiciona la experiencia. En Power Automate lo que toca a Microsoft funciona con una profundidad que Zapier no alcanza: permisos heredados del directorio corporativo, acceso a documentos, aprobaciones dentro de Teams, formularios internos. Lo que queda fuera del ecosistema se maneja peor, con conectores más ásperos y a menudo clasificados como avanzados, lo que además implica coste adicional. Zapier hace lo contrario: cubre bien lo de fuera y se queda en la superficie de lo de dentro.',
+          'También difieren en quién los administra. Zapier lo instala una persona con una tarjeta y empieza a producir valor esa misma tarde, con el riesgo de que aparezcan automatizaciones descontroladas por toda la empresa. Power Automate llega ya gobernado: políticas de prevención de fuga de datos, entornos separados y control desde el mismo panel que gestiona el resto de la plataforma. Una organización grande valora eso; un equipo pequeño lo vive como burocracia.',
+        ],
+      },
+      {
+        title: 'Facilidad de uso frente a profundidad corporativa',
+        paragraphs: [
+          'Zapier es más agradable de usar, sin discusión. La configuración de cada paso está resuelta, los errores se explican con claridad y la mayoría de la gente monta su primera automatización sin ayuda. Power Automate tiene una interfaz más pesada, más pasos intermedios y una gestión de conectores y entornos que confunde a quien no ha trabajado antes con la plataforma. Cuando algo falla, entender por qué suele costar bastante más que en Zapier.',
+          'A cambio, hay cosas que solo hace Power Automate. Automatizar tareas en el escritorio de un equipo Windows, incluido interactuar con aplicaciones antiguas que no tienen forma de conectarse desde fuera, es su gran ventaja en empresas con software heredado. Añade también flujos de aprobación integrados en Teams y acceso a datos corporativos respetando los permisos de cada usuario. Zapier no compite en ese terreno y no pretende hacerlo.',
+        ],
+        bullets: [
+          'Power Automate es la respuesta si necesitas automatizar aplicaciones de escritorio o procesos internos con permisos corporativos.',
+          'Zapier es la respuesta si tu operación vive en herramientas de terceros que no son de Microsoft.',
+          'Si dudas, mira dónde están los datos que quieres mover: la plataforma que los aloja suele ganar.',
+        ],
+      },
+      {
+        title: 'Pagar por tareas frente a pagar por usuario',
+        paragraphs: [
+          'Zapier cobra por tareas ejecutadas: cuanto más automatizas, más pagas, con independencia de cuánta gente lo use. Power Automate se factura principalmente por usuario, con una parte de funcionalidad ya incluida en las licencias de Microsoft que muchas empresas tienen contratadas, y suplementos cuando entran conectores avanzados, automatización de escritorio o capacidades de la plataforma de datos. Son dos lógicas que se cruzan: una escala con el volumen y la otra con el número de personas.',
+          'La consecuencia práctica es contraintuitiva. Para una empresa mediana o grande que ya paga licencias de Microsoft, empezar con Power Automate puede costar prácticamente cero en incremento, y ese argumento gana casi cualquier discusión interna aunque la herramienta sea menos cómoda. Para un equipo pequeño, una agencia o cualquier organización que no viva en Microsoft, Zapier sale más barato y muchísimo más rápido de poner en marcha, porque no arrastra licencias ni administración de plataforma.',
+        ],
+      },
+      {
+        title: 'Español y requisitos de una empresa en España',
+        paragraphs: [
+          'Las dos ofrecen interfaz en español. La de Power Automate está traducida por completo, aunque con la terminología heredada de Microsoft, que a veces resulta poco natural y complica buscar soluciones porque los nombres de las funciones no coinciden con los que aparecen en la documentación en inglés. Zapier tiene una traducción más ligera pero suficiente y una documentación en castellano más práctica para resolver dudas concretas.',
+          'En cumplimiento normativo, Power Automate tiene ventaja en empresas españolas con requisitos formales: forma parte de un contrato de tratamiento de datos que probablemente ya está firmado con Microsoft, con opciones de residencia de datos en la Unión Europea y controles de administración centralizados. Con Zapier hay que dar de alta un proveedor nuevo y revisar el flujo de datos personales por separado, que en organizaciones con responsable de protección de datos no siempre es un trámite rápido.',
+        ],
+      },
+      {
+        title: 'Convivencia realista en una empresa',
+        paragraphs: [
+          'Es una de las combinaciones que mejor funcionan en la práctica, precisamente porque no se pisan. Power Automate para todo lo que ocurre dentro de Microsoft y para lo que exige permisos corporativos o automatización de escritorio; Zapier para conectar herramientas externas de marketing, ventas o soporte que Microsoft cubre mal. El punto de unión suele ser un correo, un archivo en SharePoint o una llamada web entre ambas. Lo importante es documentar qué proceso vive en cuál para que nadie tenga que adivinarlo cuando algo se rompe.',
+        ],
+      },
     ],
     faqs: [
       {
@@ -2866,6 +4198,49 @@ export const comparisons: Comparison[] = [
       'Trabajas en un entorno con requisitos de cumplimiento y control de permisos corporativos.',
       'El coste por usuario no es el factor decisivo frente al ahorro de tiempo del equipo.',
     ],
+    sections: [
+      {
+        title: 'Dos ideas opuestas de dónde vive tu trabajo',
+        paragraphs: [
+          'Notion AI no es un producto aparte: es una capa que se activa dentro de un espacio de trabajo que tú has construido a base de páginas, bases de datos y wikis. Su utilidad depende directamente de cuánta información hayas metido ahí. Microsoft 365 Copilot parte de la premisa contraria: da por hecho que tu trabajo ya está repartido entre Outlook, Teams, Word, Excel y SharePoint, y va a buscarlo donde esté. Uno asume que centralizas; el otro asume que estás disperso y necesita un índice que lo una todo.',
+          'Esa diferencia decide a quién sirve cada uno. Notion AI encaja en equipos pequeños y medianos que ya han hecho el esfuerzo de documentar en un solo sitio y que quieren consultar, resumir y redactar sobre ese material. Copilot está pensado para organizaciones con Microsoft 365 desplegado de verdad: licencias, permisos heredados, gobernanza y el correo como sistema nervioso de la empresa. Si tu compañía funciona a base de hilos de correo y reuniones de Teams, Notion AI no tiene con qué trabajar.',
+          'También cambia la unidad sobre la que pides. En Notion trabajas sobre una página o una base de datos concreta, y el resultado se queda ahí como contenido editable. En Copilot pides sobre reuniones, hilos de correo, hojas de cálculo y documentos que viven en SharePoint, respetando los permisos que ya tenía cada archivo. Eso es una ventaja de seguridad real, pero también su punto débil: si el contenido de la empresa está mal organizado o duplicado, Copilot devuelve respuestas mediocres y no hay prompt que lo arregle.',
+        ],
+      },
+      {
+        title: 'Dónde gana cada uno en tareas concretas',
+        paragraphs: [
+          'Notion AI se nota en el trabajo de documentación continuada: resumir un wiki que ha crecido sin control, rellenar propiedades de una base de datos a partir del texto de cada ficha, redactar el borrador de un procedimiento con el estilo del resto del espacio, o encontrar aquella decisión que alguien anotó hace meses. Todo ocurre dentro del editor, sin exportar ni copiar. Su límite es evidente: lo que no esté en Notion, no existe para él, y mantener el espacio actualizado es trabajo humano que nadie te quita.',
+          'Copilot gana en el flujo diario de una empresa que vive en Microsoft. Resumir una reunión de Teams indicando quién se comprometió a qué, redactar una respuesta con el hilo de correo entero como contexto, convertir un documento de Word en una presentación, o razonar sobre una hoja de Excel con fórmulas y tablas dinámicas. Su calidad es irregular: brilla en correo y reuniones, y decepciona más a menudo en Excel y PowerPoint, donde el resultado suele necesitar bastante retoque manual antes de servir para algo.',
+        ],
+        bullets: [
+          'Base de conocimiento interna y documentación viva: Notion AI',
+          'Actas de reunión, correo y contexto repartido en SharePoint: Copilot',
+          'Rellenar y clasificar registros de una base de datos: Notion AI',
+          'Análisis rápido sobre hojas de cálculo corporativas: Copilot, con revisión',
+        ],
+      },
+      {
+        title: 'Qué modelo de precio sale más a cuenta',
+        paragraphs: [
+          'Las estructuras no se parecen. Notion cobra por miembro del espacio de trabajo y ha ido integrando la IA dentro de sus planes en lugar de venderla como complemento suelto. El efecto práctico es que el coste crece con el tamaño del espacio, aunque solo una parte del equipo use la IA a diario, y que subir de plan por otras razones puede desbloquear funciones de IA que no habías pedido. Es un gasto único y relativamente predecible, integrado en una herramienta que probablemente ya pagabas.',
+          'Copilot funciona como licencia adicional apilada sobre una suscripción de Microsoft 365 que ya estás pagando, normalmente con compromiso anual y por usuario asignado. Eso lo convierte en una decisión de despliegue, no de prueba: hay que elegir a quién se la das. Solo sale rentable en perfiles que viven en Outlook, Teams y Excel muchas horas al día. Para alguien que apenas usa el correo, el coste por licencia es difícil de justificar, y conviene medir el uso real antes de ampliarlo a toda la plantilla.',
+        ],
+      },
+      {
+        title: 'Cómo se comportan en español',
+        paragraphs: [
+          'Los dos redactan español correcto, pero fallan en sitios distintos. El punto flojo de Copilot en España está en la transcripción de reuniones: acentos variados, gente que se solapa, y sobre todo la mezcla constante de español e inglés técnico, que suele salir mal transcrita y arrastra el error al resumen. Conviene revisar los acuerdos que extrae antes de darlos por buenos. Notion AI se defiende bien en texto largo, aunque su registro por defecto suena a traducción del inglés y tiende a un tono neutro que no es el que usa un equipo español.',
+          'En búsqueda hay otra diferencia útil: preguntar en español dentro de Notion funciona razonablemente porque el contenido indexado es tuyo y suele estar en un solo idioma. En Copilot, con documentación mezclada en inglés y español, las respuestas pierden precisión y a veces contesta en el idioma del documento fuente en lugar del tuyo. Si tu empresa trabaja con material bilingüe, merece la pena pedir explícitamente el idioma de salida en cada consulta.',
+        ],
+      },
+      {
+        title: 'Usar las dos a la vez tiene sentido, con una condición',
+        paragraphs: [
+          'Es una combinación frecuente y funciona: Microsoft para el flujo del día a día (correo, reuniones, hojas de cálculo) y Notion como base de conocimiento donde queda lo que hay que recordar. El reparto natural es lo efímero en Microsoft y lo duradero en Notion. El riesgo real no es el coste de las dos licencias, sino acabar con dos fuentes de verdad: procedimientos en SharePoint y en Notion, cada uno con una versión distinta. Si conviven, hay que decidir qué tipo de documento vive en cada sitio y sostener esa regla.',
+        ],
+      },
+    ],
     faqs: [
       {
         question: '¿Cuál es mejor, Notion AI o Microsoft 365 Copilot?',
@@ -2944,6 +4319,43 @@ export const comparisons: Comparison[] = [
       'Necesitas pasar de un texto o un guion a diapositivas en cuestión de minutos.',
       'Quieres publicar el resultado como página web o compartirlo sin exportar a PowerPoint.',
       'Te importa más el impacto visual que la gestión del conocimiento.',
+    ],
+    sections: [
+      {
+        title: 'Uno guarda el conocimiento, el otro lo enseña',
+        paragraphs: [
+          'Gamma existe para producir algo que se ve: presentaciones, documentos con diseño, páginas para compartir. El formato es el producto. Le das un tema o un guion y devuelve piezas maquetadas con tipografía, imágenes y una coherencia visual que tú no has tenido que decidir. Notion AI existe dentro de un espacio de trabajo donde el contenido ya está: su trabajo es leer, resumir, redactar y organizar sobre material propio. Uno parte de un prompt y llega al diseño; el otro parte de tu documentación y se queda en el texto.',
+          'Por eso el público es distinto. Gamma lo usa quien tiene que presentar hacia fuera con frecuencia: una propuesta comercial, un pitch, una clase, un informe para un cliente. Notion AI lo usa quien trabaja hacia dentro de forma continua: actas, procedimientos, notas de proyecto, bases de datos. Gamma no es donde guardas la información, es donde la enseñas, y esa distinción resuelve la mayoría de las dudas sobre cuál elegir.',
+          'También difieren en la unidad de contenido. Gamma trabaja con tarjetas que se adaptan al ancho de la pantalla y se comparten como enlace web, no con diapositivas de tamaño fijo pensadas para proyectar y exportar a PDF. Notion trabaja con bloques dentro de páginas jerárquicas. Si tu entregable habitual es un PowerPoint que alguien va a editar después, ninguna de las dos es la opción cómoda, y conviene saberlo antes de montar el flujo de trabajo encima.',
+        ],
+      },
+      {
+        title: 'Acabado visual frente a profundidad del contenido',
+        paragraphs: [
+          'Gamma tiene una ventaja difícil de discutir: en minutos tienes algo presentable, con tema coherente, imágenes y ritmo. El problema es el texto. Si le pides una presentación solo con el título, escribe contenido genérico, plano y con esa estructura previsible de tres puntos por tarjeta que se reconoce enseguida. Su mejor uso es el contrario al que promete el marketing: pegar tu propio guion, tus datos y tus conclusiones, y dejar que Gamma se ocupe únicamente de convertirlo en algo que se pueda enseñar sin vergüenza.',
+          'Notion AI produce mejor texto cuando hay material de partida: resúmenes de documentos largos, reescrituras con contexto, extracción de puntos clave de varias páginas. Es más útil para pensar y para dejar constancia que para comunicar hacia fuera. Su límite es justo el punto fuerte de Gamma: lo que sale es un documento, y convertirlo en una presentación implica salir de la herramienta. Para una reunión interna donde basta compartir la página, sobra; para un cliente, se queda corto de forma evidente.',
+        ],
+      },
+      {
+        title: 'Créditos frente a suscripción por miembro',
+        paragraphs: [
+          'Gamma funciona con un plan gratuito que da créditos para generar y deja marca de la propia herramienta en lo que compartes, más planes de pago por usuario que quitan esa marca, amplían la generación y añaden control sobre el diseño y los dominios personalizados. La consecuencia práctica es que el coste depende de cuánto generas, no de cuánta gente lo mira: compartir una presentación con cien personas no cuesta más. Para uso ocasional, el plan gratuito aguanta bastante más de lo que uno espera.',
+          'Notion cobra por miembro del espacio de trabajo, con la IA integrada en los planes en lugar de vendida aparte. Si tu equipo ya paga Notion, la capa de IA no supone una decisión de compra nueva; si no lo paga, contratarlo solo por la IA es caro comparado con un asistente general. El reparto rentable es claro: quien presenta mucho y documenta poco encuentra más valor en Gamma; quien documenta mucho y presenta poco no debería pagar Gamma por costumbre.',
+        ],
+      },
+      {
+        title: 'Cómo funcionan en español',
+        paragraphs: [
+          'Gamma genera presentaciones en español sin problema, pero el texto que produce suena a plantilla traducida: titulares con imperativos calcados del inglés, subtítulos redundantes y llamadas a la acción que en España nadie escribiría así. La recomendación práctica es escribir tú los titulares y dejarle el cuerpo y el diseño. Hay además un detalle de maquetación que se pasa por alto: el español ocupa alrededor de un quince por ciento más que el inglés, y los textos generados desbordan tarjetas pensadas con proporciones inglesas, así que hay que revisar cortes y desbordes.',
+          'Notion AI se maneja mejor en texto largo en español y mantiene el registro con más consistencia, aunque también arrastra estructuras del inglés cuando redacta desde cero. En su caso el problema típico no es el idioma sino el tratamiento: mezcla tuteo y formas impersonales dentro del mismo documento. Si el espacio de trabajo tiene una guía de estilo escrita en una página, referenciarla en la petición mejora bastante el resultado.',
+        ],
+      },
+      {
+        title: 'El flujo natural es encadenarlas',
+        paragraphs: [
+          'Se complementan mejor de lo que compiten. El flujo que funciona es preparar el contenido en Notion, donde están los datos, las notas y las decisiones, y llevar ese texto a Gamma cuando toca enseñarlo, porque Gamma importa desde texto y documentos con facilidad y se ocupa del acabado. Así evitas el problema de cada una: Notion no maqueta y Gamma no debería ser tu archivo. Lo que no compensa es pagar las dos si solo presentas de vez en cuando, o mantener la versión buena de un documento dentro de una presentación.',
+        ],
+      },
     ],
     faqs: [
       {
@@ -3024,6 +4436,43 @@ export const comparisons: Comparison[] = [
       'Necesitas encadenar pasos (investigar cuenta, redactar, enviar) en un único flujo.',
       'Prefieres una herramienta que se integre en tu operativa comercial más que en tu blog.',
     ],
+    sections: [
+      {
+        title: 'Nacieron iguales y hoy resuelven problemas distintos',
+        paragraphs: [
+          'Los dos empezaron como generadores de copy con plantillas, y ahí acaba el parecido. Jasper se ha ido hacia el marketing de marca en empresa: voz de marca definida a partir de tus textos, guías de estilo, campañas coordinadas entre canales, permisos y revisión. Copy.ai ha pivotado hacia la automatización comercial: flujos de trabajo que procesan listas de cuentas, enriquecen datos, generan mensajes personalizados y encadenan pasos. Comparar sus resultados frase a frase es perder el tiempo, porque ya no compiten por el mismo presupuesto.',
+          'Eso se ve en quién los compra. Jasper lo defiende el equipo de contenido o de marca, que necesita que veinte piezas escritas por cinco personas suenen a la misma empresa. Copy.ai lo compra ventas u operaciones de ingresos, que valoran las integraciones con el CRM y el ahorro de horas repetitivas. Si lo que buscas es sencillamente un sitio donde escribir textos sueltos con IA, ambos te sobran y te van a costar dinero por capacidades que no vas a tocar.',
+          'La unidad de trabajo también difiere. En Jasper la unidad es la pieza de contenido dentro de una campaña, con su brief, su tono y su revisión. En Copy.ai la unidad es el flujo que se ejecuta sobre muchos registros a la vez. Uno optimiza la calidad de una salida que va a leer un humano con calma; el otro optimiza la consistencia de cientos de salidas que nadie va a leer entera. Son objetivos de ingeniería opuestos.',
+        ],
+      },
+      {
+        title: 'Consistencia de marca frente a volumen personalizado',
+        paragraphs: [
+          'Jasper gana claramente cuando el requisito es que suene a la marca. Puedes alimentarlo con documentos de estilo y piezas anteriores, y mantiene el registro entre formatos: un artículo, sus variantes de anuncio y el correo asociado salen reconociblemente del mismo sitio. En textos largos aguanta mejor el tono sin derivar hacia la prosa neutra de IA, y sus controles de revisión encajan con equipos donde alguien aprueba antes de publicar. Sigue necesitando edición humana, pero la cantidad de reescritura es menor.',
+          'Copy.ai gana cuando el requisito es volumen sobre datos. Generar trescientos correos distintos a partir de una lista de cuentas, resumir información de cada empresa, clasificar respuestas o preparar resúmenes de cuenta antes de una llamada. Su salida individual es más plana que la de Jasper, pero medida pieza a pieza no es la métrica correcta: lo que importa es que el proceso completo funcione sin supervisión. Para un artículo de blog con criterio editorial, Copy.ai se queda por detrás sin discusión.',
+        ],
+      },
+      {
+        title: 'Asientos frente a créditos de ejecución',
+        paragraphs: [
+          'Jasper cobra por asiento, con niveles que desbloquean la voz de marca, la gestión de campañas y el control de equipo. Es un coste que crece con el número de personas que escriben y que solo se justifica si esas personas producen contenido de forma continua. Para un autónomo o para quien publica dos artículos al mes, el suelo de precio es difícil de amortizar frente a un asistente general. La pregunta útil no es cuánto cuesta el asiento, sino cuántas horas de reescritura ahorra al equipo.',
+          'Copy.ai combina asientos con consumo de créditos por ejecución de flujos, y ahí está la parte del coste que de verdad escala. Procesar listas grandes o encadenar muchos pasos consume rápido, y el gasto se dispara justo cuando el sistema empieza a funcionar bien. Su rentabilidad se calcula contra horas de trabajo comercial: si sustituye una parte del trabajo manual de prospección, sale a cuenta con facilidad. Si se usa como generador de textos ocasional, es una herramienta cara para lo que se le pide.',
+        ],
+      },
+      {
+        title: 'Cómo escriben en español',
+        paragraphs: [
+          'Los dos producen español gramaticalmente correcto, pero pensado desde plantillas inglesas. Se nota en las llamadas a la acción, en el abuso de imperativos tipo descubre y transforma, y en estructuras de titular que en el mercado español suenan a publicidad importada. Jasper mejora bastante si alimentas la voz de marca con textos reales en español en lugar de traducciones: sin ese paso, aplica el tono definido en inglés y el resultado queda a medio camino. Es el trabajo previo que más rendimiento da en esta herramienta.',
+          'En Copy.ai el problema más habitual en campañas hacia España es el tratamiento: mezcla tuteo y usted dentro de la misma secuencia, y las líneas de asunto traducidas literalmente del inglés funcionan mal aquí. Merece la pena fijar el tratamiento explícitamente en las instrucciones del flujo y revisar una muestra antes de lanzar un envío grande, porque los errores de registro se multiplican por el número de destinatarios.',
+        ],
+      },
+      {
+        title: 'Combinarlas solo si contenido y ventas son equipos distintos',
+        paragraphs: [
+          'Tiene sentido cuando hay dos funciones separadas con dos problemas separados: Copy.ai automatizando la prospección y los procesos comerciales, y Jasper produciendo el contenido publicado con la voz de la marca. No se estorban porque casi no se solapan. En una empresa pequeña, donde la misma persona escribe el blog y manda los correos de captación, pagar las dos es tirar el dinero: elige según dónde tengas el cuello de botella. Si el problema es que el contenido suena a cualquiera, Jasper; si es que no llegas al volumen, Copy.ai.',
+        ],
+      },
+    ],
     faqs: [
       {
         question: '¿Cuál es mejor, Jasper o Copy.ai?',
@@ -3103,6 +4552,43 @@ export const comparisons: Comparison[] = [
       'Trabajas solo o en un equipo pequeño con presupuesto ajustado.',
       'Priorizas volumen de artículos publicados sobre refinamiento de marca.',
     ],
+    sections: [
+      {
+        title: 'Plataforma de marca frente a fábrica de contenido SEO',
+        paragraphs: [
+          'Jasper se ha posicionado como plataforma de marketing para empresa: voz de marca, campañas, gobernanza y trabajo en equipo con revisión. Su promesa no es escribir más rápido, sino que todo lo que escribe la organización suene igual. Writesonic empaqueta el proceso completo de publicación con vocación SEO y precio bajo de entrada: investigación de palabra clave, esquema, artículo, optimización y publicación. Uno vende consistencia; el otro vende cobertura del flujo entero sin salir de la herramienta.',
+          'El comprador también cambia. Jasper entra en departamentos de marketing con varias personas y alguien que aprueba antes de publicar. Writesonic entra en autónomos, agencias pequeñas y pymes que necesitan producir artículos con un presupuesto que no da para más. Hay una diferencia de temperamento que conviene tener en cuenta: Writesonic se mueve rápido y ha añadido, cambiado y retirado productos con frecuencia, mientras que Jasper es más conservador. Si vas a montar un proceso encima, esa estabilidad tiene valor real.',
+          'En la práctica la distinción es esta: Writesonic pone el criterio SEO dentro del producto, con lo bueno y lo malo de que lo ponga una máquina. Jasper te da mejor texto pero espera que el criterio editorial y de posicionamiento lo aportes tú o venga de otra herramienta. Si tienes estrategia de contenidos definida, Jasper la ejecuta mejor. Si no la tienes y necesitas empezar a publicar mañana, Writesonic al menos te da un camino, aunque el resultado sea más previsible.',
+        ],
+      },
+      {
+        title: 'Qué texto sale de cada uno',
+        paragraphs: [
+          'En texto de marca Jasper gana. Controla mejor el tono, mantiene el registro a lo largo de piezas largas y cae menos en las muletillas reconocibles de la IA. Cargando ejemplos propios y una guía de estilo, la distancia se nota sobre todo en formatos donde la voz importa: páginas de producto, correos a clientes, artículos de opinión firmados. No hace magia, pero reduce el trabajo de reescritura, que es donde de verdad se va el tiempo del equipo.',
+          'Writesonic gana en cobertura de proceso y en velocidad hasta el borrador. De una palabra clave sales con un artículo estructurado, encabezados, preguntas frecuentes y metadatos, listo para revisar. El precio es la uniformidad: párrafos cortos, listas por sistema, conclusiones que repiten lo dicho y ese estilo plano que un lector atento identifica. Sirve para cubrir volumen indexable en temas donde nadie espera una voz propia. Para contenido que sostiene la confianza en la marca, necesita mucha más reescritura que Jasper.',
+        ],
+      },
+      {
+        title: 'Suelo de precio alto frente a créditos baratos',
+        paragraphs: [
+          'Writesonic entra por precio con planes basados en créditos o volumen de palabras, con niveles bajos que hacen fácil probarlo. La trampa está en el consumo: los artículos largos y las regeneraciones agotan los créditos mucho antes de lo que sugiere la cifra del plan, y acabas subiendo de nivel o racionando el uso. Antes de comprometerte, calcula cuántos artículos completos entran de verdad en el plan contando las reescrituras, no solo la primera generación de cada texto.',
+          'Jasper cobra por asiento con un suelo bastante más alto y con las funciones de marca y gobernanza en los niveles superiores. Para una sola persona rara vez compensa. Para un equipo de tres a cinco que publica de forma constante y donde la coherencia es un requisito, el coste por asiento se justifica en horas de edición ahorradas y en menos discusiones sobre el tono. El punto de corte suele estar en si publicas de manera continua o a rachas: a rachas, Jasper es un gasto fijo que duele.',
+        ],
+      },
+      {
+        title: 'Rendimiento en español',
+        paragraphs: [
+          'Writesonic genera español correcto, pero su capa de optimización está calibrada sobre datos y hábitos de búsqueda anglosajones. Los esquemas que propone, las preguntas frecuentes que sugiere y la longitud recomendada no siempre corresponden a lo que se busca en España, y a veces plantea secciones que aquí nadie consulta. Conviene contrastar sus sugerencias con los resultados reales de Google en español antes de darlas por buenas, y ajustar el esquema a mano; la parte de redacción se aprovecha mejor que la parte de estrategia.',
+          'Jasper produce un registro más natural en español cuando le das ejemplos propios, aunque sin ese paso también arrastra construcciones calcadas del inglés y anglicismos innecesarios. Ambos comparten un vicio: en español la prosa generada tiende a ser más redundante que en inglés, con frases largas que no dicen nada. Es el primer sitio donde hay que recortar al editar, y ninguna de las dos herramientas lo hace sola por muy bien que le expliques el tono.',
+        ],
+      },
+      {
+        title: 'Combinarlas solo si publicas mucho',
+        paragraphs: [
+          'El reparto lógico es usar Writesonic para el trabajo de volumen y de investigación (esqueletos, temas de cola larga, artículos de apoyo) y Jasper para las piezas visibles que representan a la marca: página de inicio, casos de éxito, contenidos firmados. Funciona porque cubren fases distintas del embudo editorial. Ahora bien, pagar las dos suscripciones solo se sostiene con un ritmo de publicación alto y sostenido. Si publicas menos de un puñado de artículos al mes, elige uno y dedica el dinero restante a que alguien edite bien lo que sale.',
+        ],
+      },
+    ],
     faqs: [
       {
         question: '¿Cuál es mejor, Jasper o Writesonic?',
@@ -3177,6 +4663,43 @@ export const comparisons: Comparison[] = [
       'Quieres empezar gratis y pagar solo cuando el volumen lo justifique.',
       'Trabajas solo o en un equipo pequeño de contenido.',
       'Necesitas apoyo de palabras clave y estructura SEO dentro de la propia herramienta.',
+    ],
+    sections: [
+      {
+        title: 'Automatización comercial frente a producción de contenido',
+        paragraphs: [
+          'Comparten origen como generadores de copy con plantillas, pero hoy resuelven problemas diferentes. Copy.ai se ha convertido en una plataforma de automatización comercial: flujos que leen listas de cuentas, enriquecen datos, generan mensajes por registro y encadenan pasos con condiciones. Writesonic sigue siendo una suite de creación de contenido con foco en búsqueda: artículos, optimización, herramientas de apoyo y publicación. Elegir entre ellas no es comparar calidad de redacción, es decidir qué problema tienes.',
+          'Quien firma la compra es distinto en cada caso. Copy.ai lo defiende ventas o el equipo de operaciones de ingresos, y lo que valoran son las integraciones con el CRM y las horas que se ahorran en tareas repetitivas. Writesonic lo compra marketing de contenidos, un autónomo o una agencia pequeña, y lo que valoran es el coste por artículo publicado. Si intentas usar uno para el trabajo del otro, la experiencia es mala en ambas direcciones y bastante frustrante.',
+          'Técnicamente también divergen. Copy.ai piensa en tablas y pasos encadenados que se ejecutan sobre muchos registros sin supervisión. Writesonic piensa en herramientas puntuales alrededor de un editor donde una persona revisa cada pieza. Uno está diseñado para que nadie mire cada salida individual; el otro para que alguien la mire siempre. Esa premisa condiciona todo lo demás, desde la interfaz hasta cómo se factura.',
+        ],
+      },
+      {
+        title: 'Qué produce cada uno cuando le pides lo suyo',
+        paragraphs: [
+          'Para un artículo pensado para posicionar, Writesonic gana sin discusión: tiene el flujo completo desde la palabra clave hasta el borrador con encabezados, preguntas frecuentes y metadatos, y conecta con la publicación. Copy.ai puede escribir un artículo, pero no te da el esquema apoyado en datos de búsqueda ni el circuito de optimización, así que acabas haciendo a mano la parte que Writesonic automatiza. En este terreno la comparación no está reñida.',
+          'Para personalizar a escala, gana Copy.ai con la misma claridad. Segmentar una lista, generar variantes por cuenta con información específica de cada empresa, clasificar respuestas y encadenar todo eso en un proceso que se ejecuta solo es exactamente su producto, y Writesonic no tiene ese motor. En calidad de prosa suelta van parejas: las dos producen texto correcto y algo plano que necesita edición. Ninguna de las dos destaca ahí, y quien prometa lo contrario no las ha usado en serio.',
+        ],
+      },
+      {
+        title: 'Coste por volumen procesado frente a coste por palabra',
+        paragraphs: [
+          'Copy.ai combina asientos con créditos que se consumen al ejecutar flujos, de modo que el gasto sigue al volumen de datos procesados y no al número de personas. Es un modelo que castiga los procesos mal diseñados: un flujo con pasos innecesarios cuesta dinero cada vez que se ejecuta. Su rentabilidad se mide contra horas de trabajo comercial ahorradas, así que solo compensa cuando sustituye tareas repetitivas que hoy hace alguien a mano varias horas por semana.',
+          'Writesonic va por planes con límite de palabras o créditos y niveles de entrada baratos, lo que lo hace accesible para quien empieza. El riesgo es el contrario: los créditos se agotan con artículos largos y regeneraciones, y el precio real por artículo publicado acaba siendo bastante mayor que el que sugiere el plan. El perfil rentable es claro en cada caso: Writesonic si publicas con presupuesto ajustado, Copy.ai si automatizas un proceso comercial con volumen. Para textos sueltos ocasionales, un asistente general sale más barato que ambos.',
+        ],
+      },
+      {
+        title: 'Cómo se portan en español',
+        paragraphs: [
+          'Writesonic redacta español aceptable, pero sus recomendaciones de posicionamiento están sesgadas hacia el mercado anglosajón: propone estructuras y preguntas que en las búsquedas en español no aparecen, y la longitud que sugiere no siempre corresponde a lo que rankea aquí. La redacción se aprovecha mejor que la estrategia, así que conviene poner tú el esquema tras mirar los resultados reales en Google España.',
+          'En Copy.ai el problema típico son las secuencias comerciales traducidas del inglés: asuntos calcados, aperturas que aquí resultan invasivas y mezcla de tuteo y usted dentro del mismo flujo. Hay que fijar el tratamiento en las instrucciones y revisar una muestra antes de un envío masivo, porque cualquier error de registro se multiplica por el número de destinatarios y el daño a la imagen no se deshace.',
+        ],
+      },
+      {
+        title: 'Se solapan poco, así que conviven bien',
+        paragraphs: [
+          'Al cubrir problemas distintos, tenerlas a la vez no genera duplicidad: Writesonic alimentando el blog y el contenido de captación, y Copy.ai trabajando el proceso comercial una vez la gente entra en la lista. Es un reparto coherente si tienes ambos frentes activos y alguien que se ocupe de cada uno. En un equipo de una sola persona, mantener dos herramientas con dos lógicas distintas resta más de lo que suma: elige la que ataque tu cuello de botella actual y revisa la decisión dentro de unos meses.',
+        ],
+      },
     ],
     faqs: [
       {
@@ -3257,6 +4780,43 @@ export const comparisons: Comparison[] = [
       'Quieres traducir con la cámara, la voz o sobre la marcha desde el móvil.',
       'No quieres pagar nada y el resultado aproximado te vale.',
     ],
+    sections: [
+      {
+        title: 'Un servicio universal frente a una herramienta de trabajo',
+        paragraphs: [
+          'Google Translate es infraestructura antes que producto. Está construido para que nadie en el mundo se quede sin traducción, y eso obliga a repartir el esfuerzo entre cientos de idiomas, muchos con poquísimos datos disponibles. Vive integrado en el navegador, el buscador, el móvil y la cámara, y su objetivo es resolver el momento: entender un cartel, una web o una conversación ahora mismo. DeepL nació con la ambición contraria: menos idiomas, mejor tratados, con el foco puesto en las lenguas europeas de mayor demanda y en textos redactados.',
+          'Esa decisión se nota en el producto que ha construido cada uno. Google optimiza el instante y la ubicuidad. DeepL optimiza el documento: glosarios de terminología, conservación del formato, alternativas por frase, integraciones con editores y herramientas de traducción profesional. No compiten por el mismo momento del día. Uno está donde estás tú; el otro está donde trabajas tú, y por eso comparar solo la calidad de una frase suelta deja fuera casi todo lo que diferencia a los dos.',
+          'El modelo de negocio explica el resto. Google no necesita que pagues por traducir, así que su desarrollo va hacia donde le interesa como plataforma. DeepL sí necesita cobrar, y eso orienta su producto a lo que una empresa está dispuesta a pagar: confidencialidad de los textos, control terminológico, API con volumen y soporte. Si eres una empresa, esa alineación de incentivos importa más de lo que parece, sobre todo en el terreno del tratamiento de datos.',
+        ],
+      },
+      {
+        title: 'Cuánta corrección posterior necesita cada uno',
+        paragraphs: [
+          'El criterio útil no es cuál traduce mejor en abstracto, sino cuánto trabajo de post-edición te deja. DeepL gana en texto continuo: informes, correspondencia formal, notas de prensa, documentación de producto, contratos en lenguaje corriente. Mantiene mejor la cohesión entre frases seguidas, elige combinaciones de palabras más idiomáticas y en la dirección inglés-español produce menos calcos sintácticos. En textos que van a leer clientes, esa diferencia se traduce directamente en menos tiempo de un revisor humano.',
+          'Google gana en fragmentos, en idiomas fuera del núcleo europeo y en todo lo que implique contexto multimodal: fotografía, voz, traducción de una página al vuelo. También suele ir mejor con nombres propios poco comunes y con terminología muy reciente, donde su volumen de datos es una ventaja real. Hay un terreno donde ninguno resuelve: humor, juegos de palabras, marketing con doble sentido y textos donde el género o el referente son ambiguos. Ahí ambos fallan y hace falta una persona.',
+        ],
+      },
+      {
+        title: 'Gratuito de facto frente a freemium con API',
+        paragraphs: [
+          'Las estructuras son distintas y eso cambia el cálculo. Google Translate es gratuito en su interfaz web y móvil sin límites prácticos para uso personal, y cobra cuando lo integras vía API de traducción en la nube, facturando por caracteres procesados. DeepL ofrece un nivel gratuito con topes de caracteres y de documentos, una suscripción por usuario para el uso profesional en la aplicación, y una API con un tramo gratuito y después precio por volumen.',
+          'Para decidir, mira el perfil de uso. Quien traduce ocasionalmente para entender algo no tiene ninguna razón para pagar: Google gratis cumple. Quien traduce de forma profesional y recurrente amortiza DeepL Pro en horas de corrección ahorradas antes de fin de mes. Y en integraciones con volumen alto, además de comparar el coste por millón de caracteres, hay que mirar las condiciones de tratamiento de datos: los planes de pago de DeepL incluyen compromisos sobre no usar tus textos, y en muchas empresas ese punto decide antes que el precio.',
+        ],
+      },
+      {
+        title: 'Cómo se comportan con el español de España',
+        paragraphs: [
+          'Para el español peninsular, DeepL suele acertar mejor el registro y el léxico. Google tiende con más frecuencia a construcciones y vocabulario de variantes americanas, algo comprensible por el volumen de datos con el que trabaja, pero que en un texto corporativo español chirría. DeepL además permite dos cosas que importan en la práctica: fijar terminología propia mediante glosario, de modo que los nombres de producto y los términos internos se traduzcan siempre igual, y ajustar la formalidad, lo que resuelve el eterno problema del tuteo frente al usted.',
+          'En lenguas cooficiales el reparto cambia. Google tiene desde hace años cobertura de catalán, gallego y euskera, aunque la calidad es desigual entre ellas y notablemente peor en euskera. DeepL ha ido ampliando su catálogo, así que conviene comprobar la cobertura actual antes de comprometer un flujo de trabajo. Si tu proyecto exige catalán o gallego de calidad publicable, la respuesta realista hoy sigue siendo traducción automática más revisión de un profesional nativo, con cualquiera de los dos.',
+        ],
+      },
+      {
+        title: 'Usarlos juntos es lo más sensato',
+        paragraphs: [
+          'No hay que elegir, porque los dos tienen versión gratuita y cubren momentos distintos. El reparto que funciona es sencillo: Google para lo que entra, cuando necesitas entender rápido un correo, una web o algo en un idioma que DeepL no cubre, y sobre todo en el móvil y sobre la marcha. DeepL para lo que sale con tu nombre encima. La regla práctica que evita disgustos es que si el texto se va a publicar, se va a firmar o tiene consecuencias contractuales, pasa por DeepL y después por una persona.',
+        ],
+      },
+    ],
     faqs: [
       {
         question: '¿Cuál es mejor, DeepL o Google Translate?',
@@ -3335,6 +4895,49 @@ export const comparisons: Comparison[] = [
       'La calidad y expresividad de las visualizaciones es un requisito, no un extra.',
       'Trabajas en un entorno Salesforce o con fuentes de datos muy heterogéneas.',
       'Puedes asumir un coste de licencia más alto a cambio de una mejor experiencia analítica.',
+    ],
+    sections: [
+      {
+        title: 'Distribución corporativa frente a exploración visual',
+        paragraphs: [
+          'Power BI nació dentro de Microsoft como prolongación natural de Excel y del resto del stack de datos corporativo. Su fuerza histórica no ha sido la belleza de los gráficos sino la integración, el precio de entrada y la facilidad para repartir informes por toda una organización con permisos y actualizaciones automáticas. Tableau viene de la investigación académica en visualización: la idea original era que explorar datos con la vista fuera tan fluido como pensar. Uno optimiza el reparto y el control; el otro, el descubrimiento.',
+          'Eso define también cómo entra cada uno en una empresa. Power BI llega desde arriba, por TI y por el contrato de Microsoft que ya existe, y su despliegue es una decisión corporativa. Tableau suele llegar desde abajo, defendido por el analista que lo prueba y descubre que puede trabajar más rápido. Desde su compra por Salesforce, Tableau se ha ido alineando con ese ecosistema, lo que ha reforzado su posición en organizaciones que viven en el CRM y la ha debilitado en otras.',
+          'Hay una diferencia de arquitectura que condiciona el trabajo diario. Power BI trae un modelo semántico propio, con Power Query para preparar y DAX para calcular, y prácticamente te obliga a modelar bien antes de visualizar. Tableau ha separado más la preparación del análisis y es más permisivo con datos que ya llegan listos. La consecuencia es predecible: un modelo mal diseñado duele mucho más en Power BI, y una fuente sucia duele mucho más en Tableau.',
+        ],
+      },
+      {
+        title: 'Descubrir frente a servir el mismo informe a cientos de personas',
+        paragraphs: [
+          'Tableau gana cuando el trabajo es averiguar algo que nadie ha mirado antes. Arrastrar dimensiones, cambiar de tipo de gráfico, filtrar y volver atrás ocurre con una fluidez que reduce la fricción entre la pregunta y la respuesta. Sus gráficos por defecto también tienen mejor criterio visual, lo que importa cuando el resultado va a un comité y no hay tiempo para maquetar. Para análisis exploratorio y para informes donde la presentación pesa, sigue siendo la referencia.',
+          'Power BI gana cuando el trabajo es industrializar. Servir el mismo informe a cientos de personas con seguridad a nivel de fila, refrescos programados, control de versiones y ciclo de despliegue es su terreno, y ahí Tableau exige más esfuerzo. También gana en modelado: DAX permite encapsular lógica de negocio compleja y reutilizarla en toda la organización, aunque su curva de aprendizaje es real y muchos equipos la subestiman. Su editor visual es menos elegante y personalizar un gráfico al detalle cuesta más trabajo.',
+        ],
+        bullets: [
+          'Análisis exploratorio puntual o informe visual muy cuidado: Tableau',
+          'Informes recurrentes, muchos consumidores y permisos por rol: Power BI',
+          'Lógica de negocio compleja reutilizable en toda la empresa: Power BI con DAX',
+          'Equipo pequeño de analistas expertos con datos ya limpios: Tableau',
+        ],
+      },
+      {
+        title: 'Licencia por usuario frente a licencia por rol',
+        paragraphs: [
+          'Power BI cobra por usuario con un precio de entrada bajo y añade una opción de capacidad dedicada cuando escalas, además de venir arrastrado por la relación comercial que la empresa ya tiene con Microsoft. Tableau licencia por rol, distinguiendo entre quien crea, quien explora y quien solo consume, y el coste del perfil creador es sensiblemente mayor. A primera vista Power BI parece siempre más barato, y en muchos casos lo es, pero la comparación honesta exige mirar el escalón siguiente.',
+          'Ahí están las trampas de cada modelo. En Power BI el coste real acaba no siendo la licencia sino la capacidad dedicada, que se vuelve necesaria en cuanto quieres refrescos frecuentes, modelos grandes o distribuir a consumidores sin licencia individual. En Tableau la trampa es el número de creadores: si media empresa quiere crear sus propios cuadros, la factura se dispara. Para una organización mediana ya instalada en Microsoft, Power BI suele salir más barato; para un equipo reducido de analistas expertos, Tableau puede compensar por productividad.',
+        ],
+      },
+      {
+        title: 'Idioma, comunidad y formatos regionales',
+        paragraphs: [
+          'Los dos tienen interfaz en español, pero Power BI va por delante en material de apoyo: la documentación de Microsoft está traducida de forma razonable y la comunidad hispanohablante es enorme, con foros, cursos y plantillas que resuelven la mayoría de atascos sin salir del idioma. Tableau depende bastante más de recursos en inglés, lo que en equipos donde no todo el mundo se maneja bien en inglés supone una barrera real de adopción y de formación interna.',
+          'Hay un detalle práctico que da más problemas de lo que parece: los formatos regionales. Coma decimal, separador de miles y fechas en dd/mm/aaaa provocan errores silenciosos al importar CSV españoles, sobre todo en Power BI, donde el modelo hereda una configuración regional que conviene fijar de forma explícita en cada informe. Tableau también se ve afectado, aunque suele dar menos sorpresas. Es la primera cosa que hay que revisar cuando una cifra no cuadra y todo lo demás parece correcto.',
+        ],
+      },
+      {
+        title: 'Conviven bien si las métricas se definen una sola vez',
+        paragraphs: [
+          'La convivencia es habitual en empresas grandes: Tableau en manos del equipo de analistas y Power BI como capa de distribución corporativa. Funciona siempre que la fuente de datos sea común, típicamente un almacén o un modelo semántico compartido, y lo único que cambie sea la capa de visualización. Lo que no funciona es mantener las mismas métricas definidas dos veces, una en cada herramienta: acabas con dos cifras de ingresos distintas y con reuniones enteras dedicadas a discutir cuál es la buena. Si van a coexistir, la definición vive aguas arriba.',
+        ],
+      },
     ],
     faqs: [
       {
@@ -3415,6 +5018,43 @@ export const comparisons: Comparison[] = [
       'Tu caso de uso central es búsqueda y recuperación de documentos.',
       'Quieres menos capas de abstracción y más control sobre lo que ocurre.',
     ],
+    sections: [
+      {
+        title: 'Amplitud frente a un diseño con opinión',
+        paragraphs: [
+          'LangChain es una caja de herramientas enorme y en movimiento constante: cadenas, agentes, integraciones con casi cualquier modelo, base vectorial o servicio que se te ocurra, y una superficie de API que ha cambiado de forma notable varias veces. Haystack, desarrollado por deepset, es más estrecho y más opinado: nació alrededor de la búsqueda y la recuperación, y su modelo mental es un grafo explícito de componentes conectados. Uno prioriza cobertura y velocidad de arranque; el otro, previsibilidad y capacidad de razonar sobre lo que hace el sistema.',
+          'El público refleja eso. LangChain sirve al prototipo rápido y a quien necesita que ya exista un conector para lo que sea, y su ecosistema alrededor pesa mucho: LangGraph para agentes con estado y control del flujo, y su capa de trazas y evaluación para ver qué está pasando dentro. Haystack sirve a equipos que construyen sistemas de recuperación en producción y quieren un pipeline que se lea, se versione y se pueda probar como cualquier otro componente de software.',
+          'La diferencia se paga en mantenimiento. La amplitud de LangChain tiene un coste en actualizaciones que rompen cosas y en abstracciones que a veces esconden el prompt real que se está enviando, lo cual complica depurar. Haystack cambia menos y su modelo mental cuesta menos de sostener a un año vista, pero cuando necesitas algo que no encaja en su forma de ver el mundo, te toca escribirlo tú. Es el intercambio clásico entre flexibilidad y disciplina.',
+        ],
+      },
+      {
+        title: 'El criterio real es qué estás construyendo',
+        paragraphs: [
+          'Si el proyecto es recuperación aumentada sobre documentos, con necesidad de evaluar y reproducir resultados, Haystack lleva ventaja. Sus pipelines declarativos se serializan y se versionan, los componentes de recuperación están bien delimitados, la integración con motores de búsqueda y bases vectoriales es natural, y tiene herramientas de evaluación pensadas para este caso. Cuando alguien pregunta por qué el sistema devolvió justo ese documento, en Haystack es más fácil responder con precisión, y eso vale mucho en producción.',
+          'Si el proyecto es un agente con herramientas, un flujo con ramas y estado persistente, o integrar un servicio poco común, LangChain gana por ecosistema. LangGraph da control explícito del grafo, de los puntos de control y de la persistencia del estado entre pasos, y las herramientas de observabilidad están más maduras que en la mayoría de alternativas. Para un prototipo que hay que enseñar esta semana, LangChain llega antes casi siempre; lo que hay que decidir después es si ese prototipo aguanta como base de producción.',
+        ],
+      },
+      {
+        title: 'Ambos son gratis, el coste está en otro sitio',
+        paragraphs: [
+          'Las dos librerías son de código abierto con licencias permisivas, así que comparar precios de la biblioteca no tiene sentido. El coste aparece en lo que las rodea. En LangChain, en la plataforma de observabilidad y evaluación y en el despliegue gestionado de agentes si decides no operarlos tú. En Haystack, en la plataforma comercial de deepset para construir y explotar pipelines con interfaz y gobernanza, mientras el núcleo sigue siendo gratuito y autoalojable. Las dos rutas admiten autoalojamiento completo si tienes el equipo para sostenerlo.',
+          'El gasto que de verdad domina no es ninguno de los dos: son los tokens del modelo, los embeddings y la infraestructura de la base vectorial. Ahí la decisión relevante es de diseño, no de librería: cuántas llamadas encadena tu sistema por cada pregunta del usuario y cuánto contexto recupera cada vez. Conviene saber que LangChain, por lo fácil que resulta, invita a cadenas largas y agentes que llaman al modelo muchas veces, y esa factura crece de forma poco intuitiva. Instrumentar el consumo desde el primer día evita sustos.',
+        ],
+      },
+      {
+        title: 'Qué cambia cuando el corpus está en español',
+        paragraphs: [
+          'La diferencia en español no la marca la librería sino el pipeline de recuperación: qué modelo de embeddings eliges, cómo tokenizas y cómo tratas la búsqueda por palabras clave. Ambas permiten cambiarlo todo, pero Haystack expone los componentes de recuperación con más claridad, y eso facilita configurar un analizador español en la búsqueda léxica y combinarla con búsqueda densa multilingüe en una estrategia híbrida. Con LangChain se hace igual, aunque sus valores por defecto asumen inglés y quien no lo revise obtendrá resultados peores sin saber por qué.',
+          'En documentación y comunidad, las dos publican casi todo en inglés. LangChain tiene mucho más material de terceros en español, tutoriales y vídeos incluidos, pero buena parte está desactualizado por los cambios de API, así que copiar código de un tutorial antiguo es una fuente habitual de frustración. Verifica siempre contra la documentación oficial y contra la versión que tienes instalada, sobre todo si el ejemplo tiene más de unos meses.',
+        ],
+      },
+      {
+        title: 'Mezclarlas en el mismo proceso es mala idea',
+        paragraphs: [
+          'Usar las dos dentro del mismo servicio suele salir mal: duplicas abstracciones que hacen lo mismo, arrastras dos árboles de dependencias que compiten por las mismas versiones y depurar se vuelve incómodo. Lo que sí tiene sentido es separarlas por responsabilidad y por proceso: Haystack desplegado como servicio de búsqueda y recuperación con su propia API, y un agente construido con LangGraph que lo consume como una herramienta más entre otras. Cada uno hace lo que hace bien y la frontera entre ambos es una llamada de red, no un import.',
+        ],
+      },
+    ],
     faqs: [
       {
         question: '¿Cuál es mejor, LangChain o Haystack?',
@@ -3493,6 +5133,49 @@ export const comparisons: Comparison[] = [
       'No tienes un SOC propio y quieres apoyarte en servicios gestionados maduros.',
       'Operas en una gran organización o en un sector muy regulado.',
       'Priorizas el reconocimiento y la trayectoria del proveedor sobre el coste.',
+    ],
+    sections: [
+      {
+        title: 'Autonomía del agente frente a inteligencia en la nube',
+        paragraphs: [
+          'CrowdStrike construyó su producto alrededor de la nube y del dato: un agente ligero que envía telemetría a una plataforma que correlaciona a escala, apoyada en un negocio de inteligencia de amenazas y en servicios con equipo humano detrás. Su apuesta es que el valor está en ver mucho y en tener analistas que entiendan lo que ven. SentinelOne apostó por la autonomía del propio endpoint: detección y respuesta ejecutadas en la máquina, con capacidad de actuar aunque esté sin conexión, y con reversión de cambios en entornos Windows.',
+          'Esa diferencia de diseño se traduce en encajes distintos. CrowdStrike rinde donde la conectividad es buena, el volumen de telemetría es un activo y se valora el servicio humano de caza gestionada y respuesta a incidentes. SentinelOne encaja mejor donde hay equipos que pasan tiempo desconectados, entornos industriales o remotos, y organizaciones que prefieren depender menos de un centro de operaciones externo. No es que uno detecte y el otro no: es dónde ocurre la decisión y qué pasa cuando el enlace con la nube falla.',
+          'En mercado también se comportan distinto. CrowdStrike tiene más presencia en grandes cuentas y más peso de marca en decisiones que se toman a nivel de dirección, lo que le da ventaja cuando la compra la firma alguien que no es técnico. SentinelOne suele aparecer como alternativa competitiva en las renovaciones y es más flexible en negociación. Ambos han ampliado bastante más allá del endpoint, hacia identidad, cargas en la nube y gestión de datos de seguridad, así que la comparación ya no es solo de antivirus avanzado.',
+        ],
+      },
+      {
+        title: 'Detectar es la parte fácil: lo difícil es investigar y contener',
+        paragraphs: [
+          'En detección pura, las evaluaciones públicas sobre el marco MITRE ATT&CK sitúan a las dos plataformas en la parte alta del mercado desde hace años. La diferencia práctica no está en si ven el ataque, sino en cuánto contexto te dan después y cuánto ruido genera cada una en el día a día. CrowdStrike destaca en el trabajo de investigación: el árbol de procesos, el enriquecimiento con inteligencia sobre el actor y la búsqueda retrospectiva sobre telemetría acumulada convierten una alerta en una historia comprensible con menos pasos.',
+          'SentinelOne destaca en el otro extremo, el de la respuesta automática: contener el equipo y revertir los cambios de un cifrado sin que intervenga nadie es especialmente valioso cuando no hay analista de guardia a las tres de la mañana. Su consola ha mejorado mucho, pero la investigación profunda todavía suele exigir más pasos manuales. La regla honesta es esta: con un centro de operaciones propio funcionando en continuo, la ventaja de CrowdStrike se nota; sin él, la autonomía de SentinelOne compensa más de lo que compensa el mejor panel.',
+        ],
+        bullets: [
+          'Equipos portátiles a menudo sin conexión o entornos industriales: SentinelOne',
+          'Organización con SOC propio y necesidad de investigación profunda: CrowdStrike',
+          'Sin equipo de seguridad interno y con presupuesto para servicio gestionado: CrowdStrike',
+          'Prioridad en contención y reversión automáticas ante ransomware: SentinelOne',
+        ],
+      },
+      {
+        title: 'Precio por endpoint y la letra pequeña de los módulos',
+        paragraphs: [
+          'Los dos venden por endpoint y por módulos, y ahí está el detalle que descoloca los presupuestos: el paquete de entrada cubre la protección, pero la retención de telemetría, la caza gestionada, la protección de identidad o la cobertura de cargas en la nube se facturan aparte. CrowdStrike tiende a un precio de lista más alto y a una escalera de paquetes bien marcada; SentinelOne suele ser más agresivo en la negociación y ha incluido más retención en sus niveles, lo que en algunos escenarios cambia bastante el total.',
+          'Para comparar de verdad hay que poner sobre la mesa el coste por endpoint a tres años con la retención que realmente necesitas para cumplir tus obligaciones, si el servicio gestionado va incluido o es un contrato aparte, y qué ocurre cuando crezcas o adquieras otra empresa. Un apunte que suele decidir mejor que el precio: en una organización sin equipo de seguridad propio, contratar caza gestionada cambia el resultado mucho más que la diferencia entre los dos agentes. Con SOC propio, mira el coste de ingesta de telemetría.',
+        ],
+      },
+      {
+        title: 'Qué esperar en España: idioma, soporte y cumplimiento',
+        paragraphs: [
+          'Las consolas y la documentación técnica de ambas están mayoritariamente en inglés, con traducción parcial de la interfaz y alertas que llegan en inglés. Para un equipo técnico español esto pesa menos de lo que parece, porque el vocabulario de seguridad ya es anglosajón, pero sí importa en el soporte: conviene verificar por contrato si la atención en español y en horario europeo va incluida o si depende del nivel contratado, porque durante un incidente esa diferencia se nota mucho.',
+          'Dos cosas más que en España deciden implantaciones. La primera es el socio: aquí el despliegue suele ir a través de distribuidor o de un proveedor de servicios gestionados, y la calidad de ese socio determinará tu experiencia más que la diferencia entre los productos. La segunda es el cumplimiento: revisa en qué región se aloja y procesa la telemetría, qué retención ofrece y cómo encaja con el RGPD y, en administración pública, con el Esquema Nacional de Seguridad. Pide esos detalles por escrito antes de firmar.',
+        ],
+      },
+      {
+        title: 'Aquí sí hay que elegir uno',
+        paragraphs: [
+          'Es de los pocos casos donde la respuesta honesta es no convivir. Dos agentes de detección y respuesta en el mismo equipo se interfieren: compiten por los mismos ganchos del sistema, degradan el rendimiento y generan conflictos de exclusiones que acaban dejando huecos justo donde creías estar más protegido. La única convivencia razonable es transitoria, durante una migración, por lotes de equipos y con las exclusiones mutuas configuradas y un plazo cerrado. Lo que sí tiene sentido es combinar el EDR con capas distintas, como correo, identidad o un SIEM independiente.',
+        ],
+      },
     ],
     faqs: [
       {
@@ -3573,6 +5256,52 @@ export const comparisons: Comparison[] = [
       'Prefieres una herramienta de detección fuerte que se integre con tu SIEM, EDR y SOAR ya existentes',
       'Quieres apoyar la caza de amenazas (threat hunting) con señales explicables y ligadas a tácticas conocidas',
     ],
+    sections: [
+      {
+        title: 'La diferencia de fondo: aprender lo normal frente a modelar al atacante',
+        paragraphs: [
+          'Darktrace parte de una premisa: cada red tiene un patrón de vida propio y todo lo que se desvía de él merece una mirada. Su motor aprende sin supervisión el comportamiento habitual de cada dispositivo y usuario, y señala la anomalía aunque nadie la haya visto antes. Vectra AI parte de la premisa contraria: los ataques, por variados que sean, dejan comportamientos reconocibles, y lo que hay que modelar es la conducta del adversario. Uno busca lo raro; el otro busca lo malo, y esa filosofía condiciona todo lo demás.',
+          'Esa decisión se nota en el producto. Darktrace ha crecido a lo ancho: red, correo, nube, endpoint y entornos industriales, con respuesta autónoma capaz de cortar una conexión sin que intervenga nadie. Vectra ha crecido a lo hondo en un terreno concreto, la detección en red y sobre todo en identidad, con el objetivo de entregar al analista pocas señales bien priorizadas. Darktrace se diseñó para organizaciones que no tienen un SOC maduro y necesitan que la herramienta actúe; Vectra asume que hay alguien al otro lado que va a investigar lo que le llegue.',
+          'De ahí sale la pregunta que de verdad decide la compra: cuánta capacidad de análisis tienes en casa. Si es poca, la contención automática de Darktrace tapa un hueco real, aunque tendrás que asumir que la herramienta bloquee cosas sin preguntar. Si ya tienes analistas y lo que falta es tiempo, el enfoque de Vectra rinde más por euro invertido porque ataca justo el cuello de botella.',
+        ],
+      },
+      {
+        title: 'Ruido, contexto y trabajo real del analista',
+        paragraphs: [
+          'El criterio decisivo no es cuántas amenazas detecta cada plataforma, sino cuánto trabajo genera confirmarlas. Darktrace produce anomalías, y una anomalía no es un incidente: un servidor que habla con un destino nuevo puede ser una exfiltración o un despliegue del martes. En entornos que cambian mucho, el modelo se reajusta y ese periodo produce ruido. Vectra entrega menos alertas y con una hipótesis de ataque asociada, lo que acorta la investigación a cambio de ser más ciego ante lo que no encaja en sus modelos.',
+          'En la práctica cada uno gana en escenarios distintos. Una cuenta corporativa comprometida que empieza a abusar de permisos delegados y aplicaciones OAuth es terreno de Vectra, que ha invertido mucho en identidad y en el ecosistema Microsoft. Un dispositivo industrial o un equipo poco estándar que se comporta de forma inédita, o un movimiento lateral que ninguna firma describe, es terreno de Darktrace. Y hay un escenario que ambos comparten y ninguno resuelve del todo: el atacante que se mueve despacio y usa herramientas legítimas.',
+        ],
+        bullets: [
+          'Cuenta de Microsoft 365 comprometida, abuso de OAuth o escalada de privilegios en el directorio: ventaja clara de Vectra AI.',
+          'Comportamiento nunca visto en red, entornos OT o dispositivos no gestionados, y necesidad de contención automática: ventaja clara de Darktrace.',
+        ],
+      },
+      {
+        title: 'Estructura de coste: licencia, módulos y personal',
+        paragraphs: [
+          'Ninguna publica precios: son ventas empresariales a medida y el importe depende del tamaño del entorno y de lo que decidas cubrir. La diferencia está en cómo se construye la factura. Darktrace se articula por módulos —red, correo, nube, endpoint— y su propuesta de valor mejora cuando contratas varios, porque la correlación entre superficies es su argumento; el problema es que el coste crece en la misma dirección. Vectra concentra el gasto en detección de red e identidad, con un alcance más acotado y, por tanto, más fácil de comparar contra lo que ya tienes.',
+          'El coste que casi nadie mete en la hoja de cálculo es el de personal. Darktrace puede reducir la necesidad de analistas porque contiene sola, pero exige afinado durante los primeros meses y alguien que revise qué está bloqueando. Vectra rinde si ya pagas un equipo que investiga: baja el tiempo por alerta, no la plantilla. Para una empresa mediana española sin SOC propio, la comparación honesta no es Darktrace contra Vectra, sino cualquiera de las dos contra un servicio gestionado externo.',
+        ],
+      },
+      {
+        title: 'Qué pasa cuando el idioma es el español',
+        paragraphs: [
+          'En la parte de red el idioma es irrelevante: los paquetes no hablan castellano. Donde sí importa es en el correo, y ahí Darktrace tiene producto propio de análisis de email mientras Vectra se centra en otras superficies. El matiz honesto es que los modelos que detectan suplantación y fraude del CEO rinden algo peor en español que en inglés, sobre todo con correos comerciales y facturas. Si tu principal vector es el correo en castellano, mídelo en la prueba de concepto.',
+          'El segundo frente es operativo. Las dos consolas están en inglés y la documentación también; lo que cambia es el soporte y la red de partners, donde Darktrace lleva más tiempo con presencia comercial en España. Para informes de cumplimiento —ENS, NIS2, auditorías internas— ninguna de las dos te va a entregar el documento redactado en castellano tal y como lo pide un comité: la exportación de datos es aprovechable, la redacción la pones tú o tu integrador.',
+        ],
+      },
+      {
+        title: 'Convivir con las dos: cuándo tiene sentido y cuándo es tirar el dinero',
+        paragraphs: [
+          'Se solapan mucho en detección de red, así que pagar las dos licencias completas es difícil de justificar ante cualquier dirección financiera. La única combinación defensible es por superficie: Vectra cubriendo identidad y nube, donde es más quirúrgico, y Darktrace cubriendo correo y entornos industriales, donde tiene más recorrido. Eso exige un SIEM común y que alguien defina qué alerta manda cuando las dos hablan del mismo host; si no, duplicas trabajo en lugar de repartirlo.',
+          'Lo más razonable es elegir una y completarla con lo que ninguna sustituye: un EDR sólido en los puestos y una gestión de identidad decente. Ninguna de estas plataformas es un antivirus ni un control de accesos, y venderlas como capa única se paga en el primer incidente. Si el presupuesto aprieta, cubre bien una superficie antes que todas a medias.',
+        ],
+        bullets: [
+          'Reparto viable: Vectra en identidad y nube, Darktrace en correo y OT, con un SIEM que unifique.',
+          'Reparto inviable: las dos vigilando el mismo tráfico de red esperando que se validen entre sí.',
+        ],
+      },
+    ],
     faqs: [
       {
         question: '¿Cuál es mejor, Darktrace o Vectra AI?',
@@ -3651,6 +5380,48 @@ export const comparisons: Comparison[] = [
       'Necesitas hacer preguntas que cruzan información de varios documentos a la vez',
       'Quieres una API para integrar la consulta de PDFs en tu propia aplicación o flujo interno',
       'Trabajas en equipo y necesitas que la documentación esté organizada y accesible, no suelta',
+    ],
+    sections: [
+      {
+        title: 'Una herramienta de un solo uso frente a una biblioteca de documentos',
+        paragraphs: [
+          'La diferencia de fondo no está en cómo responden, sino en qué pasa con el documento después de preguntarle. ChatPDF está diseñado como un gesto único: arrastras el archivo, preguntas, obtienes respuesta y cierras la pestaña. Toda su interfaz empuja hacia esa inmediatez y por eso apenas hay que aprender nada. AskYourPDF está diseñado como repositorio: los documentos se quedan, se organizan en carpetas, se consultan juntos y se vuelve a ellos semanas después. Uno resuelve un momento; el otro construye un archivo consultable.',
+          'Esa decisión de producto explica el resto. AskYourPDF ha añadido lo que un repositorio necesita —chat sobre varios documentos a la vez, extensión de navegador, API para integrarlo en otra cosa— y con ello ha ganado superficie y también complejidad. ChatPDF ha resistido esa tentación y sigue siendo casi trivial de usar, lo que en la práctica significa que un compañero al que se lo enseñas lo entiende en treinta segundos.',
+          'Elegir bien depende de una pregunta simple: ¿vas a volver a este PDF? Si la respuesta es no, cualquier estructura que te obligue a registrar, clasificar y mantener documentos es fricción sin retorno. Si la respuesta es sí, y sobre todo si vas a acumular decenas de archivos del mismo tema, ChatPDF se queda corto muy rápido porque cada consulta empieza de cero.',
+        ],
+      },
+      {
+        title: 'Dónde falla la respuesta: documentos largos, tablas y varias fuentes',
+        paragraphs: [
+          'Ambas herramientas hacen lo mismo por debajo: trocean el PDF, lo indexan y recuperan los fragmentos que parecen relevantes antes de responder. La calidad no depende tanto del modelo como de esa recuperación, y ahí es donde se separan. Con un texto continuo de unas decenas de páginas —un artículo, un manual, un informe— los dos responden bien y las diferencias son cosméticas. El problema aparece cuando la respuesta obliga a juntar información de capítulos distantes, o vive en un anexo tabulado, o depende de una nota al pie.',
+          'En esos casos AskYourPDF tiene ventaja por dos motivos: puede buscar en varios documentos a la vez y es más explícito citando de dónde sale cada afirmación, lo que permite verificar sin releer todo. ChatPDF gana cuando el objetivo es entender rápido un único documento. Y hay un límite que comparten y conviene decir claro: con PDF escaneados sin capa de texto, con gráficos y con tablas complejas, ninguno de los dos es fiable. Si vas a tomar una decisión sobre una cifra, ábrela en el original.',
+        ],
+        bullets: [
+          'Entender un informe recién recibido en diez minutos: ChatPDF.',
+          'Cruzar varios pliegos, contratos o informes trimestrales buscando una cláusula concreta: AskYourPDF.',
+        ],
+      },
+      {
+        title: 'Qué sale más a cuenta según cuánto leas',
+        paragraphs: [
+          'Los dos funcionan con el mismo esquema freemium, y los límites del plan gratuito son los que de verdad deciden: número de páginas por documento, documentos al día y preguntas por documento. Para un uso esporádico, el nivel gratuito de ChatPDF resuelve sin pagar nada y es difícil justificar una suscripción. En cuanto el uso se vuelve diario y los archivos superan las páginas permitidas, la cuota mensual entra en juego en ambos, y ahí lo que cambia el cálculo es que AskYourPDF ofrece API: si vas a integrarlo en un flujo interno, la comparación deja de ser entre dos webs.',
+          'Hay un tercer camino que casi nadie plantea y que a partir de cierto volumen sale mejor: montar tu propio sistema de recuperación sobre los documentos. Pagas tokens en lugar de suscripción, controlas dónde se guarda todo y no dependes de los límites de nadie. No compensa para diez PDF al mes, sí compensa cuando son cientos y hay datos sensibles de por medio. Antes de subir documentos con información confidencial a cualquiera de las dos, mira la política de retención: es un requisito, no una precaución.',
+        ],
+      },
+      {
+        title: 'Preguntar en español sobre documentos en inglés',
+        paragraphs: [
+          'Las dos responden con soltura en castellano porque el modelo que redacta es multilingüe. El problema no está en generar, sino en recuperar. Si el documento está en inglés y tú preguntas en español, la búsqueda semántica tiene que cruzar idiomas y eso degrada la selección de fragmentos: a veces trae párrafos que solo se parecen de lejos y la respuesta sale con lagunas. El truco práctico es formular la pregunta con los términos del documento, en su idioma, y pedir después la respuesta en español.',
+          'Con documentación española —normativa, convenios, pliegos de contratación, textos del BOE— las dos se defienden razonablemente, aunque tienden a suavizar el lenguaje jurídico y a parafrasear donde hay que citar literal. Para trabajo administrativo o legal, úsalas para localizar el punto exacto del documento y luego lee ese punto tú. La interfaz de ambas está principalmente en inglés, algo que en un equipo poco técnico pesa más de lo que parece.',
+        ],
+      },
+      {
+        title: 'Usar las dos sin duplicar esfuerzo',
+        paragraphs: [
+          'No hay ningún motivo técnico para elegir solo una: son webs, los planes gratuitos no se estorban y el original siempre lo sigues teniendo tú, así que no hay dependencia real de ninguna. El reparto natural es por vida útil del documento. ChatPDF para el archivo que te acaba de llegar y quieres entender hoy; AskYourPDF para el corpus estable —normativa de tu sector, documentación de producto, bibliografía de una investigación— que vas a consultar durante meses.',
+          'Lo que no compensa es pagar las dos suscripciones. Si el uso se ha vuelto serio, elige la que encaje con tu patrón y deja la otra en el plan gratuito para consultas puntuales. Y mantén una regla fija por encima de cualquier herramienta: lo que vayas a citar, firmar o enviar a un cliente, verifícalo en el PDF original. Ninguna de las dos está pensada para ser la última palabra.',
+        ],
+      },
     ],
     faqs: [
       {
@@ -3731,6 +5502,44 @@ export const comparisons: Comparison[] = [
       'Necesitas una demostración rápida para enseñar el concepto a un equipo o a un cliente',
       'Tus tareas son exploratorias y cortas, no automatizaciones que deban funcionar en producción',
     ],
+    sections: [
+      {
+        title: 'Dos caminos distintos desde la misma idea original',
+        paragraphs: [
+          'Los dos proyectos nacieron del mismo entusiasmo de 2023: dar un objetivo a un modelo y dejar que se organice solo. Lo interesante es que han evolucionado en direcciones opuestas. AutoGPT dejó de ser un script autónomo y se ha convertido en una plataforma con constructor visual de flujos, bloques reutilizables, servidor propio y ejecución programada. AgentGPT se quedó cerca del concepto original: escribes una meta en el navegador, ves cómo el agente la descompone en tareas y las va tachando en pantalla.',
+          'Esa divergencia responde a que cada uno aprendió una lección distinta del experimento. AutoGPT concluyó que la autonomía pura no es fiable y que hace falta estructura, así que ahora te pide que definas el flujo. AgentGPT concluyó que el valor estaba en la demostración inmediata, y ha optimizado la barrera de entrada por encima de todo. Ninguna de las dos posturas es tonta; simplemente sirven a personas distintas.',
+          'En términos prácticos, la diferencia se nota antes de escribir una sola línea. AgentGPT arranca con un navegador y una clave de API, y en cinco minutos ya estás viendo ejecutarse el agente. AutoGPT, si lo quieres en serio, implica contenedores, variables de configuración, actualizaciones periódicas y alguien que lo mantenga cuando algo se rompa. Es la diferencia entre probar una idea y montar infraestructura, y conviene tenerlo claro antes de invertir una tarde en la instalación para descubrir que solo querías curiosear.',
+        ],
+      },
+      {
+        title: 'Fiabilidad: qué pasa cuando la tarea dura más de cinco pasos',
+        paragraphs: [
+          'El criterio que decide entre estas dos herramientas es cuántas veces terminan una tarea con algo aprovechable. Los agentes en bucle comparten un fallo estructural conocido: se atascan repitiendo el mismo paso, dan por buenas conclusiones que no han verificado y consumen tokens sin avanzar. AgentGPT lo enseña muy bien porque todo ocurre a la vista, y esa transparencia es su mejor virtud didáctica; el problema es que suele producir un plan convincente y unos resultados superficiales, con más descripción de lo que haría que ejecución real.',
+          'AutoGPT, en su versión actual de flujos, mitiga el problema por la vía menos glamurosa: reduciendo la autonomía. Si tú defines los bloques, el orden y las condiciones, el sistema falla mucho menos, aunque ya no sea el agente mágico del vídeo original. Para una tarea repetible y con disparador llega a producir algo utilizable. Para una investigación abierta con fuentes citadas, ninguno de los dos está a la altura de lo que hace hoy un buen chat con navegación.',
+        ],
+      },
+      {
+        title: 'Coste real: el software es gratis, el bucle no',
+        paragraphs: [
+          'Los dos son de código abierto, así que la licencia cuesta cero y esa parte de la comparación se agota rápido. El gasto real tiene dos componentes: los tokens del modelo que pongas detrás y el sitio donde se ejecute. AgentGPT ofrece una versión hospedada con límites de ejecuciones para probar sin montar nada, y también se puede autoalojar. AutoGPT está pensado para autoalojarse, con el coste de servidor y mantenimiento que eso implica, además de una oferta gestionada para quien no quiera administrarlo.',
+          'El componente que descoloca presupuestos es el consumo de tokens. Un agente que itera arrastra el historial en cada llamada, de forma que el gasto no crece de manera lineal con la duración de la tarea. Es perfectamente posible quemar en una ejecución fallida lo que costaría resolver el mismo problema con tres prompts bien escritos. Antes de automatizar nada con estos sistemas, pon un límite de gasto en la API y calcula cuánto vale una ejecución completa: para muchos casos, la conclusión honesta es que el bucle autónomo no compensa.',
+        ],
+      },
+      {
+        title: 'Trabajar en castellano con agentes autónomos',
+        paragraphs: [
+          'Puedes escribir el objetivo en español y ambos lo entienden, porque quien razona es el modelo subyacente y no el framework. El problema es otro: los prompts internos de los dos proyectos están escritos en inglés, y eso arrastra la ejecución. Es habitual que el agente empiece en castellano, genere sus tareas intermedias en inglés y devuelva un resultado con los dos idiomas mezclados. La solución práctica es dejarlo explícito y repetido en el objetivo: indicar que todos los pasos intermedios y la salida final deben estar en español de España.',
+          'El segundo obstáculo es de mantenimiento. Documentación, incidencias en GitHub y comunidad están íntegramente en inglés, y eso pesa mucho más en AutoGPT, donde autoalojar significa que tarde o temprano tendrás que leer un hilo técnico para desatascar una actualización o entender por qué un bloque dejó de funcionar. AgentGPT, al usarse hospedado, evita casi toda esa exposición: si algo falla, cierras la pestaña. Para un equipo español sin perfil técnico dedicado, ese detalle decide más que cualquier comparación de funciones.',
+        ],
+      },
+      {
+        title: '¿Merece la pena mantener las dos?',
+        paragraphs: [
+          'No, porque resuelven lo mismo con distinto grado de ambición y no se complementan. Lo que sí tiene sentido es usarlas en orden. Empieza por AgentGPT durante media hora: es la forma más rápida y barata de comprobar si un agente autónomo aporta algo a tu caso concreto o si estás intentando resolver con un bucle lo que resolvería un flujo determinista. Esa validación cuesta muy poco y evita instalaciones inútiles.',
+          'Si la prueba sale bien y quieres llevarlo a producción, el salto natural no es necesariamente AutoGPT: puede serlo, por su constructor de flujos y sus integraciones, pero también merece mirar frameworks con más control como CrewAI o LangGraph, que asumen desde el principio que un sistema fiable necesita pasos definidos, reintentos y trazas. Ser honesto ayuda aquí: para la mayoría de tareas de empresa, hoy el agente completamente autónomo sigue siendo una demostración más que una herramienta.',
+        ],
+      },
+    ],
     faqs: [
       {
         question: '¿Cuál es mejor, AutoGPT o AgentGPT?',
@@ -3809,6 +5618,48 @@ export const comparisons: Comparison[] = [
       'Tu caso se describe de forma natural como un equipo con roles: investigador, redactor, revisor',
       'Prefieres un framework opinado que ya decide por ti cómo se orquestan las tareas',
       'Vas a modelar procesos de negocio y necesitas que otros compañeros entiendan el flujo al leerlo',
+    ],
+    sections: [
+      {
+        title: 'De dónde vienen y hacia dónde van',
+        paragraphs: [
+          'Más allá de la metáfora que cada uno usa, hay una diferencia de origen que explica casi todo. AutoGen sale de un entorno de investigación, y eso se nota en que su unidad central es la conversación: agentes que se pasan mensajes y un orquestador que decide quién habla después. El comportamiento del sistema es emergente. CrewAI sale de una lógica de producto: la unidad es la tarea, con su descripción, su responsable y su salida esperada, y el proceso se declara antes de ejecutar nada.',
+          'La consecuencia práctica es que AutoGen puede sorprenderte, para bien y para mal, mientras que CrewAI produce sistemas que puedes explicar en una reunión sin abrir el código. Si tienes que justificar ante un cliente o un comité por qué el sistema hizo lo que hizo, la estructura de tareas y responsables de CrewAI se defiende sola. AutoGen, en cambio, te obliga a explicar una conversación, y eso es mucho más difícil de convertir en un diagrama que alguien de negocio acepte sin más preguntas.',
+          'Conviene mirar también la trayectoria, porque apostar por un framework es apostar a dos o tres años. CrewAI se apoya en una capa comercial alrededor del proyecto abierto: la dirección del producto está clara, pero sujeta a intereses de empresa. AutoGen ha pasado por reescrituras profundas de su núcleo y por reorganizaciones dentro del ecosistema de Microsoft, lo que aporta respaldo e introduce el riesgo de migrar cuando la estrategia cambie.',
+        ],
+      },
+      {
+        title: 'Depurar el sistema cuando falla',
+        paragraphs: [
+          'Montar un sistema multiagente es la parte fácil; lo caro es entender por qué un día dejó de funcionar, y ahí la diferencia entre ambos es grande. En CrewAI los fallos están localizados: una tarea concreta ha devuelto algo que no encaja, tienes su entrada, su salida y el rol que la ejecutó, y la corrección suele ser ajustar la descripción de esa tarea o el objetivo del agente. Es un ciclo corto que un desarrollador sin experiencia previa en agentes sigue sin ayuda.',
+          'En AutoGen los fallos son emergentes y se investigan leyendo transcripciones. El patrón clásico es una conversación que no converge: dos agentes se dan la razón mutuamente, declaran resuelto el problema y terminan sin haber producido nada útil. Detectarlo exige criterios de finalización bien pensados y bastante lectura. A cambio, hay un escenario donde ese mismo bucle conversacional es exactamente la herramienta correcta: escribir código, ejecutarlo, leer el error y volver a intentarlo hasta que pase la prueba. Ahí AutoGen gana con claridad y CrewAI se queda forzado.',
+        ],
+        bullets: [
+          'Cadena investigación, redacción y revisión con entregable definido: CrewAI llega antes y se mantiene mejor.',
+          'Resolución iterativa con ejecución de código y corrección de errores hasta converger: AutoGen encaja de forma natural.',
+        ],
+      },
+      {
+        title: 'El coste que no está en la licencia: número de llamadas al modelo',
+        paragraphs: [
+          'Dado que ambos son gratuitos, la comparación económica se juega en cuántas llamadas al modelo genera cada arquitectura. Un flujo secuencial de CrewAI con cuatro tareas produce un número acotado de llamadas y por tanto un coste presupuestable por ejecución. Una conversación de grupo en AutoGen crece de forma menos predecible: cada turno arrastra el historial acumulado, y si el criterio de parada es laxo, el gasto se dispara justo en las ejecuciones que peor resultado dan. Con modelos caros, esa diferencia separa céntimos de euros por ejecución.',
+          'El segundo eje es la capa comercial. CrewAI ofrece una plataforma gestionada de pago para desplegar y observar los sistemas, de forma que pagas por no montar infraestructura; tiene sentido para equipos pequeños sin plataforma propia. AutoGen no tiene un equivalente propio equiparable, así que la observabilidad, las colas y el despliegue los resuelves con herramientas externas que ya tengas. Si vuestro equipo ya opera servicios en producción, esa libertad no cuesta nada; si no, el tiempo de montarlo todo es el coste oculto real.',
+        ],
+      },
+      {
+        title: 'Controlar el idioma de una ejecución en español',
+        paragraphs: [
+          'Los dos frameworks son neutrales respecto al idioma: quien escribe en castellano es el modelo. La diferencia está en cuánto control tienes sobre que se mantenga. En CrewAI el idioma se fija donde ya estás escribiendo, en el objetivo del agente y en la salida esperada de cada tarea, y esa instrucción se propaga por toda la ejecución. En AutoGen los agentes conversan entre ellos y es frecuente que los turnos intermedios deriven al inglés aunque el resultado final salga en español.',
+          'Eso importa más de lo que parece cuando la traza tiene que ser auditable. Si vas a enseñar a un cliente o a un responsable de cumplimiento cómo llegó el sistema a una conclusión, un registro medio en inglés resta credibilidad. Con CrewAI da menos guerra conseguir trazas coherentes en castellano; con AutoGen hay que insistir en el mensaje de sistema de cada agente. La documentación y los ejemplos de ambos están en inglés, sin excepciones relevantes.',
+        ],
+      },
+      {
+        title: 'Combinarlos por capas en lugar de por proyecto',
+        paragraphs: [
+          'Meter los dos en el mismo proceso no aporta nada, pero hay un reparto que sí se sostiene: separarlos por nivel. CrewAI como orquestador de negocio, que es donde brilla su legibilidad, y un subsistema de AutoGen invocado como herramienta cuando aparece una parte que exige iteración con código —generar un script, ejecutarlo, corregirlo—. El orquestador no necesita saber cómo se resolvió por dentro, solo recibe el resultado.',
+          'Ese montaje tiene un precio: dos dependencias, dos modelos mentales y dos sitios donde mirar cuando algo falla. Solo compensa si el subsistema aporta algo que el otro no puede hacer sin retorcerse. Para el resto de casos, la recomendación es aburrida pero acertada: elige uno por proyecto según si necesitas resultados legibles o exploración conversacional, y dedica el esfuerzo ahorrado a las herramientas que los agentes van a usar, que es donde de verdad se gana o se pierde la calidad del sistema.',
+        ],
+      },
     ],
     faqs: [
       {
@@ -3889,6 +5740,48 @@ export const comparisons: Comparison[] = [
       'Necesitas puntos de aprobación humana en medio del proceso y poder reanudar donde se quedó',
       'Ya trabajas en el ecosistema LangChain y quieres aprovechar sus herramientas de observabilidad',
     ],
+    sections: [
+      {
+        title: 'Un equipo de trabajo frente a una máquina de estados',
+        paragraphs: [
+          'CrewAI ofrece una abstracción sobre la idea de equipo: hay roles, hay tareas y hay un proceso que las encadena. LangGraph ofrece una abstracción mucho más básica y por eso más potente: un estado compartido, nodos que lo modifican y aristas que deciden a dónde ir después, incluidas aristas condicionales y ciclos. LangGraph no tiene opinión sobre qué es un agente; le da igual que un nodo sea un modelo, una función de Python o una llamada a tu API interna.',
+          'De ahí sale la asimetría que conviene entender: en LangGraph puedes construir algo equivalente a CrewAI, pero al revés no. Esa potencia se paga escribiendo más código y, sobre todo, pensando el flujo antes de programarlo. Con CrewAI describes qué quieres que haga cada rol; con LangGraph dibujas el grafo, decides qué viaja en el estado y qué condición lleva de un nodo a otro.',
+          'Por eso el público es distinto. CrewAI es para quien necesita enseñar un resultado esta semana y valora que el código se lea casi como una descripción del proceso de negocio. LangGraph es para quien va a poner el sistema en producción y sabe que va a necesitar reintentos, ramas, pausas para aprobación humana y capacidad de reanudar sin repetir trabajo. Es la diferencia entre una demostración convincente y un servicio que aguanta.',
+        ],
+      },
+      {
+        title: 'Control en producción: pausas, reintentos y reanudación',
+        paragraphs: [
+          'El criterio que decide este par es cuánto control necesitas sobre la ejecución. LangGraph incorpora de serie la persistencia del estado en puntos intermedios, y de ahí salen tres capacidades que en CrewAI hay que improvisar: parar el flujo para que una persona apruebe antes de un paso irreversible, retomar tras una caída sin rehacer lo ya hecho, y expresar bucles con condición explícita del tipo reintentar hasta que el validador dé el visto bueno, con un máximo de intentos. Son requisitos habituales en cuanto el sistema toca clientes o dinero.',
+          'CrewAI gana donde el flujo es lineal y el valor está en llegar rápido. Un proceso de investigación, redacción y revisión con un entregable claro se monta en una tarde y se entiende sin documentación. En cambio, cuando pides que ese mismo proceso se detenga a mitad, notifique a alguien, espere respuesta y continúe días después, empiezas a escribir alrededor del framework en lugar de con él. Ese es el momento de plantearse el cambio, y suele llegar antes de lo previsto.',
+        ],
+        bullets: [
+          'Prototipo de proceso de negocio para enseñar a un cliente: CrewAI, sin discusión, por tiempo de desarrollo.',
+          'Flujo con aprobación humana, reintentos controlados y reanudación tras fallo: LangGraph, por diseño.',
+        ],
+      },
+      {
+        title: 'Coste por ejecución frente a coste en horas',
+        paragraphs: [
+          'Los dos son de código abierto y ambos tienen su capa comercial alrededor: CrewAI con una plataforma gestionada para desplegar y supervisar, y LangGraph con la infraestructura de despliegue y el sistema de trazas del ecosistema LangChain. En los dos casos pagas por no montar tú la observabilidad y las colas, y en los dos casos puedes prescindir de ello si ya tienes plataforma. La factura de verdad, sin embargo, la ponen los tokens.',
+          'Ahí LangGraph tiende a salir más barato por ejecución, porque tú decides exactamente qué contexto viaja en el estado de un nodo al siguiente y cuántas llamadas al modelo hay. CrewAI arrastra prompts de rol y contexto de tareas anteriores por diseño, lo que resulta cómodo pero engorda cada llamada. La contrapartida es clara: CrewAI cuesta mucho menos en horas de desarrollo. La regla práctica es sencilla: si el sistema va a ejecutarse unas pocas veces al día, gana CrewAI porque el ahorro de tokens no paga el tiempo de ingeniería; si va a ejecutarse miles de veces, gana LangGraph.',
+        ],
+      },
+      {
+        title: 'Estrategia de idioma cuando el resultado va en español',
+        paragraphs: [
+          'En CrewAI el castellano se fija donde ya escribes: el contexto del rol y la salida esperada de cada tarea. Es cómodo y suele bastar. En LangGraph tienes que decidirlo tú en cada nodo o mediante instrucciones compartidas en el estado, lo cual es más trabajo pero abre una posibilidad que CrewAI no da con la misma limpieza: separar el idioma del razonamiento del idioma del resultado.',
+          'Ese patrón funciona bien en la práctica. Dejar que los nodos de análisis, búsqueda y verificación trabajen en inglés, donde los modelos suelen rendir algo mejor y donde está la mayor parte de la documentación técnica, y reservar un nodo final de redacción que produzca el texto en español de España con las convenciones que toquen. El resultado suele ser mejor que forzar castellano en toda la cadena, sobre todo en dominios técnicos. Si vas a producir contenido en español a escala, esa capacidad de control por nodo es un argumento real a favor de LangGraph.',
+        ],
+      },
+      {
+        title: 'Convivir, o migrar de uno al otro',
+        paragraphs: [
+          'Esta es una de las pocas combinaciones que se sostiene técnicamente: LangGraph como esqueleto del sistema, con su estado y su control de flujo, y una crew de CrewAI encapsulada dentro de un nodo cuando una parte del proceso encaja de verdad en la metáfora de equipo con roles. El grafo mantiene la persistencia y las aprobaciones; el nodo resuelve su parte. Funciona porque cada uno hace lo que mejor sabe y no compiten por el control.',
+          'Aun así, en un sistema pequeño sostener las dos abstracciones confunde más de lo que aporta. El camino más frecuente y más sano es el de migración: prototipar en CrewAI para validar que el proceso tiene sentido y que el resultado interesa a alguien, y reescribir en LangGraph cuando aparezcan los requisitos que obligan —persistencia, aprobación humana, control de coste—. Asumir desde el principio que el prototipo es desechable ahorra discusiones más adelante.',
+        ],
+      },
+    ],
     faqs: [
       {
         question: '¿Cuál es mejor, CrewAI o LangGraph?',
@@ -3968,6 +5861,44 @@ export const comparisons: Comparison[] = [
       'Necesitas informes de progreso por alumno y por grupo para evaluar de forma sostenida',
       'Tu centro ya usa un LMS o Google Classroom y quieres integrar la escritura en ese flujo',
     ],
+    sections: [
+      {
+        title: 'Corregir un texto no es lo mismo que enseñar a escribir',
+        paragraphs: [
+          'Aunque las dos aplican inteligencia artificial sobre texto, persiguen objetivos distintos y eso las coloca casi en categorías diferentes. Grammarly acompaña a una persona mientras escribe, en cualquier aplicación, mediante extensiones y teclado, y su medida de éxito es que el texto quede mejor ahora. Writable no corrige a nadie: organiza el trabajo de escritura dentro de un aula, con tareas asignadas, rúbricas, entregas, comentarios revisados por el docente y seguimiento del progreso a lo largo del curso.',
+          'La diferencia de fondo es a quién sirve el sistema. Grammarly optimiza el resultado; Writable persigue el aprendizaje, que es justo lo contrario de que la máquina haga el trabajo. Por eso Grammarly en un aula plantea un problema evidente: si el alumno acepta sugerencias que no entiende, el texto mejora pero no aprende nada, y el profesor evalúa a la herramienta.',
+          'Elegir entre las dos, por tanto, casi nunca es una decisión real. Un profesional que escribe informes no tiene ninguna razón para mirar Writable, y un centro educativo que quiere estructurar la escritura no encontrará en Grammarly ni asignaciones, ni rúbricas, ni panel de seguimiento del grupo. La comparación solo tiene sentido para un docente que se pregunta cuál de las dos ayuda de verdad a su clase.',
+        ],
+      },
+      {
+        title: 'Feedback inmediato frente a feedback con criterio',
+        paragraphs: [
+          'Como corrector puro, Grammarly es claramente superior: detecta más, sugiere mejor y el flujo de aceptar o rechazar de un clic es difícil de igualar. Sus indicaciones de tono, claridad y concisión funcionan bien en textos profesionales y ahorran revisiones. Lo que no hace es explicar por qué algo estaba mal de una forma que sirva para no repetirlo, ni relacionar la corrección con unos criterios de evaluación.',
+          'Writable trabaja al revés. Sus comentarios se anclan a los criterios de una rúbrica, pasan por la revisión del docente antes de llegar al alumno y quedan asociados a versiones sucesivas del mismo texto, de forma que se puede ver la evolución a lo largo de varios trabajos. Es más lento y menos brillante en la corrección concreta, pero responde a una pregunta que Grammarly ni se plantea: ¿este alumno escribe mejor que en octubre? Para un informe que hay que enviar hoy, Grammarly. Para una secuencia de redacciones evaluadas durante un trimestre, Writable.',
+        ],
+      },
+      {
+        title: 'Suscripción personal frente a licencia de centro',
+        paragraphs: [
+          'Las estructuras de precio son tan distintas como los productos. Grammarly funciona como freemium personal: las correcciones básicas están disponibles sin pagar y las funciones avanzadas de estilo, reescritura y generación quedan en el plan de pago, con modalidades por usuario para equipos y centros. Eso significa que cualquiera puede evaluarlo sin gastar nada y decidir después. Writable se contrata como licencia institucional, negociada por centro o por distrito, y no existe un plan individual que un profesor pueda pagarse para probar.',
+          'Esa diferencia decide quién debería mirar cada uno. Para un particular, un autónomo o una empresa, Grammarly es la única opción de las dos que tiene sentido, y muchas veces el nivel gratuito ya cubre lo necesario. Para un centro, el gasto de Writable no se justifica por la calidad de la corrección —donde no gana— sino por las horas de gestión y revisión que ahorra al profesorado y por tener el rastro de la evolución de cada alumno en un sitio. Si ese rastro no se va a usar, el coste no se sostiene.',
+        ],
+      },
+      {
+        title: 'El punto crítico para un centro español: el idioma',
+        paragraphs: [
+          'Aquí conviene ser directo, porque es lo que la comparativa anglosajona no dice. Grammarly es un producto construido alrededor del inglés: aunque maneje otros idiomas en algunas funciones generativas, su corrección gramatical y de estilo en castellano no está al nivel de herramientas pensadas para español, y para escribir en nuestro idioma existen alternativas mejores y más baratas. Usarlo como corrector de castellano es desaprovecharlo y arriesgarse a sugerencias flojas.',
+          'Writable va todavía más lejos en esa dependencia: está construido sobre estándares curriculares y textos en inglés estadounidense, de modo que en un centro español su utilidad se reduce prácticamente a las clases de inglés. No es un defecto del producto, es su público objetivo. Para un colegio o instituto que quiera estructurar la escritura en castellano, ninguna de las dos es la respuesta por defecto y conviene mirar soluciones locales antes de firmar nada.',
+        ],
+      },
+      {
+        title: 'El único escenario donde tiene sentido tenerlas juntas',
+        paragraphs: [
+          'Ese escenario es la enseñanza del inglés. Writable aporta la estructura —tarea, rúbrica, entrega, evaluación y seguimiento de la evolución— y Grammarly ayuda al alumno con la mecánica de la lengua mientras redacta, que es justo lo que más le cuesta a quien escribe en un idioma que no es el suyo. En una clase de inglés como lengua extranjera la combinación es coherente porque cada herramienta cubre una capa distinta del mismo problema: una organiza el proceso y la otra resuelve la fricción lingüística del borrador.',
+          'El riesgo hay que asumirlo de frente: si el alumno acepta correcciones sin comprenderlas, la rúbrica termina midiendo a Grammarly y no a quien firma el texto. Por eso lo razonable es separar los momentos, permitiendo el corrector en las fases de borrador y desactivándolo en la entrega evaluable, o pidiendo que el alumno justifique los cambios aceptados. Fuera de ese contexto educativo no hay solapamiento que gestionar: son herramientas de mundos distintos que rara vez se cruzan.',
+        ],
+      },
+    ],
     faqs: [
       {
         question: '¿Cuál es mejor, Grammarly o Writable?',
@@ -4046,6 +5977,48 @@ export const comparisons: Comparison[] = [
       'Te importa especialmente la tipografía y la coherencia cromática de la propuesta',
       'Quieres iterar sobre unas pocas ideas fuertes en lugar de navegar entre cientos de variantes',
       'Ya tienes resuelto el resto de tu identidad y solo te falta la marca gráfica',
+    ],
+    sections: [
+      {
+        title: 'Plataforma de marca frente a compra puntual',
+        paragraphs: [
+          'La diferencia de fondo entre estos dos generadores no está en el algoritmo, está en el modelo de negocio, y eso condiciona todo el producto. Looka trata el logo como la puerta de entrada a un kit de marca: una vez tienes el símbolo, la plataforma te genera tarjetas, cabeceras de redes, plantillas y variantes cada vez que las necesitas, a cambio de una suscripción. Brandmark trata el logo como un archivo: pagas una vez, descargas el paquete y no vuelves.',
+          'Esa decisión explica dónde ha invertido cada uno. Looka ha construido el ecosistema posterior —editor, aplicaciones, coherencia entre piezas— y por eso su resultado se ve más terminado y más fácil de aplicar. Brandmark ha invertido en la generación en sí: exploración tipográfica, combinaciones de fuentes y paletas de color con criterio, además de utilidades sueltas para comprobar disponibilidad de nombre o elegir colores.',
+          'El perfil de usuario, en consecuencia, es distinto. Looka encaja con quien está montando un negocio desde cero, no tiene diseñador ni presupuesto para contratarlo y va a necesitar producir piezas nuevas durante los próximos meses. Brandmark encaja con quien solo quiere un logo digno para un proyecto concreto, ya tiene resuelto el resto de su identidad y no está dispuesto a sumar otra cuota recurrente a una lista de suscripciones que probablemente ya es larga.',
+        ],
+      },
+      {
+        title: 'Qué logo sale de cada uno',
+        paragraphs: [
+          'Conviene decirlo antes que nada: ninguno dibuja un símbolo original. Ambos combinan iconos de librería con tipografías y color, y esa es su limitación estructural. Dentro de ese marco, Looka produce resultados más pulidos y consistentes, con el logo ya aplicado en mockups que ayudan a ver si funciona; el precio es que muchos resultados tienen un aire reconocible y acabas viendo logos primos hermanos en el mismo sector. Brandmark propone soluciones más tipográficas y con paletas más arriesgadas: acierta menos veces, pero cuando acierta se parece menos a lo de al lado.',
+          'En tareas concretas la ventaja cambia de lado. Un nombre largo o compuesto, habitual en servicios profesionales y consultoría, se resuelve mejor con el enfoque tipográfico de Brandmark, que no necesita apoyarse en un icono para funcionar. Un comercio electrónico o una aplicación, que van a necesitar icono, favicon y perfil coherentes desde el primer día, sacan más partido del kit de Looka. Y en los dos casos, antes de comprar: comprueba que ese icono no lo esté usando ya otra marca de tu sector.',
+        ],
+        bullets: [
+          'Nombre largo, sin icono claro, imagen sobria: Brandmark suele dar mejores propuestas.',
+          'Necesitas icono, favicon, redes y tarjetas coherentes ya: Looka ahorra días de trabajo.',
+        ],
+      },
+      {
+        title: 'Pago único frente a suscripción: cuál sale rentable',
+        paragraphs: [
+          'Las dos te dejan generar y ver resultados sin pagar, y cobran en el momento de descargar, así que puedes explorar ambas sin gastar nada. A partir de ahí las estructuras divergen. Brandmark vende paquetes de una sola vez, con niveles según los formatos y los derechos incluidos, y ahí termina la relación. Looka combina la compra del logo con una suscripción anual que da acceso al editor y al kit de marca; cuando dejas de pagar, conservas lo descargado pero pierdes la capacidad de seguir generando piezas nuevas.',
+          'La rentabilidad depende de una sola pregunta: cuántas piezas vas a necesitar el primer año. Si solo quieres el logo y sus vectores, Brandmark sale más barato y no genera compromiso. Si vas a ir pidiendo cabeceras, tarjetas, plantillas y adaptaciones cada pocas semanas, el kit de Looka cuesta menos que encargarlas y menos aún que hacerlas mal tú. Y hay un tercer escenario que hay que nombrar: si la marca es el activo principal del negocio, el presupuesto correcto no es ninguno de los dos, sino un diseñador que trabaje sobre tu posicionamiento.',
+        ],
+      },
+      {
+        title: 'Nombres en español: tildes, eñes y palabras largas',
+        paragraphs: [
+          'Los dos generadores componen a partir del nombre que escribes, así que el idioma influye más de lo que parece. Los nombres en castellano tienden a ser más largos que los anglosajones y muchos llevan tilde o eñe, y las composiciones están calibradas con nombres cortos en inglés. El resultado típico es que la tilde queda demasiado cerca del icono, que la versión horizontal se estira y pierde proporción, o que en tamaños pequeños el acento desaparece. Revisa el logo en tamaño favicon antes de comprarlo, no después.',
+          'El otro punto es el contenido acompañante. Las sugerencias de eslogan, las descripciones de sector y buena parte de los ejemplos están pensados para el mercado anglosajón, y traducidos literalmente suenan raros; casi siempre es mejor dejar el eslogan vacío y escribirlo tú. La interfaz y el soporte funcionan en inglés en ambos productos, aunque Looka tiene parte de su web traducida, y a la hora de reclamar o pedir un cambio esa asimetría se nota.',
+        ],
+      },
+      {
+        title: 'Probar en las dos y comprar en una',
+        paragraphs: [
+          'Como generar es gratis en ambas y los estilos que producen son distintos, la estrategia sensata es pasar el nombre por las dos antes de decidir nada. En una tarde tienes decenas de propuestas de dos motores con criterios estéticos diferentes, y eso vale más que la opinión de cualquier comparativa. Un reparto que funciona bien: usar Brandmark para explorar dirección tipográfica y paleta de color, y llevar esa dirección ya decidida a Looka para producir el kit completo.',
+          'Lo que no tiene ningún sentido es pagar en las dos por el mismo logo: son productos sustitutivos en el momento de la compra. Y sea cual sea la elegida, exige siempre el archivo vectorial en el paquete que compres. Sin SVG o EPS, el primer proveedor que te pida el logo para imprimir o para una valla te obligará a rehacerlo, y ese será el pago real que no habías presupuestado.',
+        ],
+      },
     ],
     faqs: [
       {

--- a/src/data/discontinued.ts
+++ b/src/data/discontinued.ts
@@ -1,0 +1,29 @@
+export type DiscontinuedTool = {
+  /** Qué pasó, en una frase, para mostrarlo en la ficha. */
+  note: string;
+  /** Fuente donde se puede comprobar. */
+  sourceUrl: string;
+};
+
+/**
+ * Herramientas del catálogo que han cerrado o están en proceso de cierre.
+ *
+ * No las borramos: la gente sigue buscándolas y una ficha que explica que
+ * cerró y a dónde ir después es más útil que un 404. Pero se marcan con un
+ * aviso y se quedan fuera de las secciones de recomendación.
+ */
+export const discontinuedTools: Record<string, DiscontinuedTool> = {
+  'Play.ht': {
+    note: 'Play.ht dejó de funcionar tras la adquisición del equipo de PlayAI por parte de Meta en julio de 2025. La API se cortó ese mismo mes y la plataforma se apagó el 31 de diciembre de 2025. Su dominio ya no resuelve.',
+    sourceUrl: 'https://techcrunch.com/2025/07/22/meta-acquires-voice-startup-play-ai/',
+  },
+  Phind: {
+    note: 'Phind cerró el 16 de enero de 2026, sin periodo de transición. Los usuarios pudieron descargar su historial hasta el 30 de enero y los suscriptores de pago recibieron un reembolso proporcional. El equipo señaló que los grandes modelos habían absorbido su caso de uso al integrar búsqueda web y programación.',
+    sourceUrl: 'https://www.aipedia.wiki/tools/phind/',
+  },
+  Sora: {
+    note: 'OpenAI anunció el cierre de Sora el 24 de marzo de 2026. La app y la web dejaron de funcionar el 26 de abril de 2026 y la API se apagó el 24 de septiembre de 2026. No es posible darse de alta ni generar vídeo con ella.',
+    sourceUrl:
+      'https://help.openai.com/en/articles/20001152-what-to-know-about-the-sora-discontinuation',
+  },
+};

--- a/src/data/tool-details.ts
+++ b/src/data/tool-details.ts
@@ -3,6 +3,9 @@ import type { ToolDetail } from '../types/tool';
 /**
  * Contenido de las fichas de herramienta (/herramienta/[slug]).
  * La clave es el nombre exacto de la herramienta en ai-tools.ts.
+ *
+ * El aviso de "consulta la web oficial" vive en la plantilla de la ficha,
+ * no aquí: repetido en cada entrada era la huella de contenido de plantilla.
  */
 export const toolDetails: Record<string, ToolDetail> = {
   ChatGPT: {
@@ -36,7 +39,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'El plan gratuito aplica límites de uso en horas de alta demanda',
     ],
     pricingNote:
-      'ChatGPT sigue un modelo freemium: hay un plan gratuito con acceso a las funciones básicas y límites de uso. Los planes individuales de pago suelen situarse en torno a los 20 $ al mes, con opciones superiores para equipos y empresas. El uso mediante API se factura aparte por consumo de tokens. Consulta su web para precios actualizados.',
+      'ChatGPT sigue un modelo freemium: hay un plan gratuito con acceso a las funciones básicas y límites de uso. Los planes individuales de pago suelen situarse en torno a los 20 $ al mes, con opciones superiores para equipos y empresas. El uso mediante API se factura aparte por consumo de tokens.',
     faqs: [
       {
         question: '¿Qué es ChatGPT y para qué sirve?',
@@ -86,7 +89,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Algunas capacidades llegan más tarde a determinados países',
     ],
     pricingNote:
-      'Claude funciona con un modelo freemium: hay un plan gratuito con límites de uso y suscripciones de pago que amplían la cuota y dan acceso a más funciones. Los planes individuales suelen rondar los 20 $ al mes, con opciones para equipos y empresas. El acceso por API se paga por consumo. Consulta su web para precios actualizados.',
+      'Claude funciona con un modelo freemium: hay un plan gratuito con límites de uso y suscripciones de pago que amplían la cuota y dan acceso a más funciones. Los planes individuales suelen rondar los 20 $ al mes, con opciones para equipos y empresas. El acceso por API se paga por consumo.',
     faqs: [
       {
         question: '¿Qué es Claude y quién lo desarrolla?',
@@ -136,7 +139,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Puede cometer errores factuales pese al acceso web',
     ],
     pricingNote:
-      'Gemini sigue un modelo freemium: hay una versión gratuita accesible con una cuenta de Google y planes de suscripción que desbloquean modelos más potentes y mayor cuota, a menudo ligados a los planes de almacenamiento y productividad de Google. El uso por API se factura por consumo. Consulta su web para precios actualizados.',
+      'Gemini sigue un modelo freemium: hay una versión gratuita accesible con una cuenta de Google y planes de suscripción que desbloquean modelos más potentes y mayor cuota, a menudo ligados a los planes de almacenamiento y productividad de Google. El uso por API se factura por consumo.',
     faqs: [
       {
         question: '¿Qué es Gemini de Google?',
@@ -236,7 +239,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Menos conocido en Europa que las alternativas estadounidenses',
     ],
     pricingNote:
-      'Qwen sigue un esquema freemium: varias versiones se publican con pesos abiertos y se pueden usar sin coste de licencia, mientras que el acceso gestionado por API en la nube se factura por consumo. Si lo ejecutas por tu cuenta, el gasto viene del hardware. Consulta su web para precios y condiciones actualizadas.',
+      'Qwen sigue un esquema freemium: varias versiones se publican con pesos abiertos y se pueden usar sin coste de licencia, mientras que el acceso gestionado por API en la nube se factura por consumo. Si lo ejecutas por tu cuenta, el gasto viene del hardware.',
     faqs: [
       {
         question: '¿Qué es Qwen?',
@@ -286,7 +289,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'El despliegue propio exige perfil técnico',
     ],
     pricingNote:
-      'Mistral combina modelos open source de uso gratuito con modelos comerciales accesibles por API y facturados por consumo de tokens. También ofrece un asistente conversacional con plan gratuito y opciones de pago. El coste depende del modelo y del volumen. Consulta su web para precios actualizados.',
+      'Mistral combina modelos open source de uso gratuito con modelos comerciales accesibles por API y facturados por consumo de tokens. También ofrece un asistente conversacional con plan gratuito y opciones de pago. El coste depende del modelo y del volumen.',
     faqs: [
       {
         question: '¿Qué es Mistral AI?',
@@ -386,7 +389,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'El acceso a datos de X puede arrastrar contenido poco fiable',
     ],
     pricingNote:
-      'Grok funciona con un modelo freemium: hay acceso gratuito con límites de uso y funciones ampliadas para usuarios de pago, normalmente asociadas a las suscripciones de X o de xAI. Existe además una API facturada por consumo para desarrolladores. Consulta su web para precios actualizados.',
+      'Grok funciona con un modelo freemium: hay acceso gratuito con límites de uso y funciones ampliadas para usuarios de pago, normalmente asociadas a las suscripciones de X o de xAI. Existe además una API facturada por consumo para desarrolladores.',
     faqs: [
       {
         question: '¿Qué es Grok y quién lo ha creado?',
@@ -486,7 +489,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'El texto generado suele necesitar edición humana',
     ],
     pricingNote:
-      'Jasper es una herramienta de pago por suscripción, con planes por usuario y niveles según las funciones y el volumen de contenido. Los planes de entrada suelen partir de unas decenas de dólares al mes y suben en las opciones para equipos y empresas. Normalmente ofrece un periodo de prueba. Consulta su web para precios actualizados.',
+      'Jasper es una herramienta de pago por suscripción, con planes por usuario y niveles según las funciones y el volumen de contenido. Los planes de entrada suelen partir de unas decenas de dólares al mes y suben en las opciones para equipos y empresas. Normalmente ofrece un periodo de prueba.',
     faqs: [
       {
         question: '¿Qué es Jasper AI y para qué sirve?',
@@ -536,7 +539,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'El coste sube rápido al ampliar usuarios y volumen',
     ],
     pricingNote:
-      'Copy.ai se comercializa mediante suscripción de pago, con planes escalonados según usuarios, volumen de generación y acceso a flujos de trabajo. Suele existir una opción de entrada de bajo coste o prueba limitada, y planes superiores para equipos y empresas. Consulta su web para precios actualizados.',
+      'Copy.ai se comercializa mediante suscripción de pago, con planes escalonados según usuarios, volumen de generación y acceso a flujos de trabajo. Suele existir una opción de entrada de bajo coste o prueba limitada, y planes superiores para equipos y empresas.',
     faqs: [
       {
         question: '¿Qué es Copy.ai?',
@@ -586,7 +589,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Menos afinado en español que en inglés',
     ],
     pricingNote:
-      'Sudowrite es una herramienta de pago por suscripción, con planes escalonados según el volumen de palabras generadas al mes. Los planes de entrada suelen situarse en el entorno de los 20 $ mensuales y suben para quienes escriben mucho. Suele ofrecer una prueba inicial. Consulta su web para precios actualizados.',
+      'Sudowrite es una herramienta de pago por suscripción, con planes escalonados según el volumen de palabras generadas al mes. Los planes de entrada suelen situarse en el entorno de los 20 $ mensuales y suben para quienes escriben mucho. Suele ofrecer una prueba inicial.',
     faqs: [
       {
         question: '¿Qué es Sudowrite?',
@@ -636,7 +639,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'El texto generado siempre requiere revisión humana',
     ],
     pricingNote:
-      'YouWrite se ofrece mediante suscripción de pago, con planes que suelen depender del volumen de texto generado o del número de usuarios. Puede incluir una prueba inicial o créditos limitados para valorar la herramienta. Consulta su web para conocer los precios y las condiciones actualizadas.',
+      'YouWrite se ofrece mediante suscripción de pago, con planes que suelen depender del volumen de texto generado o del número de usuarios. Puede incluir una prueba inicial o créditos limitados para valorar la herramienta.',
     faqs: [
       {
         question: '¿Qué es YouWrite?',
@@ -686,7 +689,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Ha sufrido limitaciones de registro por saturación del servicio',
     ],
     pricingNote:
-      'DeepSeek sigue un modelo freemium: su asistente conversacional se puede usar de forma gratuita con límites, y varios de sus modelos se publican con pesos abiertos. El acceso por API se factura por consumo de tokens, con tarifas notablemente más bajas que las de otros grandes proveedores. Consulta su web para precios actualizados.',
+      'DeepSeek sigue un modelo freemium: su asistente conversacional se puede usar de forma gratuita con límites, y varios de sus modelos se publican con pesos abiertos. El acceso por API se factura por consumo de tokens, con tarifas notablemente más bajas que las de otros grandes proveedores.',
     faqs: [
       {
         question: '¿Qué es DeepSeek?',
@@ -736,7 +739,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'El flujo desde Discord resulta poco intuitivo al principio',
     ],
     pricingNote:
-      'Midjourney es un servicio de pago por suscripción, sin plan gratuito permanente. Los planes se escalonan según el tiempo de generación y las opciones de privacidad, partiendo de unos 10 $ al mes en el nivel más básico y subiendo en los planes profesionales. Consulta su web para precios actualizados.',
+      'Midjourney es un servicio de pago por suscripción, sin plan gratuito permanente. Los planes se escalonan según el tiempo de generación y las opciones de privacidad, partiendo de unos 10 $ al mes en el nivel más básico y subiendo en los planes profesionales.',
     faqs: [
       {
         question: '¿Qué es Midjourney y para qué sirve?',
@@ -786,7 +789,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'El uso amplio requiere suscripción o pago por API',
     ],
     pricingNote:
-      'DALL·E sigue un esquema freemium a través de ChatGPT: hay un acceso limitado sin coste y una generación más amplia en los planes de pago, que suelen partir de unos 20 $ al mes. El uso mediante API se factura por imagen generada. Consulta su web para precios actualizados.',
+      'DALL·E sigue un esquema freemium a través de ChatGPT: hay un acceso limitado sin coste y una generación más amplia en los planes de pago, que suelen partir de unos 20 $ al mes. El uso mediante API se factura por imagen generada.',
     faqs: [
       {
         question: '¿Qué es DALL·E?',
@@ -886,7 +889,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Calidad artística algo por detrás de rivales especializados',
     ],
     pricingNote:
-      'Firefly sigue un modelo freemium: hay un uso gratuito con un número limitado de créditos generativos al mes y planes de pago que amplían esa cuota, además de estar incluido en las suscripciones de Creative Cloud. El coste depende del plan de Adobe contratado. Consulta su web para precios actualizados.',
+      'Firefly sigue un modelo freemium: hay un uso gratuito con un número limitado de créditos generativos al mes y planes de pago que amplían esa cuota, además de estar incluido en las suscripciones de Creative Cloud. El coste depende del plan de Adobe contratado.',
     faqs: [
       {
         question: '¿Qué es Adobe Firefly?',
@@ -936,7 +939,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Filtros de contenido que restringen ciertas peticiones',
     ],
     pricingNote:
-      'Imagen se usa normalmente a través de productos de Google: dentro de Gemini hay generación gratuita con límites y mayor cuota en los planes de pago, mientras que en las plataformas cloud se factura por imagen generada. No es una herramienta con precio propio independiente. Consulta la web de Google para condiciones actualizadas.',
+      'Imagen se usa normalmente a través de productos de Google: dentro de Gemini hay generación gratuita con límites y mayor cuota en los planes de pago, mientras que en las plataformas cloud se factura por imagen generada. No es una herramienta con precio propio independiente.',
     faqs: [
       {
         question: '¿Qué es Imagen de Google?',
@@ -986,7 +989,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Las licencias varían según la versión del modelo',
     ],
     pricingNote:
-      'FLUX combina modelos con pesos abiertos, gratuitos de descargar y ejecutar, con variantes comerciales que se pagan por uso a través de API o plataformas de terceros. Algunas webs ofrecen generación gratuita limitada. Las condiciones de licencia cambian según la versión, así que consulta su web para información actualizada.',
+      'FLUX combina modelos con pesos abiertos, gratuitos de descargar y ejecutar, con variantes comerciales que se pagan por uso a través de API o plataformas de terceros. Algunas webs ofrecen generación gratuita limitada. Las condiciones de licencia cambian según la versión, así que',
     faqs: [
       {
         question: '¿Qué es FLUX en IA de imágenes?',
@@ -1035,7 +1038,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'El texto largo o complejo aún puede salir con errores',
     ],
     pricingNote:
-      'Ideogram funciona con un modelo freemium: suele ofrecer un plan gratuito con un número limitado de generaciones y planes de pago con más créditos, generación más rápida y uso comercial. Los tramos de pago se mueven en el rango habitual de este tipo de servicios, en torno a unos pocos euros al mes en la entrada. Consulta su web para precios actualizados.',
+      'Ideogram funciona con un modelo freemium: suele ofrecer un plan gratuito con un número limitado de generaciones y planes de pago con más créditos, generación más rápida y uso comercial. Los tramos de pago se mueven en el rango habitual de este tipo de servicios, en torno a unos pocos euros al mes en la entrada.',
     faqs: [
       {
         question: '¿Qué es Ideogram?',
@@ -1084,7 +1087,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Los vectores generados pueden necesitar limpieza manual',
     ],
     pricingNote:
-      'Recraft sigue un modelo freemium: hay un plan gratuito con créditos diarios limitados y planes de pago por suscripción que amplían créditos, resolución y derechos de uso comercial. Los planes de entrada suelen situarse en el entorno de los precios habituales de las herramientas de diseño SaaS. Consulta su web para precios actualizados.',
+      'Recraft sigue un modelo freemium: hay un plan gratuito con créditos diarios limitados y planes de pago por suscripción que amplían créditos, resolución y derechos de uso comercial. Los planes de entrada suelen situarse en el entorno de los precios habituales de las herramientas de diseño SaaS.',
     faqs: [
       {
         question: '¿Qué es Recraft?',
@@ -1133,7 +1136,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Los tiempos de espera aumentan en horas de mucha demanda',
     ],
     pricingNote:
-      'Leonardo AI es freemium: incluye un sistema de créditos gratuitos que se renuevan a diario y varios planes de suscripción que amplían créditos, generaciones simultáneas y funciones avanzadas. Los planes de pago cubren desde uso personal hasta equipos. Consulta su web para precios actualizados.',
+      'Leonardo AI es freemium: incluye un sistema de créditos gratuitos que se renuevan a diario y varios planes de suscripción que amplían créditos, generaciones simultáneas y funciones avanzadas. Los planes de pago cubren desde uso personal hasta equipos.',
     faqs: [
       {
         question: '¿Qué es Leonardo AI?',
@@ -1182,7 +1185,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'La documentación en español es escasa',
     ],
     pricingNote:
-      'Seedream se presenta como un modelo accesible de forma gratuita a través de las interfaces y productos de su desarrollador, aunque el uso vía API o en volumen puede estar sujeto a condiciones y costes específicos. Las condiciones de acceso pueden cambiar con el tiempo. Consulta su web para conocer la disponibilidad y los precios actualizados.',
+      'Seedream se presenta como un modelo accesible de forma gratuita a través de las interfaces y productos de su desarrollador, aunque el uso vía API o en volumen puede estar sujeto a condiciones y costes específicos. Las condiciones de acceso pueden cambiar con el tiempo.',
     faqs: [
       {
         question: '¿Qué es Seedream?',
@@ -1231,7 +1234,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Su disponibilidad y límites pueden cambiar con frecuencia',
     ],
     pricingNote:
-      'Aurora se ofrece dentro del ecosistema de xAI y su acceso completo está asociado a las suscripciones de pago que dan acceso a Grok. Los planes se comercializan por suscripción mensual y pueden incluir límites de generación. Consulta su web para conocer los planes y precios actualizados.',
+      'Aurora se ofrece dentro del ecosistema de xAI y su acceso completo está asociado a las suscripciones de pago que dan acceso a Grok. Los planes se comercializan por suscripción mensual y pueden incluir límites de generación.',
     faqs: [
       {
         question: '¿Qué es Aurora de xAI?',
@@ -1280,7 +1283,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'La calidad depende mucho de lo bien redactado que esté el prompt',
     ],
     pricingNote:
-      'Playground AI funciona con un modelo freemium: ofrece una cuota de imágenes gratuitas al día y planes de pago que amplían generaciones, velocidad y funciones avanzadas. Los planes de suscripción se sitúan en el rango habitual de las herramientas de imagen generativa. Consulta su web para precios actualizados.',
+      'Playground AI funciona con un modelo freemium: ofrece una cuota de imágenes gratuitas al día y planes de pago que amplían generaciones, velocidad y funciones avanzadas. Los planes de suscripción se sitúan en el rango habitual de las herramientas de imagen generativa.',
     faqs: [
       {
         question: '¿Qué es Playground AI?',
@@ -1329,7 +1332,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'La clonación de voz plantea cuestiones éticas y legales a vigilar',
     ],
     pricingNote:
-      'ElevenLabs es freemium: hay un plan gratuito con una cuota mensual reducida de caracteres y varios planes de pago escalonados según el volumen de audio y las funciones de clonación. Los planes de entrada arrancan en cifras bajas y suben conforme aumenta el consumo. Consulta su web para precios actualizados.',
+      'ElevenLabs es freemium: hay un plan gratuito con una cuota mensual reducida de caracteres y varios planes de pago escalonados según el volumen de audio y las funciones de clonación. Los planes de entrada arrancan en cifras bajas y suben conforme aumenta el consumo.',
     faqs: [
       {
         question: '¿Qué es ElevenLabs?',
@@ -1378,7 +1381,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'El soporte para macOS es más limitado que en Windows',
     ],
     pricingNote:
-      'Voicemod tiene un modelo freemium: la versión gratuita permite usar un conjunto rotatorio de voces y efectos, mientras que la licencia de pago desbloquea el catálogo completo y funciones avanzadas. Suele comercializarse por suscripción o pago único. Consulta su web para precios actualizados.',
+      'Voicemod tiene un modelo freemium: la versión gratuita permite usar un conjunto rotatorio de voces y efectos, mientras que la licencia de pago desbloquea el catálogo completo y funciones avanzadas. Suele comercializarse por suscripción o pago único.',
     faqs: [
       {
         question: '¿Qué es Voicemod?',
@@ -1427,7 +1430,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Menos control fino que un editor de audio profesional',
     ],
     pricingNote:
-      'Descript funciona con un modelo freemium: el plan gratuito incluye un número limitado de horas de transcripción y funciones básicas, mientras que los planes de pago amplían la transcripción, la exportación en alta calidad y las funciones de IA. Los tramos se comercializan por usuario y mes. Consulta su web para precios actualizados.',
+      'Descript funciona con un modelo freemium: el plan gratuito incluye un número limitado de horas de transcripción y funciones básicas, mientras que los planes de pago amplían la transcripción, la exportación en alta calidad y las funciones de IA. Los tramos se comercializan por usuario y mes.',
     faqs: [
       {
         question: '¿Qué es Descript?',
@@ -1476,7 +1479,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Requiere muestras de audio de calidad para un buen clonado',
     ],
     pricingNote:
-      'Resemble AI ofrece un acceso freemium o de prueba con límites y planes de pago escalonados según el volumen de audio generado y las necesidades de clonación. Para escenarios empresariales dispone de precios a medida. Consulta su web para conocer los tramos y precios actualizados.',
+      'Resemble AI ofrece un acceso freemium o de prueba con límites y planes de pago escalonados según el volumen de audio generado y las necesidades de clonación. Para escenarios empresariales dispone de precios a medida.',
     faqs: [
       {
         question: '¿Qué es Resemble AI?',
@@ -1525,7 +1528,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'El coste crece con el número de usuarios del equipo',
     ],
     pricingNote:
-      'Murf sigue un modelo freemium: ofrece una prueba gratuita con límites de tiempo de voz y descarga restringida, y planes de pago por suscripción según minutos de audio y número de usuarios. Los planes se orientan tanto a creadores individuales como a equipos. Consulta su web para precios actualizados.',
+      'Murf sigue un modelo freemium: ofrece una prueba gratuita con límites de tiempo de voz y descarga restringida, y planes de pago por suscripción según minutos de audio y número de usuarios. Los planes se orientan tanto a creadores individuales como a equipos.',
     faqs: [
       {
         question: '¿Qué es Murf?',
@@ -1574,7 +1577,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'La calidad varía notablemente según la voz elegida',
     ],
     pricingNote:
-      'Play.ht es freemium: existe un nivel gratuito con una cuota reducida de palabras y planes de pago escalonados según el volumen de audio, la clonación de voz y el uso de la API. También ofrece condiciones específicas para empresas. Consulta su web para precios actualizados.',
+      'Play.ht es freemium: existe un nivel gratuito con una cuota reducida de palabras y planes de pago escalonados según el volumen de audio, la clonación de voz y el uso de la API. También ofrece condiciones específicas para empresas.',
     faqs: [
       {
         question: '¿Qué es Play.ht?',
@@ -1623,7 +1626,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'La lectura de PDF con maquetación compleja puede fallar',
     ],
     pricingNote:
-      'Speechify usa un modelo freemium: la versión gratuita permite escuchar textos con voces básicas y velocidad limitada, mientras que la suscripción de pago desbloquea voces más naturales, mayor velocidad y funciones adicionales. La suscripción se comercializa de forma mensual o anual. Consulta su web para precios actualizados.',
+      'Speechify usa un modelo freemium: la versión gratuita permite escuchar textos con voces básicas y velocidad limitada, mientras que la suscripción de pago desbloquea voces más naturales, mayor velocidad y funciones adicionales. La suscripción se comercializa de forma mensual o anual.',
     faqs: [
       {
         question: '¿Qué es Speechify?',
@@ -1672,7 +1675,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'El editor de vídeo es básico comparado con herramientas dedicadas',
     ],
     pricingNote:
-      'Lovo funciona con un modelo freemium: hay un plan gratuito con minutos de voz limitados y planes de pago escalonados según el volumen de audio, el acceso a voces premium y la clonación. Los tramos se comercializan por suscripción mensual o anual. Consulta su web para precios actualizados.',
+      'Lovo funciona con un modelo freemium: hay un plan gratuito con minutos de voz limitados y planes de pago escalonados según el volumen de audio, el acceso a voces premium y la clonación. Los tramos se comercializan por suscripción mensual o anual.',
     faqs: [
       {
         question: '¿Qué es Lovo?',
@@ -1721,7 +1724,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'El plan gratuito limita los minutos de vídeo procesados',
     ],
     pricingNote:
-      'Dubverse sigue un modelo freemium: ofrece una cuota gratuita de minutos para probar el doblaje y planes de pago basados en el volumen de vídeo procesado y el acceso a voces premium. También dispone de opciones para empresas con necesidades de volumen. Consulta su web para precios actualizados.',
+      'Dubverse sigue un modelo freemium: ofrece una cuota gratuita de minutos para probar el doblaje y planes de pago basados en el volumen de vídeo procesado y el acceso a voces premium. También dispone de opciones para empresas con necesidades de volumen.',
     faqs: [
       {
         question: '¿Qué es Dubverse?',
@@ -1770,7 +1773,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'El uso de voces de personas reales plantea problemas éticos y legales',
     ],
     pricingNote:
-      'Voice.ai emplea un modelo freemium: buena parte de sus funciones de cambio de voz están disponibles sin coste, mientras que las opciones avanzadas y el uso sin límites pueden requerir una suscripción de pago. Las condiciones han variado con el tiempo. Consulta su web para precios actualizados.',
+      'Voice.ai emplea un modelo freemium: buena parte de sus funciones de cambio de voz están disponibles sin coste, mientras que las opciones avanzadas y el uso sin límites pueden requerir una suscripción de pago. Las condiciones han variado con el tiempo.',
     faqs: [
       {
         question: '¿Qué es Voice.ai?',
@@ -1819,7 +1822,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Los derechos de uso comercial dependen del plan contratado',
     ],
     pricingNote:
-      'Suno funciona con un modelo freemium: hay un plan gratuito con créditos diarios que permiten generar unas pocas canciones, y planes de pago que amplían los créditos y otorgan derechos de uso comercial. Los planes de suscripción se ofrecen en varios tramos. Consulta su web para precios actualizados.',
+      'Suno funciona con un modelo freemium: hay un plan gratuito con créditos diarios que permiten generar unas pocas canciones, y planes de pago que amplían los créditos y otorgan derechos de uso comercial. Los planes de suscripción se ofrecen en varios tramos.',
     faqs: [
       {
         question: '¿Qué es Suno?',
@@ -1917,7 +1920,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Poca flexibilidad creativa fuera del formato de presentador',
     ],
     pricingNote:
-      'Colossyan es una herramienta de pago que se comercializa por suscripción, con planes escalonados según los minutos de vídeo generados, los avatares disponibles y el número de usuarios. Suele ofrecer una prueba limitada y precios a medida para grandes organizaciones. Consulta su web para precios actualizados.',
+      'Colossyan es una herramienta de pago que se comercializa por suscripción, con planes escalonados según los minutos de vídeo generados, los avatares disponibles y el número de usuarios. Suele ofrecer una prueba limitada y precios a medida para grandes organizaciones.',
     faqs: [
       {
         question: '¿Qué es Colossyan?',
@@ -1966,7 +1969,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Aún comete errores de física, manos y texto dentro de la escena',
     ],
     pricingNote:
-      'Sora se ofrece con acceso gratuito limitado y con más capacidad dentro de las suscripciones de pago del ecosistema de OpenAI, que amplían el número de generaciones, la duración y la resolución. Las condiciones y la disponibilidad por país cambian con frecuencia. Consulta su web para precios actualizados.',
+      'Sora se ofrece con acceso gratuito limitado y con más capacidad dentro de las suscripciones de pago del ecosistema de OpenAI, que amplían el número de generaciones, la duración y la resolución. Las condiciones y la disponibilidad por país cambian con frecuencia.',
     faqs: [
       {
         question: '¿Qué es Sora?',
@@ -2015,7 +2018,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'El control fino sobre el resultado sigue siendo limitado',
     ],
     pricingNote:
-      'Veo se ofrece a través de productos de Google, normalmente con acceso gratuito limitado y funciones ampliadas dentro de suscripciones de pago. La disponibilidad y los límites de uso cambian con frecuencia. Consulta su web para precios actualizados y condiciones de acceso en tu país.',
+      'Veo se ofrece a través de productos de Google, normalmente con acceso gratuito limitado y funciones ampliadas dentro de suscripciones de pago. La disponibilidad y los límites de uso cambian con frecuencia.',
     faqs: [
       {
         question: '¿Qué es Veo?',
@@ -2064,7 +2067,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'La curva de aprendizaje de las herramientas avanzadas es notable',
     ],
     pricingNote:
-      'Runway funciona con un modelo freemium basado en créditos: hay un plan gratuito con un número limitado de generaciones y varios planes de pago según el volumen y la resolución. Los planes individuales suelen situarse en el entorno de los 15-35 $/mes. Consulta su web para precios actualizados.',
+      'Runway funciona con un modelo freemium basado en créditos: hay un plan gratuito con un número limitado de generaciones y varios planes de pago según el volumen y la resolución. Los planes individuales suelen situarse en el entorno de los 15-35 $/mes.',
     faqs: [
       {
         question: '¿Qué es Runway?',
@@ -2113,7 +2116,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Los créditos gratuitos se agotan enseguida',
     ],
     pricingNote:
-      'Pika Labs sigue un modelo freemium con créditos: el plan gratuito permite un número limitado de generaciones al mes y los planes de pago amplían créditos, calidad y uso comercial. Los tramos individuales suelen rondar los 10-35 $/mes. Consulta su web para precios actualizados.',
+      'Pika Labs sigue un modelo freemium con créditos: el plan gratuito permite un número limitado de generaciones al mes y los planes de pago amplían créditos, calidad y uso comercial. Los tramos individuales suelen rondar los 10-35 $/mes.',
     faqs: [
       {
         question: '¿Qué es Pika Labs?',
@@ -2162,7 +2165,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Poco adecuado para contenido creativo o emocional',
     ],
     pricingNote:
-      'Synthesia es una herramienta de pago con planes por suscripción que limitan los minutos de vídeo generados al mes, además de planes empresariales a medida. Los tramos de entrada suelen situarse en torno a los 20-30 $/mes. Consulta su web para precios actualizados.',
+      'Synthesia es una herramienta de pago con planes por suscripción que limitan los minutos de vídeo generados al mes, además de planes empresariales a medida. Los tramos de entrada suelen situarse en torno a los 20-30 $/mes.',
     faqs: [
       {
         question: '¿Qué es Synthesia?',
@@ -2211,7 +2214,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Poco control fino para trabajos audiovisuales exigentes',
     ],
     pricingNote:
-      'InVideo funciona con un modelo freemium: hay un plan gratuito con marca de agua y límites de exportación, y varios planes de pago que amplían minutos, material de archivo y eliminan la marca. Los planes suelen rondar los 20-35 $/mes. Consulta su web para precios actualizados.',
+      'InVideo funciona con un modelo freemium: hay un plan gratuito con marca de agua y límites de exportación, y varios planes de pago que amplían minutos, material de archivo y eliminan la marca. Los planes suelen rondar los 20-35 $/mes.',
     faqs: [
       {
         question: '¿Qué es InVideo?',
@@ -2260,7 +2263,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Las voces pueden sonar planas en textos largos',
     ],
     pricingNote:
-      'Fliki es freemium: el plan gratuito incluye unos pocos minutos de generación al mes con marca de agua, y los planes de pago amplían minutos, voces premium y uso comercial. Los tramos suelen empezar en torno a los 20-30 $/mes. Consulta su web para precios actualizados.',
+      'Fliki es freemium: el plan gratuito incluye unos pocos minutos de generación al mes con marca de agua, y los planes de pago amplían minutos, voces premium y uso comercial. Los tramos suelen empezar en torno a los 20-30 $/mes.',
     faqs: [
       {
         question: '¿Qué es Fliki?',
@@ -2309,7 +2312,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'El acceso y los límites cambian con frecuencia',
     ],
     pricingNote:
-      'Kling ofrece acceso gratuito con un sistema de créditos diarios o mensuales limitados, ampliables mediante planes de suscripción de pago con más generaciones y mayor calidad. Las condiciones varían según la región. Consulta su web para precios actualizados.',
+      'Kling ofrece acceso gratuito con un sistema de créditos diarios o mensuales limitados, ampliables mediante planes de suscripción de pago con más generaciones y mayor calidad. Las condiciones varían según la región.',
     faqs: [
       {
         question: '¿Qué es Kling?',
@@ -2358,7 +2361,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Los límites de uso gratuito cambian con frecuencia',
     ],
     pricingNote:
-      'MiniMax ofrece acceso gratuito con límites de uso y planes de pago o créditos para volúmenes mayores, además de tarificación por uso en su API. Las condiciones varían según el producto concreto. Consulta su web para precios actualizados.',
+      'MiniMax ofrece acceso gratuito con límites de uso y planes de pago o créditos para volúmenes mayores, además de tarificación por uso en su API. Las condiciones varían según el producto concreto.',
     faqs: [
       {
         question: '¿Qué es MiniMax?',
@@ -2407,7 +2410,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Control creativo escaso frente a suites profesionales',
     ],
     pricingNote:
-      'VideoFX se enmarca en las herramientas experimentales de Google, con acceso gratuito y límites de uso, aunque algunas funciones pueden requerir una suscripción de Google. La disponibilidad depende del país. Consulta su web para condiciones actualizadas.',
+      'VideoFX se enmarca en las herramientas experimentales de Google, con acceso gratuito y límites de uso, aunque algunas funciones pueden requerir una suscripción de Google. La disponibilidad depende del país.',
     faqs: [
       {
         question: '¿Qué es VideoFX?',
@@ -2456,7 +2459,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'No hay plan gratuito general para uso profesional',
     ],
     pricingNote:
-      'GitHub Copilot es de pago mediante suscripción, con planes individuales y de empresa, además de un nivel gratuito limitado y acceso sin coste para estudiantes y mantenedores de proyectos open source verificados. El plan individual suele rondar los 10 $/mes. Consulta su web para precios actualizados.',
+      'GitHub Copilot es de pago mediante suscripción, con planes individuales y de empresa, además de un nivel gratuito limitado y acceso sin coste para estudiantes y mantenedores de proyectos open source verificados. El plan individual suele rondar los 10 $/mes.',
     faqs: [
       {
         question: '¿Qué es GitHub Copilot?',
@@ -2505,7 +2508,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Depende de servicios en la nube, con implicaciones de privacidad',
     ],
     pricingNote:
-      'Cursor es freemium: incluye un plan gratuito con un número limitado de peticiones a los modelos más potentes y planes de pago para uso intensivo, además de opciones de equipo. El plan profesional suele rondar los 20 $/mes. Consulta su web para precios actualizados.',
+      'Cursor es freemium: incluye un plan gratuito con un número limitado de peticiones a los modelos más potentes y planes de pago para uso intensivo, además de opciones de equipo. El plan profesional suele rondar los 20 $/mes.',
     faqs: [
       {
         question: '¿Qué es Cursor?',
@@ -2554,7 +2557,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'El despliegue privado requiere infraestructura y coste añadido',
     ],
     pricingNote:
-      'Tabnine es freemium: cuenta con un plan gratuito de autocompletado básico, planes de pago para desarrolladores individuales y opciones empresariales con despliegue privado. Los planes profesionales suelen rondar los 10-15 $/mes por usuario. Consulta su web para precios actualizados.',
+      'Tabnine es freemium: cuenta con un plan gratuito de autocompletado básico, planes de pago para desarrolladores individuales y opciones empresariales con despliegue privado. Los planes profesionales suelen rondar los 10-15 $/mes por usuario.',
     faqs: [
       {
         question: '¿Qué es Tabnine?',
@@ -2603,7 +2606,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'No sustituye una estrategia de testing bien diseñada',
     ],
     pricingNote:
-      'Codium sigue un modelo freemium con un plan gratuito para desarrolladores individuales y planes de pago para equipos y empresas, con funciones adicionales de colaboración y control. Consulta su web para precios actualizados y condiciones de uso comercial.',
+      'Codium sigue un modelo freemium con un plan gratuito para desarrolladores individuales y planes de pago para equipos y empresas, con funciones adicionales de colaboración y control.',
     faqs: [
       {
         question: '¿Qué es Codium?',
@@ -2652,7 +2655,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Depende de que el repositorio sea accesible',
     ],
     pricingNote:
-      'AskTheCode ofrece un uso gratuito para consultar repositorios, aunque puede aplicar límites de volumen o restricciones sobre repositorios privados. Consulta su web para conocer las condiciones y precios actualizados si necesitas un uso más intensivo.',
+      'AskTheCode ofrece un uso gratuito para consultar repositorios, aunque puede aplicar límites de volumen o restricciones sobre repositorios privados.',
     faqs: [
       {
         question: '¿Qué es AskTheCode?',
@@ -2701,7 +2704,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Requiere tiempo de configuración inicial',
     ],
     pricingNote:
-      'Testim ofrece un plan de entrada gratuito o de prueba con un número limitado de ejecuciones, y planes de pago orientados a equipos y empresas con precios a medida según volumen. Consulta su web para precios actualizados y para solicitar una demostración.',
+      'Testim ofrece un plan de entrada gratuito o de prueba con un número limitado de ejecuciones, y planes de pago orientados a equipos y empresas con precios a medida según volumen.',
     faqs: [
       {
         question: '¿Qué es Testim?',
@@ -2750,7 +2753,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Los planes empresariales son caros',
     ],
     pricingNote:
-      'Diffblue combina una versión gratuita o de comunidad con límites de uso y planes empresariales de pago con precios a medida según el tamaño del proyecto y del equipo. Consulta su web para precios actualizados y para solicitar una demostración.',
+      'Diffblue combina una versión gratuita o de comunidad con límites de uso y planes empresariales de pago con precios a medida según el tamaño del proyecto y del equipo.',
     faqs: [
       {
         question: '¿Qué es Diffblue?',
@@ -2799,7 +2802,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Su disponibilidad y límites cambian con frecuencia',
     ],
     pricingNote:
-      'Jules es freemium: ofrece un nivel gratuito con un número limitado de tareas al día y niveles superiores incluidos en las suscripciones de IA de Google, con más capacidad. Consulta su web para precios actualizados y límites vigentes.',
+      'Jules es freemium: ofrece un nivel gratuito con un número limitado de tareas al día y niveles superiores incluidos en las suscripciones de IA de Google, con más capacidad.',
     faqs: [
       {
         question: '¿Qué es Jules?',
@@ -2848,7 +2851,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Los planes de pago pueden salir caros en equipos grandes',
     ],
     pricingNote:
-      'DeepSource es freemium: gratuito para proyectos de código abierto y con planes de pago por usuario para repositorios privados y equipos. Los tramos de entrada suelen situarse en el entorno de los 10-30 $ por usuario al mes. Consulta su web para precios actualizados.',
+      'DeepSource es freemium: gratuito para proyectos de código abierto y con planes de pago por usuario para repositorios privados y equipos. Los tramos de entrada suelen situarse en el entorno de los 10-30 $ por usuario al mes.',
     faqs: [
       {
         question: '¿Qué es DeepSource?',
@@ -2897,7 +2900,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'La curva de aprendizaje inicial es notable',
     ],
     pricingNote:
-      'El framework LangChain es de código abierto y gratuito. La empresa ofrece además productos comerciales complementarios de observabilidad y despliegue con planes freemium y de pago. Consulta su web para precios actualizados de esos servicios adicionales.',
+      'El framework LangChain es de código abierto y gratuito. La empresa ofrece además productos comerciales complementarios de observabilidad y despliegue con planes freemium y de pago.',
     faqs: [
       {
         question: '¿Qué es LangChain?',
@@ -2995,7 +2998,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Algunas funciones y skills solo están disponibles en inglés',
     ],
     pricingNote:
-      'El uso de Alexa como asistente no tiene coste: el software y la app son gratuitos. El gasto está en el hardware (altavoces y pantallas Echo) y, opcionalmente, en servicios de suscripción de Amazon que amplían funciones o contenidos. Consulta su web para conocer las condiciones actualizadas.',
+      'El uso de Alexa como asistente no tiene coste: el software y la app son gratuitos. El gasto está en el hardware (altavoces y pantallas Echo) y, opcionalmente, en servicios de suscripción de Amazon que amplían funciones o contenidos.',
     faqs: [
       {
         question: '¿Qué es Alexa?',
@@ -3044,7 +3047,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Menor utilidad fuera del ecosistema de Google',
     ],
     pricingNote:
-      'Google Assistant es gratuito y viene incluido en los dispositivos Android y en el hardware de Google compatible. No hay suscripción para usarlo como asistente, aunque algunos servicios conectados pueden tener coste propio. Consulta su web para conocer las condiciones actualizadas.',
+      'Google Assistant es gratuito y viene incluido en los dispositivos Android y en el hardware de Google compatible. No hay suscripción para usarlo como asistente, aunque algunos servicios conectados pueden tener coste propio.',
     faqs: [
       {
         question: '¿Qué es Google Assistant?',
@@ -3093,7 +3096,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'El soporte en español puede ser menos pulido que en inglés',
     ],
     pricingNote:
-      'Pi sigue un modelo freemium: suele ofrecer acceso gratuito con límites de uso y funciones básicas de conversación. Las condiciones y los posibles planes de pago han cambiado con el tiempo, así que conviene consultar su web para precios actualizados antes de decidirse.',
+      'Pi sigue un modelo freemium: suele ofrecer acceso gratuito con límites de uso y funciones básicas de conversación. Las condiciones y los posibles planes de pago han cambiado con el tiempo, así que conviene',
     faqs: [
       {
         question: '¿Qué es Pi de Inflection AI?',
@@ -3142,7 +3145,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Conviene revisar siempre las citas antes de darlas por buenas',
     ],
     pricingNote:
-      'Perplexity funciona con modelo freemium: hay un plan gratuito con límites de uso diarios y un plan de pago para particulares que amplía consultas avanzadas y acceso a modelos más potentes. Los planes de pago suelen situarse en torno a los 20 $/mes; consulta su web para precios actualizados.',
+      'Perplexity funciona con modelo freemium: hay un plan gratuito con límites de uso diarios y un plan de pago para particulares que amplía consultas avanzadas y acceso a modelos más potentes. Los planes de pago suelen situarse en torno a los 20 $/mes;',
     faqs: [
       {
         question: '¿Qué es Perplexity?',
@@ -3191,7 +3194,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Puede generar apego o dependencia si se usa de forma intensiva',
     ],
     pricingNote:
-      'Replika sigue un modelo freemium: la versión gratuita permite chatear con límites y opciones de personalización reducidas, mientras que la suscripción de pago desbloquea modos de relación, voz y personalización avanzada. Suele ofrecerse en cuotas mensuales o anuales; consulta su web para precios actualizados.',
+      'Replika sigue un modelo freemium: la versión gratuita permite chatear con límites y opciones de personalización reducidas, mientras que la suscripción de pago desbloquea modos de relación, voz y personalización avanzada. Suele ofrecerse en cuotas mensuales o anuales;',
     faqs: [
       {
         question: '¿Qué es Replika?',
@@ -3240,7 +3243,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Curva de configuración inicial notable',
     ],
     pricingNote:
-      'Intercom es una herramienta de pago con planes por puesto de agente y cargos adicionales por las resoluciones que gestiona su agente de IA. Existen descuentos para startups y periodos de prueba. Al combinarse el coste por asiento y por uso, conviene consultar su web para precios actualizados y simular el gasto.',
+      'Intercom es una herramienta de pago con planes por puesto de agente y cargos adicionales por las resoluciones que gestiona su agente de IA. Existen descuentos para startups y periodos de prueba. Al combinarse el coste por asiento y por uso, conviene',
     faqs: [
       {
         question: '¿Qué es Intercom?',
@@ -3289,7 +3292,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Requiere diseñar bien los flujos para que aporte valor',
     ],
     pricingNote:
-      'Drift es una herramienta de pago, con planes orientados a equipos de ventas y marketing y precios normalmente bajo presupuesto personalizado. No suele publicar tarifas cerradas en su web, por lo que hay que solicitar una demostración. Consulta su web para precios actualizados.',
+      'Drift es una herramienta de pago, con planes orientados a equipos de ventas y marketing y precios normalmente bajo presupuesto personalizado. No suele publicar tarifas cerradas en su web, por lo que hay que solicitar una demostración.',
     faqs: [
       {
         question: '¿Qué es Drift?',
@@ -3338,7 +3341,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Requiere inversión inicial en contenidos e integraciones',
     ],
     pricingNote:
-      'Ada es una solución de pago dirigida al segmento empresarial, con precios habitualmente personalizados según volumen de conversaciones y canales activos. No publica tarifas cerradas, por lo que hay que solicitar una demostración. Consulta su web para precios actualizados.',
+      'Ada es una solución de pago dirigida al segmento empresarial, con precios habitualmente personalizados según volumen de conversaciones y canales activos. No publica tarifas cerradas, por lo que hay que solicitar una demostración.',
     faqs: [
       {
         question: '¿Qué es Ada?',
@@ -3387,7 +3390,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Poco adecuada para equipos pequeños',
     ],
     pricingNote:
-      'LivePerson es una plataforma de pago del segmento empresarial, con precios personalizados según volumen de conversaciones, canales e integraciones. No publica tarifas cerradas y suele requerir un proceso comercial con demostración previa. Consulta su web para precios actualizados.',
+      'LivePerson es una plataforma de pago del segmento empresarial, con precios personalizados según volumen de conversaciones, canales e integraciones. No publica tarifas cerradas y suele requerir un proceso comercial con demostración previa.',
     faqs: [
       {
         question: '¿Qué es LivePerson?',
@@ -3436,7 +3439,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Su valor depende de la calidad de los datos del CRM',
     ],
     pricingNote:
-      'Einstein no es un producto independiente: se comercializa como complemento o como parte de determinadas ediciones de las nubes de Salesforce, con coste adicional por usuario o por consumo. El precio depende de la edición contratada y de los módulos activados. Consulta su web para precios actualizados.',
+      'Einstein no es un producto independiente: se comercializa como complemento o como parte de determinadas ediciones de las nubes de Salesforce, con coste adicional por usuario o por consumo. El precio depende de la edición contratada y de los módulos activados.',
     faqs: [
       {
         question: '¿Qué es Salesforce Einstein?',
@@ -3485,7 +3488,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Menos potente que un asistente general para tareas ajenas al CRM',
     ],
     pricingNote:
-      'ChatSpot sigue un modelo freemium ligado al ecosistema de HubSpot: es accesible para usuarios con cuenta de HubSpot, incluidas las gratuitas, y su alcance depende del plan contratado. HubSpot ha ido reorganizando sus asistentes de IA, así que conviene consultar su web para conocer la disponibilidad y precios actualizados.',
+      'ChatSpot sigue un modelo freemium ligado al ecosistema de HubSpot: es accesible para usuarios con cuenta de HubSpot, incluidas las gratuitas, y su alcance depende del plan contratado. HubSpot ha ido reorganizando sus asistentes de IA, así que conviene',
     faqs: [
       {
         question: '¿Qué es ChatSpot?',
@@ -3534,7 +3537,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Configuración avanzada con curva de aprendizaje',
     ],
     pricingNote:
-      'Zendesk es de pago, con planes por agente y varios niveles según las funciones incluidas. Las capacidades avanzadas de IA se comercializan normalmente como complemento adicional. Suele haber periodo de prueba gratuito. Consulta su web para precios actualizados, ya que la estructura de planes cambia con frecuencia.',
+      'Zendesk es de pago, con planes por agente y varios niveles según las funciones incluidas. Las capacidades avanzadas de IA se comercializan normalmente como complemento adicional. Suele haber periodo de prueba gratuito.',
     faqs: [
       {
         question: '¿Qué es Zendesk?',
@@ -3583,7 +3586,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Configuración técnica exigente para usuarios no desarrolladores',
     ],
     pricingNote:
-      'AutoGPT es software de código abierto y su uso no tiene coste de licencia. Sin embargo, para funcionar necesita claves de API de un proveedor de modelos, cuyo consumo se factura aparte y puede dispararse si el agente ejecuta muchas iteraciones. Consulta su web y la del proveedor de modelos para condiciones actualizadas.',
+      'AutoGPT es software de código abierto y su uso no tiene coste de licencia. Sin embargo, para funcionar necesita claves de API de un proveedor de modelos, cuyo consumo se factura aparte y puede dispararse si el agente ejecuta muchas iteraciones.',
     faqs: [
       {
         question: '¿Qué es AutoGPT?',
@@ -3632,7 +3635,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Consumo de tokens elevado si el agente itera mucho',
     ],
     pricingNote:
-      'AgentGPT es de código abierto y se puede usar sin coste, tanto en su versión alojada con límites como autoalojándolo. Para desbloquear más ejecuciones o modelos más potentes suele hacer falta aportar la propia clave de API, cuyo consumo se factura aparte. Consulta su web para condiciones actualizadas.',
+      'AgentGPT es de código abierto y se puede usar sin coste, tanto en su versión alojada con límites como autoalojándolo. Para desbloquear más ejecuciones o modelos más potentes suele hacer falta aportar la propia clave de API, cuyo consumo se factura aparte.',
     faqs: [
       {
         question: '¿Qué es AgentGPT?',
@@ -3681,7 +3684,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'El código generado necesita revisión humana antes de usarse',
     ],
     pricingNote:
-      'MetaGPT es un proyecto de código abierto sin coste de licencia. El gasto real viene del consumo de la API del modelo de lenguaje que se configure, que se factura por uso y puede ser significativo al ejecutar varios agentes en paralelo. Consulta su repositorio y el proveedor de modelos para condiciones actualizadas.',
+      'MetaGPT es un proyecto de código abierto sin coste de licencia. El gasto real viene del consumo de la API del modelo de lenguaje que se configure, que se factura por uso y puede ser significativo al ejecutar varios agentes en paralelo.',
     faqs: [
       {
         question: '¿Qué es MetaGPT?',
@@ -3730,7 +3733,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Conviene revisar el resultado, ya que puede cometer errores',
     ],
     pricingNote:
-      'ChatGPT funciona con modelo freemium: hay un plan gratuito con funciones limitadas, mientras que las capacidades agénticas suelen estar disponibles en los planes de pago, con distintos niveles y límites de uso. Los planes individuales de pago rondan los 20 $/mes; consulta su web para precios actualizados.',
+      'ChatGPT funciona con modelo freemium: hay un plan gratuito con funciones limitadas, mientras que las capacidades agénticas suelen estar disponibles en los planes de pago, con distintos niveles y límites de uso. Los planes individuales de pago rondan los 20 $/mes;',
     faqs: [
       {
         question: '¿Qué son los agentes de ChatGPT?',
@@ -3779,7 +3782,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'La calidad depende de cómo estén organizados los datos internos',
     ],
     pricingNote:
-      'Los agentes de Copilot son de pago y se comercializan mediante licencias de Microsoft 365 Copilot por usuario y, en algunos casos, con modelos de consumo por mensaje o acción. La estructura de precios de Microsoft cambia con frecuencia, así que consulta su web para precios actualizados.',
+      'Los agentes de Copilot son de pago y se comercializan mediante licencias de Microsoft 365 Copilot por usuario y, en algunos casos, con modelos de consumo por mensaje o acción. La estructura de precios de Microsoft cambia con frecuencia, así que',
     faqs: [
       {
         question: '¿Qué son los agentes de Microsoft Copilot?',
@@ -3828,7 +3831,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Puede añadir capas de abstracción innecesarias en casos simples',
     ],
     pricingNote:
-      'LangChain es una librería de código abierto y su uso no tiene coste de licencia. Los gastos vienen del consumo de la API del modelo de lenguaje elegido y, opcionalmente, de servicios de pago del ecosistema como sus herramientas de observabilidad. Consulta su web para precios actualizados de esos servicios.',
+      'LangChain es una librería de código abierto y su uso no tiene coste de licencia. Los gastos vienen del consumo de la API del modelo de lenguaje elegido y, opcionalmente, de servicios de pago del ecosistema como sus herramientas de observabilidad.',
     faqs: [
       {
         question: '¿Qué son los agentes de LangChain?',
@@ -3877,7 +3880,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Las funciones avanzadas suelen requerir suscripción',
     ],
     pricingNote:
-      'Sigue un modelo freemium: suele existir una vía de acceso gratuita con límites de uso, mientras que las capacidades avanzadas o el uso intensivo requieren suscripción o consumo de API facturado por uso. Al tratarse de un producto en evolución, consulta su web para precios actualizados antes de contratar.',
+      'Sigue un modelo freemium: suele existir una vía de acceso gratuita con límites de uso, mientras que las capacidades avanzadas o el uso intensivo requieren suscripción o consumo de API facturado por uso. Al tratarse de un producto en evolución,',
     faqs: [
       {
         question: '¿Qué son los agentes de xAI?',
@@ -3926,7 +3929,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'El plan gratuito se queda corto para uso profesional',
     ],
     pricingNote:
-      'Zapier funciona con modelo freemium: hay un plan gratuito con un número limitado de tareas mensuales y flujos de un solo paso. Los planes de pago se escalonan según el volumen de tareas y las funciones avanzadas, empezando en cifras modestas y creciendo con el uso. Consulta su web para precios actualizados.',
+      'Zapier funciona con modelo freemium: hay un plan gratuito con un número limitado de tareas mensuales y flujos de un solo paso. Los planes de pago se escalonan según el volumen de tareas y las funciones avanzadas, empezando en cifras modestas y creciendo con el uso.',
     faqs: [
       {
         question: '¿Qué es Zapier?',
@@ -3975,7 +3978,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Su licencia no es completamente open source para usos comerciales revendidos',
     ],
     pricingNote:
-      'n8n se puede autoalojar de forma gratuita bajo su licencia de código abierto, asumiendo solo los costes del servidor. También ofrece una versión en la nube de pago con planes por volumen de ejecuciones. Consulta su web para precios actualizados.',
+      'n8n se puede autoalojar de forma gratuita bajo su licencia de código abierto, asumiendo solo los costes del servidor. También ofrece una versión en la nube de pago con planes por volumen de ejecuciones.',
     faqs: [
       {
         question: '¿Qué es n8n y para qué sirve?',
@@ -4024,7 +4027,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'No permite autoalojamiento',
     ],
     pricingNote:
-      'Make funciona con un modelo freemium: hay un plan gratuito con un número limitado de operaciones mensuales, suficiente para probar y automatizar tareas sencillas. Los planes de pago escalan según las operaciones consumidas y la frecuencia de ejecución. Consulta su web para precios actualizados.',
+      'Make funciona con un modelo freemium: hay un plan gratuito con un número limitado de operaciones mensuales, suficiente para probar y automatizar tareas sencillas. Los planes de pago escalan según las operaciones consumidas y la frecuencia de ejecución.',
     faqs: [
       {
         question: '¿Qué es Make y para qué sirve?',
@@ -4073,7 +4076,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Algunas capacidades avanzadas requieren licencias adicionales',
     ],
     pricingNote:
-      'Power Automate sigue un modelo freemium dentro del ecosistema Microsoft: ciertas licencias de Microsoft 365 incluyen funcionalidades básicas de automatización. Las capacidades avanzadas, como RPA o el procesamiento de documentos con IA, requieren planes de pago por usuario o por proceso. Consulta su web para precios actualizados.',
+      'Power Automate sigue un modelo freemium dentro del ecosistema Microsoft: ciertas licencias de Microsoft 365 incluyen funcionalidades básicas de automatización. Las capacidades avanzadas, como RPA o el procesamiento de documentos con IA, requieren planes de pago por usuario o por proceso.',
     faqs: [
       {
         question: '¿Qué es Power Automate?',
@@ -4122,7 +4125,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Menos adecuado para automatizaciones empresariales serias',
     ],
     pricingNote:
-      'IFTTT tiene un modelo freemium: el plan gratuito permite mantener activo un número reducido de applets. Los planes de pago amplían ese límite, dan acceso a applets con varias acciones y a ejecuciones más rápidas. Consulta su web para precios actualizados.',
+      'IFTTT tiene un modelo freemium: el plan gratuito permite mantener activo un número reducido de applets. Los planes de pago amplían ese límite, dan acceso a applets con varias acciones y a ejecuciones más rápidas.',
     faqs: [
       {
         question: '¿Qué es IFTTT y cómo funciona?',
@@ -4171,7 +4174,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Menos control fino que si ejecutas los pasos manualmente',
     ],
     pricingNote:
-      'Manus opera con un modelo freemium basado en créditos: suele ofrecer una cantidad gratuita de créditos para probar el servicio, que se consumen según la complejidad de cada tarea. Los planes de pago amplían los créditos disponibles y la ejecución simultánea. Consulta su web para precios actualizados.',
+      'Manus opera con un modelo freemium basado en créditos: suele ofrecer una cantidad gratuita de créditos para probar el servicio, que se consumen según la complejidad de cada tarea. Los planes de pago amplían los créditos disponibles y la ejecución simultánea.',
     faqs: [
       {
         question: '¿Qué es Manus?',
@@ -4220,7 +4223,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Menos plantillas e integraciones listas que las plataformas visuales',
     ],
     pricingNote:
-      'Trigger.dev es open source y puede autoalojarse sin coste de licencia, asumiendo la infraestructura. Su versión gestionada en la nube suele incluir un tramo gratuito y planes de pago según el uso y la concurrencia. Consulta su web para precios actualizados.',
+      'Trigger.dev es open source y puede autoalojarse sin coste de licencia, asumiendo la infraestructura. Su versión gestionada en la nube suele incluir un tramo gratuito y planes de pago según el uso y la concurrencia.',
     faqs: [
       {
         question: '¿Qué es Trigger.dev?',
@@ -4269,7 +4272,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Menos potente que asistentes de IA especializados en tareas concretas',
     ],
     pricingNote:
-      'Notion tiene un plan gratuito para uso personal, pero las funciones de IA suelen comercializarse como complemento de pago o incluidas en determinados planes de suscripción. El coste se calcula por usuario y mes. Consulta su web para precios actualizados.',
+      'Notion tiene un plan gratuito para uso personal, pero las funciones de IA suelen comercializarse como complemento de pago o incluidas en determinados planes de suscripción. El coste se calcula por usuario y mes.',
     faqs: [
       {
         question: '¿Qué es Notion AI y para qué sirve?',
@@ -4318,7 +4321,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'La calidad depende de lo bien organizados que estén los datos internos',
     ],
     pricingNote:
-      'Microsoft 365 Copilot es un producto de pago que se factura como complemento por usuario y mes sobre una licencia de Microsoft 365 existente. Su precio se sitúa en la franja alta de los asistentes de IA empresariales. Consulta su web para precios actualizados.',
+      'Microsoft 365 Copilot es un producto de pago que se factura como complemento por usuario y mes sobre una licencia de Microsoft 365 existente. Su precio se sitúa en la franja alta de los asistentes de IA empresariales.',
     faqs: [
       {
         question: '¿Qué es Microsoft 365 Copilot?',
@@ -4367,7 +4370,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Algunas funciones llegan antes en inglés que en español',
     ],
     pricingNote:
-      'Las funciones de IA de Google Workspace son de pago y se contratan como complemento por usuario y mes sobre una licencia de Workspace, aunque Google ha ido incluyéndolas en determinados planes. Consulta su web para conocer el empaquetado y los precios actualizados.',
+      'Las funciones de IA de Google Workspace son de pago y se contratan como complemento por usuario y mes sobre una licencia de Workspace, aunque Google ha ido incluyéndolas en determinados planes.',
     faqs: [
       {
         question: '¿Qué es Google Workspace Duet?',
@@ -4416,7 +4419,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'La exportación a otros formatos puede perder parte del diseño',
     ],
     pricingNote:
-      'Gamma funciona con un modelo freemium basado en créditos: el plan gratuito incluye una cantidad inicial de créditos para generar contenido, con marca de agua en algunos casos. Los planes de pago amplían los créditos y desbloquean opciones avanzadas de personalización. Consulta su web para precios actualizados.',
+      'Gamma funciona con un modelo freemium basado en créditos: el plan gratuito incluye una cantidad inicial de créditos para generar contenido, con marca de agua en algunos casos. Los planes de pago amplían los créditos y desbloquean opciones avanzadas de personalización.',
     faqs: [
       {
         question: '¿Qué es Gamma y para qué sirve?',
@@ -4465,7 +4468,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Los textos suelen requerir edición para sonar naturales',
     ],
     pricingNote:
-      'Magic Write forma parte de las funciones de IA de Canva y sigue un modelo freemium: la cuenta gratuita incluye un número limitado de usos, mientras que las suscripciones de pago de Canva amplían considerablemente ese límite. Consulta su web para precios actualizados.',
+      'Magic Write forma parte de las funciones de IA de Canva y sigue un modelo freemium: la cuenta gratuita incluye un número limitado de usos, mientras que las suscripciones de pago de Canva amplían considerablemente ese límite.',
     faqs: [
       {
         question: '¿Qué es Magic Write de Canva?',
@@ -4514,7 +4517,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Los diseños pueden parecer genéricos si se abusa de las plantillas',
     ],
     pricingNote:
-      'Canva sigue un modelo freemium: la cuenta gratuita da acceso a las funciones de Magic Studio con límites de uso mensuales. Las suscripciones de pago, como Canva Pro o Teams, amplían esos límites y añaden recursos premium. Consulta su web para precios actualizados.',
+      'Canva sigue un modelo freemium: la cuenta gratuita da acceso a las funciones de Magic Studio con límites de uso mensuales. Las suscripciones de pago, como Canva Pro o Teams, amplían esos límites y añaden recursos premium.',
     faqs: [
       {
         question: '¿Qué es Canva Magic Studio?',
@@ -4563,7 +4566,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'La versión de escritorio solo está disponible para Windows',
     ],
     pricingNote:
-      'Power BI tiene un modelo freemium: Power BI Desktop se puede descargar y usar gratis para crear informes. Compartirlos y colaborar requiere licencias de pago por usuario, con planes superiores para grandes volúmenes. Consulta su web para precios actualizados.',
+      'Power BI tiene un modelo freemium: Power BI Desktop se puede descargar y usar gratis para crear informes. Compartirlos y colaborar requiere licencias de pago por usuario, con planes superiores para grandes volúmenes.',
     faqs: [
       {
         question: '¿Qué es Power BI y para qué sirve?',
@@ -4612,7 +4615,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'La preparación de datos es menos fluida que en otras suites',
     ],
     pricingNote:
-      'Tableau es una plataforma de pago con licencias por usuario diferenciadas según el rol: creador, explorador o visualizador. El coste por creador se sitúa en la franja alta del mercado de BI. Consulta su web para conocer los planes y precios actualizados.',
+      'Tableau es una plataforma de pago con licencias por usuario diferenciadas según el rol: creador, explorador o visualizador. El coste por creador se sitúa en la franja alta del mercado de BI.',
     faqs: [
       {
         question: '¿Qué es Tableau?',
@@ -4661,7 +4664,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Menos flexible que otras herramientas para visualizaciones muy personalizadas',
     ],
     pricingNote:
-      'ThoughtSpot es una plataforma de pago dirigida principalmente al segmento empresarial, con precios que dependen del volumen de datos y del número de usuarios. Suele ofrecer periodos de prueba y ediciones diferenciadas. Consulta su web para conocer los precios actualizados.',
+      'ThoughtSpot es una plataforma de pago dirigida principalmente al segmento empresarial, con precios que dependen del volumen de datos y del número de usuarios. Suele ofrecer periodos de prueba y ediciones diferenciadas.',
     faqs: [
       {
         question: '¿Qué es ThoughtSpot?',
@@ -4710,7 +4713,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Parte del contenido premium depende de suscripciones adicionales',
     ],
     pricingNote:
-      'AlphaSense es un servicio de pago dirigido a profesionales, con suscripciones anuales cuyo precio se negocia con el proveedor y se sitúa en la franja alta del mercado. No suele existir plan gratuito, aunque sí demostraciones. Consulta su web para conocer las condiciones actuales.',
+      'AlphaSense es un servicio de pago dirigido a profesionales, con suscripciones anuales cuyo precio se negocia con el proveedor y se sitúa en la franja alta del mercado. No suele existir plan gratuito, aunque sí demostraciones.',
     faqs: [
       {
         question: '¿Qué es AlphaSense?',
@@ -4759,7 +4762,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Poca transparencia sobre el funcionamiento interno de los modelos',
     ],
     pricingNote:
-      'Kavout es un servicio de pago con suscripciones dirigidas tanto a inversores particulares avanzados como a clientes institucionales, con distintos niveles según las funciones y los datos incluidos. Consulta su web para conocer los planes y precios actualizados.',
+      'Kavout es un servicio de pago con suscripciones dirigidas tanto a inversores particulares avanzados como a clientes institucionales, con distintos niveles según las funciones y los datos incluidos.',
     faqs: [
       {
         question: '¿Qué es Kavout?',
@@ -4808,7 +4811,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'El asistente de IA suele ser un complemento de pago aparte',
     ],
     pricingNote:
-      'ClickUp funciona con un modelo freemium: dispone de un plan gratuito con tareas ilimitadas y funciones básicas. Los planes de pago, por usuario y mes, añaden capacidades avanzadas, y el asistente de IA suele contratarse como complemento. Consulta su web para precios actualizados.',
+      'ClickUp funciona con un modelo freemium: dispone de un plan gratuito con tareas ilimitadas y funciones básicas. Los planes de pago, por usuario y mes, añaden capacidades avanzadas, y el asistente de IA suele contratarse como complemento.',
     faqs: [
       {
         question: '¿Qué es ClickUp y para qué sirve?',
@@ -4857,7 +4860,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Menos personalizable que otras plataformas más flexibles',
     ],
     pricingNote:
-      'Asana tiene un modelo freemium: el plan gratuito cubre las necesidades básicas de equipos pequeños. Las funciones avanzadas, incluidas las capacidades de IA, se incluyen en los planes de pago por usuario y mes. Consulta su web para precios actualizados.',
+      'Asana tiene un modelo freemium: el plan gratuito cubre las necesidades básicas de equipos pequeños. Las funciones avanzadas, incluidas las capacidades de IA, se incluyen en los planes de pago por usuario y mes.',
     faqs: [
       {
         question: '¿Qué es Asana y para qué sirve?',
@@ -4906,7 +4909,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Puede volverse desordenado si no se define bien la estructura inicial',
     ],
     pricingNote:
-      'Monday.com sigue un modelo freemium: dispone de un plan gratuito muy limitado en número de usuarios y elementos. Los planes de pago se facturan por usuario y mes con mínimos de asientos, y las funciones de IA se consumen mediante créditos. Consulta su web para precios actualizados.',
+      'Monday.com sigue un modelo freemium: dispone de un plan gratuito muy limitado en número de usuarios y elementos. Los planes de pago se facturan por usuario y mes con mínimos de asientos, y las funciones de IA se consumen mediante créditos.',
     faqs: [
       {
         question: '¿Qué es Monday.com?',
@@ -4955,7 +4958,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Sin informes ni métricas potentes de serie',
     ],
     pricingNote:
-      'Trello es freemium: mantiene un plan gratuito con tableros ilimitados y ciertos límites de colaboradores y automatizaciones. Los planes de pago se facturan por usuario y mes, con tramos aproximados que suelen empezar en torno a los 5-6 $ y subir según funciones (vistas avanzadas, administración, seguridad). Consulta su web para precios actualizados.',
+      'Trello es freemium: mantiene un plan gratuito con tableros ilimitados y ciertos límites de colaboradores y automatizaciones. Los planes de pago se facturan por usuario y mes, con tramos aproximados que suelen empezar en torno a los 5-6 $ y subir según funciones (vistas avanzadas, administración, seguridad).',
     faqs: [
       {
         question: '¿Qué es Trello y para qué sirve?',
@@ -5004,7 +5007,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Requiere siempre revisión de un profesional: no sustituye criterio jurídico',
     ],
     pricingNote:
-      'Harvey es una herramienta de pago con modelo empresarial: no publica tarifas abiertas ni ofrece registro autoservicio. El acceso se negocia mediante contrato con el despacho o el departamento legal, normalmente con licencias por usuario y condiciones a medida. Hay que solicitar una demo para conocer las condiciones. Consulta su web para precios actualizados.',
+      'Harvey es una herramienta de pago con modelo empresarial: no publica tarifas abiertas ni ofrece registro autoservicio. El acceso se negocia mediante contrato con el despacho o el departamento legal, normalmente con licencias por usuario y condiciones a medida. Hay que solicitar una demo para conocer las condiciones.',
     faqs: [
       {
         question: '¿Qué es Harvey AI?',
@@ -5053,7 +5056,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Los resultados necesitan siempre validación de un jurista',
     ],
     pricingNote:
-      'Luminance es una solución de pago con enfoque empresarial. No publica tarifas públicas: el precio depende del número de usuarios, los módulos contratados y el volumen documental, y se negocia mediante presupuesto tras una demo. Consulta su web para precios actualizados.',
+      'Luminance es una solución de pago con enfoque empresarial. No publica tarifas públicas: el precio depende del número de usuarios, los módulos contratados y el volumen documental, y se negocia mediante presupuesto tras una demo.',
     faqs: [
       {
         question: '¿Qué es Luminance?',
@@ -5103,7 +5106,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Ha recibido críticas y litigios sobre el alcance real de su servicio',
     ],
     pricingNote:
-      'DoNotPay funciona con un modelo freemium tirando a suscripción: permite explorar el servicio, pero para completar la mayoría de trámites hay que pagar una cuota, habitualmente mensual o trimestral de importe reducido. Los precios varían según el país y el servicio concreto. Consulta su web para precios actualizados.',
+      'DoNotPay funciona con un modelo freemium tirando a suscripción: permite explorar el servicio, pero para completar la mayoría de trámites hay que pagar una cuota, habitualmente mensual o trimestral de importe reducido. Los precios varían según el país y el servicio concreto.',
     faqs: [
       {
         question: '¿Qué es DoNotPay?',
@@ -5152,7 +5155,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Todas las sugerencias requieren revisión profesional',
     ],
     pricingNote:
-      'Spellbook es una herramienta de pago con licencias por usuario, orientada a profesionales y despachos. Suele ofrecer una prueba o demo antes de contratar, pero no un plan gratuito permanente. El precio depende del número de licencias y del plan elegido. Consulta su web para precios actualizados.',
+      'Spellbook es una herramienta de pago con licencias por usuario, orientada a profesionales y despachos. Suele ofrecer una prueba o demo antes de contratar, pero no un plan gratuito permanente. El precio depende del número de licencias y del plan elegido.',
     faqs: [
       {
         question: '¿Qué es Spellbook?',
@@ -5201,7 +5204,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Poco adecuada para despachos pequeños o autónomos',
     ],
     pricingNote:
-      'Evisort es una plataforma de pago con modelo empresarial. No publica tarifas abiertas: el precio se calcula según el número de usuarios, el volumen contractual y los módulos contratados, y se negocia mediante presupuesto tras una demostración. Consulta su web para precios actualizados.',
+      'Evisort es una plataforma de pago con modelo empresarial. No publica tarifas abiertas: el precio se calcula según el número de usuarios, el volumen contractual y los módulos contratados, y se negocia mediante presupuesto tras una demostración.',
     faqs: [
       {
         question: '¿Qué es Evisort?',
@@ -5250,7 +5253,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Coste empresarial, no orientado a pymes ni autónomos',
     ],
     pricingNote:
-      'LawGeex es de pago con modelo empresarial y no publica tarifas abiertas. El precio depende del volumen de contratos revisados, el número de usuarios y los tipos de acuerdo configurados, y se negocia por presupuesto tras una demo. Consulta su web para precios actualizados.',
+      'LawGeex es de pago con modelo empresarial y no publica tarifas abiertas. El precio depende del volumen de contratos revisados, el número de usuarios y los tipos de acuerdo configurados, y se negocia por presupuesto tras una demo.',
     faqs: [
       {
         question: '¿Qué es LawGeex?',
@@ -5299,7 +5302,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'El código generado necesita revisión y pruebas',
     ],
     pricingNote:
-      'Replit funciona con un modelo freemium: hay un nivel gratuito con el que empezar a programar, y las capacidades de IA más amplias se incluyen en los planes de pago por suscripción mensual. Los tramos y los nombres de los planes han ido cambiando con el tiempo. Consulta su web para precios actualizados.',
+      'Replit funciona con un modelo freemium: hay un nivel gratuito con el que empezar a programar, y las capacidades de IA más amplias se incluyen en los planes de pago por suscripción mensual. Los tramos y los nombres de los planes han ido cambiando con el tiempo.',
     faqs: [
       {
         question: '¿Qué es Ghostwriter de Replit?',
@@ -5348,7 +5351,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Menos control que un flujo de desarrollo tradicional',
     ],
     pricingNote:
-      'Bolt es freemium y funciona con un sistema de créditos o tokens: hay una asignación gratuita diaria o mensual limitada, y los planes de pago amplían ese consumo. Las suscripciones suelen arrancar en torno a los 20 $/mes y escalar según el volumen. Consulta su web para precios actualizados.',
+      'Bolt es freemium y funciona con un sistema de créditos o tokens: hay una asignación gratuita diaria o mensual limitada, y los planes de pago amplían ese consumo. Las suscripciones suelen arrancar en torno a los 20 $/mes y escalar según el volumen.',
     faqs: [
       {
         question: '¿Qué es Bolt.new?',
@@ -5397,7 +5400,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Requiere conocimientos previos de automatización de tests',
     ],
     pricingNote:
-      'TestingBot funciona con un modelo freemium: ofrece una prueba gratuita y planes de pago por suscripción mensual que varían según los minutos de test, la ejecución en paralelo y el acceso a dispositivos reales. Los tramos suelen empezar en cifras modestas y escalar bastante para equipos grandes. Consulta su web para precios actualizados.',
+      'TestingBot funciona con un modelo freemium: ofrece una prueba gratuita y planes de pago por suscripción mensual que varían según los minutos de test, la ejecución en paralelo y el acceso a dispositivos reales. Los tramos suelen empezar en cifras modestas y escalar bastante para equipos grandes.',
     faqs: [
       {
         question: '¿Qué es TestingBot?',
@@ -5446,7 +5449,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'La autorreparación no siempre acierta y hay que supervisarla',
     ],
     pricingNote:
-      'Mabl es freemium en la práctica: ofrece una prueba gratuita para evaluar la plataforma y planes de pago por suscripción dirigidos a equipos, con precio en función del volumen de ejecuciones y usuarios. No publica una tarifa pública detallada. Consulta su web para precios actualizados.',
+      'Mabl es freemium en la práctica: ofrece una prueba gratuita para evaluar la plataforma y planes de pago por suscripción dirigidos a equipos, con precio en función del volumen de ejecuciones y usuarios. No publica una tarifa pública detallada.',
     faqs: [
       {
         question: '¿Qué es Mabl?',
@@ -5495,7 +5498,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Puede generar mucho ruido si no se ajustan bien las reglas',
     ],
     pricingNote:
-      'SonarQube tiene una edición Community open source y gratuita que se puede autoalojar. Las ediciones de pago (Developer, Enterprise) añaden más lenguajes, análisis de ramas y funciones de seguridad, con precio según líneas de código analizadas. También existe SonarCloud como versión gestionada, gratuita para proyectos públicos. Consulta su web para precios actualizados.',
+      'SonarQube tiene una edición Community open source y gratuita que se puede autoalojar. Las ediciones de pago (Developer, Enterprise) añaden más lenguajes, análisis de ramas y funciones de seguridad, con precio según líneas de código analizadas. También existe SonarCloud como versión gestionada, gratuita para proyectos públicos.',
     faqs: [
       {
         question: '¿Qué es SonarQube y para qué sirve?',
@@ -5544,7 +5547,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Los repositorios privados requieren plan de pago',
     ],
     pricingNote:
-      'Code Climate es freemium: su análisis de calidad es gratuito para repositorios de código abierto, mientras que los repositorios privados y las funciones de métricas de equipo se facturan por usuario y mes en planes de pago. Consulta su web para precios actualizados.',
+      'Code Climate es freemium: su análisis de calidad es gratuito para repositorios de código abierto, mientras que los repositorios privados y las funciones de métricas de equipo se facturan por usuario y mes en planes de pago.',
     faqs: [
       {
         question: '¿Qué es Code Climate?',
@@ -5593,7 +5596,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Puede generar ruido si no se afinan las reglas al inicio',
     ],
     pricingNote:
-      'CodeFactor es freemium: gratuito para repositorios públicos y de código abierto, con planes de pago por suscripción para repositorios privados, normalmente escalados según el número de repositorios o de usuarios. Consulta su web para precios actualizados.',
+      'CodeFactor es freemium: gratuito para repositorios públicos y de código abierto, con planes de pago por suscripción para repositorios privados, normalmente escalados según el número de repositorios o de usuarios.',
     faqs: [
       {
         question: '¿Qué es CodeFactor?',
@@ -5642,7 +5645,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Es una ayuda al diagnóstico, no un sustituto del radiólogo',
     ],
     pricingNote:
-      'Aidoc es una solución de pago dirigida a instituciones sanitarias. No publica tarifas: el precio se negocia por contrato con el hospital o la red de centros, en función de los algoritmos contratados y el volumen de estudios. Consulta su web para precios actualizados.',
+      'Aidoc es una solución de pago dirigida a instituciones sanitarias. No publica tarifas: el precio se negocia por contrato con el hospital o la red de centros, en función de los algoritmos contratados y el volumen de estudios.',
     faqs: [
       {
         question: '¿Qué es Aidoc?',
@@ -5691,7 +5694,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Coste y despliegue de nivel institucional',
     ],
     pricingNote:
-      'PathAI es una solución de pago con modelo empresarial e institucional. No ofrece tarifas públicas ni acceso para particulares: los acuerdos se negocian con laboratorios, hospitales y compañías farmacéuticas según el proyecto. Consulta su web para precios actualizados.',
+      'PathAI es una solución de pago con modelo empresarial e institucional. No ofrece tarifas públicas ni acceso para particulares: los acuerdos se negocian con laboratorios, hospitales y compañías farmacéuticas según el proyecto.',
     faqs: [
       {
         question: '¿Qué es PathAI?',
@@ -5740,7 +5743,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Puede generar respuestas incorrectas y requiere supervisión médica',
     ],
     pricingNote:
-      'Med-PaLM es principalmente un proyecto de investigación de Google, sin un modelo comercial de suscripción abierto al público. El acceso se ha canalizado a través de programas para organizaciones sanitarias seleccionadas y de la plataforma cloud de Google, donde el uso se factura por consumo. Consulta su web para precios actualizados.',
+      'Med-PaLM es principalmente un proyecto de investigación de Google, sin un modelo comercial de suscripción abierto al público. El acceso se ha canalizado a través de programas para organizaciones sanitarias seleccionadas y de la plataforma cloud de Google, donde el uso se factura por consumo.',
     faqs: [
       {
         question: '¿Qué es Med-PaLM?',
@@ -5789,7 +5792,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Siempre requiere validación del hallazgo por un radiólogo',
     ],
     pricingNote:
-      'Zebra Medical es una solución de pago dirigida a hospitales y sistemas de salud. No publica tarifas: el modelo habitual en este sector es el contrato institucional con precio por algoritmo o por estudio analizado. Su oferta se ha integrado en la de Nanox. Consulta su web para precios actualizados.',
+      'Zebra Medical es una solución de pago dirigida a hospitales y sistemas de salud. No publica tarifas: el modelo habitual en este sector es el contrato institucional con precio por algoritmo o por estudio analizado. Su oferta se ha integrado en la de Nanox.',
     faqs: [
       {
         question: '¿Qué es Zebra Medical Vision?',
@@ -5838,7 +5841,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Herramienta de apoyo: el diagnóstico sigue siendo del médico',
     ],
     pricingNote:
-      'Lunit es una solución de pago dirigida a instituciones sanitarias y farmacéuticas. No publica tarifas públicas: el precio se acuerda mediante contrato según los productos contratados y el volumen de estudios analizados. Consulta su web para precios actualizados.',
+      'Lunit es una solución de pago dirigida a instituciones sanitarias y farmacéuticas. No publica tarifas públicas: el precio se acuerda mediante contrato según los productos contratados y el volumen de estudios analizados.',
     faqs: [
       {
         question: '¿Qué es Lunit?',
@@ -5887,7 +5890,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Coste e implantación de nivel institucional',
     ],
     pricingNote:
-      'Enlitic es una solución de pago con modelo empresarial dirigida a hospitales y redes sanitarias. No publica tarifas abiertas: el precio se negocia por contrato según el volumen de estudios y los módulos contratados, normalmente tras una demostración. Consulta su web para precios actualizados.',
+      'Enlitic es una solución de pago con modelo empresarial dirigida a hospitales y redes sanitarias. No publica tarifas abiertas: el precio se negocia por contrato según el volumen de estudios y los módulos contratados, normalmente tras una demostración.',
     faqs: [
       {
         question: '¿Qué es Enlitic?',
@@ -5937,7 +5940,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Las funciones avanzadas se orientan sobre todo a empresas y aseguradoras',
     ],
     pricingNote:
-      'Ada Health sigue un modelo freemium: la evaluación de síntomas para particulares se ofrece sin coste en su aplicación, mientras que la monetización llega por acuerdos con sistemas sanitarios, aseguradoras y empresas. No hay tarifas públicas cerradas para el uso corporativo, que se negocia caso a caso. Consulta su web para condiciones y precios actualizados.',
+      'Ada Health sigue un modelo freemium: la evaluación de síntomas para particulares se ofrece sin coste en su aplicación, mientras que la monetización llega por acuerdos con sistemas sanitarios, aseguradoras y empresas. No hay tarifas públicas cerradas para el uso corporativo, que se negocia caso a caso.',
     faqs: [
       {
         question: '¿Qué es Ada Health?',
@@ -5987,7 +5990,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'No sustituye la atención presencial en casos urgentes o complejos',
     ],
     pricingNote:
-      'eMed opera con un modelo freemium: algunas funciones de orientación pueden usarse sin coste, mientras que las consultas clínicas y las pruebas supervisadas se facturan por servicio o a través de un plan corporativo o de aseguradora. Los precios dependen del país y del tipo de servicio contratado. Consulta su web para precios actualizados.',
+      'eMed opera con un modelo freemium: algunas funciones de orientación pueden usarse sin coste, mientras que las consultas clínicas y las pruebas supervisadas se facturan por servicio o a través de un plan corporativo o de aseguradora. Los precios dependen del país y del tipo de servicio contratado.',
     faqs: [
       {
         question: '¿Qué es eMed?',
@@ -6037,7 +6040,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'La versión avanzada e integrable está orientada a organizaciones',
     ],
     pricingNote:
-      'Buoy Health tiene un modelo freemium: el comprobador de síntomas es de uso gratuito para el público general, y los ingresos proceden de los acuerdos con sistemas sanitarios, aseguradoras y empresas que integran la herramienta. No publica tarifas cerradas para ese uso corporativo. Consulta su web para precios actualizados.',
+      'Buoy Health tiene un modelo freemium: el comprobador de síntomas es de uso gratuito para el público general, y los ingresos proceden de los acuerdos con sistemas sanitarios, aseguradoras y empresas que integran la herramienta. No publica tarifas cerradas para ese uso corporativo.',
     faqs: [
       {
         question: '¿Qué es Buoy Health?',
@@ -6087,7 +6090,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'La disponibilidad del servicio ha variado con el tiempo',
     ],
     pricingNote:
-      'Your.MD se ha ofrecido como servicio gratuito para el usuario final, sin coste por consultar síntomas ni acceder a sus contenidos de salud. El modelo de negocio se apoya en acuerdos con terceros del sector sanitario más que en suscripciones de particulares. Consulta su web para confirmar la disponibilidad y las condiciones actuales.',
+      'Your.MD se ha ofrecido como servicio gratuito para el usuario final, sin coste por consultar síntomas ni acceder a sus contenidos de salud. El modelo de negocio se apoya en acuerdos con terceros del sector sanitario más que en suscripciones de particulares.',
     faqs: [
       {
         question: '¿Qué es Your.MD?',
@@ -6187,7 +6190,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Sus predicciones deben validarse con evidencia adicional',
     ],
     pricingNote:
-      'AlphaMissense se ha liberado como recurso gratuito para la comunidad investigadora, con acceso abierto a su catálogo de predicciones. No funciona como producto comercial con planes de suscripción, aunque determinados usos pueden estar sujetos a condiciones de licencia. Consulta la documentación oficial para conocer los términos actualizados.',
+      'AlphaMissense se ha liberado como recurso gratuito para la comunidad investigadora, con acceso abierto a su catálogo de predicciones. No funciona como producto comercial con planes de suscripción, aunque determinados usos pueden estar sujetos a condiciones de licencia.',
     faqs: [
       {
         question: '¿Qué es AlphaMissense?',
@@ -6238,7 +6241,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Precios no públicos y orientados a acuerdos corporativos',
     ],
     pricingNote:
-      'BenevolentAI es un producto de pago dirigido a la industria biofarmacéutica y a organizaciones de investigación, sin plan gratuito ni autoservicio. El acceso suele articularse mediante licencias de plataforma o acuerdos de colaboración negociados caso a caso. No publica tarifas cerradas; consulta su web para solicitar información actualizada.',
+      'BenevolentAI es un producto de pago dirigido a la industria biofarmacéutica y a organizaciones de investigación, sin plan gratuito ni autoservicio. El acceso suele articularse mediante licencias de plataforma o acuerdos de colaboración negociados caso a caso. No publica tarifas cerradas;',
     faqs: [
       {
         question: '¿Qué es BenevolentAI?',
@@ -6288,7 +6291,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Puede cometer errores en explicaciones complejas y conviene revisarlas',
     ],
     pricingNote:
-      'Khanmigo se ofrece de forma gratuita para el profesorado y, en el caso de familias y distritos escolares, ha existido una suscripción de bajo coste destinada a cubrir gastos de funcionamiento. Al tratarse de una organización sin ánimo de lucro, las condiciones pueden variar por región. Consulta su web para precios actualizados.',
+      'Khanmigo se ofrece de forma gratuita para el profesorado y, en el caso de familias y distritos escolares, ha existido una suscripción de bajo coste destinada a cubrir gastos de funcionamiento. Al tratarse de una organización sin ánimo de lucro, las condiciones pueden variar por región.',
     faqs: [
       {
         question: '¿Qué es Khanmigo?',
@@ -6388,7 +6391,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'El plan gratuito tiene límites en captura y personalización',
     ],
     pricingNote:
-      'Scribe funciona con un modelo freemium: hay un plan gratuito con funciones básicas de captura y creación de guías, y planes de pago para profesionales y equipos que añaden IA avanzada, difuminado automático y controles de administración. Los planes de pago suelen partir de unos 20 $ por usuario y mes. Consulta su web para precios actualizados.',
+      'Scribe funciona con un modelo freemium: hay un plan gratuito con funciones básicas de captura y creación de guías, y planes de pago para profesionales y equipos que añaden IA avanzada, difuminado automático y controles de administración. Los planes de pago suelen partir de unos 20 $ por usuario y mes.',
     faqs: [
       {
         question: '¿Qué es Scribe AI?',
@@ -6438,7 +6441,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Las funciones de centro y administración son de pago',
     ],
     pricingNote:
-      'MagicSchool AI sigue un modelo freemium: ofrece un plan gratuito para docentes con acceso a buena parte de sus herramientas y planes de pago con más funciones, capacidad y administración para centros o distritos. Las tarifas dependen del número de usuarios. Consulta su web para precios actualizados.',
+      'MagicSchool AI sigue un modelo freemium: ofrece un plan gratuito para docentes con acceso a buena parte de sus herramientas y planes de pago con más funciones, capacidad y administración para centros o distritos. Las tarifas dependen del número de usuarios.',
     faqs: [
       {
         question: '¿Qué es MagicSchool AI?',
@@ -6488,7 +6491,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Puede sugerir cambios que alteran el estilo propio del autor',
     ],
     pricingNote:
-      'Grammarly funciona con un modelo freemium: el plan gratuito cubre correcciones básicas de gramática y ortografía, mientras que los planes de pago añaden sugerencias de estilo, tono y funciones avanzadas de IA. Las suscripciones individuales suelen rondar los 12-30 $ al mes según la modalidad, y existen planes por equipo. Consulta su web para precios actualizados.',
+      'Grammarly funciona con un modelo freemium: el plan gratuito cubre correcciones básicas de gramática y ortografía, mientras que los planes de pago añaden sugerencias de estilo, tono y funciones avanzadas de IA. Las suscripciones individuales suelen rondar los 12-30 $ al mes según la modalidad, y existen planes por equipo.',
     faqs: [
       {
         question: '¿Qué es Grammarly?',
@@ -6538,7 +6541,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Las funciones completas requieren licencia de centro',
     ],
     pricingNote:
-      'Writable opera con un modelo freemium: existe acceso gratuito con funciones limitadas para docentes y licencias de pago para centros y distritos que amplían el alcance, la integración y la administración. Las tarifas se negocian según el número de alumnos. Consulta su web para precios actualizados.',
+      'Writable opera con un modelo freemium: existe acceso gratuito con funciones limitadas para docentes y licencias de pago para centros y distritos que amplían el alcance, la integración y la administración. Las tarifas se negocian según el número de alumnos.',
     faqs: [
       {
         question: '¿Qué es Writable?',
@@ -6588,7 +6591,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'La calidad en español puede ser inferior a la del inglés',
     ],
     pricingNote:
-      'Eduaide sigue un modelo freemium: dispone de un plan gratuito con un número limitado de generaciones y planes de pago con uso ampliado y funciones adicionales. Las suscripciones individuales para docentes suelen situarse en una franja asequible mensual o anual. Consulta su web para precios actualizados.',
+      'Eduaide sigue un modelo freemium: dispone de un plan gratuito con un número limitado de generaciones y planes de pago con uso ampliado y funciones adicionales. Las suscripciones individuales para docentes suelen situarse en una franja asequible mensual o anual.',
     faqs: [
       {
         question: '¿Qué es Eduaide?',
@@ -6638,7 +6641,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'La versión gratuita muestra publicidad y tiene límites',
     ],
     pricingNote:
-      'Quizlet funciona con un modelo freemium: puedes crear y estudiar fichas gratis, mientras que las funciones avanzadas de IA, los exámenes de práctica ilimitados y la experiencia sin anuncios pertenecen a la suscripción de pago. Los planes individuales suelen rondar unos pocos euros al mes en su modalidad anual. Consulta su web para precios actualizados.',
+      'Quizlet funciona con un modelo freemium: puedes crear y estudiar fichas gratis, mientras que las funciones avanzadas de IA, los exámenes de práctica ilimitados y la experiencia sin anuncios pertenecen a la suscripción de pago. Los planes individuales suelen rondar unos pocos euros al mes en su modalidad anual.',
     faqs: [
       {
         question: '¿Qué es Quizlet?',
@@ -6688,7 +6691,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'La calidad depende mucho del texto de partida',
     ],
     pricingNote:
-      'QuestionWell es freemium: ofrece un plan gratuito con un número limitado de generaciones al mes y planes de pago para docentes o centros que amplían el uso y añaden funciones. Los precios individuales se sitúan en una franja asequible mensual o anual. Consulta su web para precios actualizados.',
+      'QuestionWell es freemium: ofrece un plan gratuito con un número limitado de generaciones al mes y planes de pago para docentes o centros que amplían el uso y añaden funciones. Los precios individuales se sitúan en una franja asequible mensual o anual.',
     faqs: [
       {
         question: '¿Qué es QuestionWell?',
@@ -6738,7 +6741,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'El contenido está más pulido en inglés que en español',
     ],
     pricingNote:
-      'Curipod es freemium: cuenta con un plan gratuito que permite crear y lanzar lecciones con límites, y planes de pago para docentes y centros que amplían las funciones, el almacenamiento y la gestión. Las tarifas dependen del tipo de licencia. Consulta su web para precios actualizados.',
+      'Curipod es freemium: cuenta con un plan gratuito que permite crear y lanzar lecciones con límites, y planes de pago para docentes y centros que amplían las funciones, el almacenamiento y la gestión. Las tarifas dependen del tipo de licencia.',
     faqs: [
       {
         question: '¿Qué es Curipod?',
@@ -6788,7 +6791,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'El uso intensivo y las funciones de centro son de pago',
     ],
     pricingNote:
-      'TeachMate AI funciona con un modelo freemium: hay un plan gratuito con acceso limitado a sus generadores y suscripciones de pago para docentes y centros que amplían el uso y añaden funciones de gestión. Las tarifas varían según el tipo de licencia. Consulta su web para precios actualizados.',
+      'TeachMate AI funciona con un modelo freemium: hay un plan gratuito con acceso limitado a sus generadores y suscripciones de pago para docentes y centros que amplían el uso y añaden funciones de gestión. Las tarifas varían según el tipo de licencia.',
     faqs: [
       {
         question: '¿Qué es TeachMate AI?',
@@ -6838,7 +6841,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Los niveles de lectura siguen referencias del sistema estadounidense',
     ],
     pricingNote:
-      'Diffit es freemium: ofrece un plan gratuito con funciones básicas para docentes y planes de pago que amplían las generaciones, la exportación y las opciones de equipo o centro. Las tarifas dependen del tipo de licencia y del número de usuarios. Consulta su web para precios actualizados.',
+      'Diffit es freemium: ofrece un plan gratuito con funciones básicas para docentes y planes de pago que amplían las generaciones, la exportación y las opciones de equipo o centro. Las tarifas dependen del tipo de licencia y del número de usuarios.',
     faqs: [
       {
         question: '¿Qué es Diffit?',
@@ -6888,7 +6891,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'El análisis se centra en la forma, no en el contenido del mensaje',
     ],
     pricingNote:
-      'Speaker Coach se incluye sin coste adicional dentro de PowerPoint, tanto en su versión web como en las aplicaciones asociadas a una cuenta Microsoft. No requiere una suscripción específica, aunque la disponibilidad de la función puede depender del plan de Microsoft 365 y del idioma. Consulta la documentación oficial para confirmar las condiciones actuales.',
+      'Speaker Coach se incluye sin coste adicional dentro de PowerPoint, tanto en su versión web como en las aplicaciones asociadas a una cuenta Microsoft. No requiere una suscripción específica, aunque la disponibilidad de la función puede depender del plan de Microsoft 365 y del idioma.',
     faqs: [
       {
         question: '¿Qué es Speaker Coach?',
@@ -6938,7 +6941,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Los datos están anonimizados, lo que dificulta interpretar las variables',
     ],
     pricingNote:
-      'Participar en la competición y descargar los datasets es gratuito. El componente económico está en el staking: se aporta criptomoneda propia del proyecto y se gana o se pierde según el rendimiento de las predicciones, por lo que no es una suscripción sino un modelo de riesgo y recompensa. Consulta su web para conocer las condiciones actualizadas.',
+      'Participar en la competición y descargar los datasets es gratuito. El componente económico está en el staking: se aporta criptomoneda propia del proyecto y se gana o se pierde según el rendimiento de las predicciones, por lo que no es una suscripción sino un modelo de riesgo y recompensa.',
     faqs: [
       {
         question: '¿Qué es Numerai?',
@@ -6988,7 +6991,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'La lógica interna de los modelos es poco transparente para el cliente',
     ],
     pricingNote:
-      'EquBot opera con un modelo de pago orientado al mercado institucional, sin planes públicos ni versión gratuita de autoservicio. El acceso suele negociarse mediante licencia o acuerdo comercial, y el coste depende del alcance y del tipo de cliente. Consulta su web y contacta con su equipo comercial para conocer las condiciones actualizadas.',
+      'EquBot opera con un modelo de pago orientado al mercado institucional, sin planes públicos ni versión gratuita de autoservicio. El acceso suele negociarse mediante licencia o acuerdo comercial, y el coste depende del alcance y del tipo de cliente.',
     faqs: [
       {
         question: '¿Qué es EquBot?',
@@ -7038,7 +7041,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Enfoque muy centrado en el mercado estadounidense',
     ],
     pricingNote:
-      'Zest AI funciona con un modelo de pago B2B, normalmente mediante licencia o contrato de servicio con la entidad financiera. No publica tarifas ni ofrece plan gratuito, y el coste depende del volumen de operaciones y del alcance de la implantación. Consulta su web y solicita una demostración para conocer las condiciones actualizadas.',
+      'Zest AI funciona con un modelo de pago B2B, normalmente mediante licencia o contrato de servicio con la entidad financiera. No publica tarifas ni ofrece plan gratuito, y el coste depende del volumen de operaciones y del alcance de la implantación.',
     faqs: [
       {
         question: '¿Qué es Zest AI?',
@@ -7088,7 +7091,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'No es una herramienta que el usuario controle: es un producto financiero',
     ],
     pricingNote:
-      'Upstart no se vende como suscripción de software: es un producto financiero. Para el solicitante, el coste está en los intereses y en posibles comisiones de apertura, que varían según su perfil de riesgo. Para las entidades, la tecnología se contrata mediante acuerdo comercial. Consulta su web para conocer condiciones y tipos actualizados.',
+      'Upstart no se vende como suscripción de software: es un producto financiero. Para el solicitante, el coste está en los intereses y en posibles comisiones de apertura, que varían según su perfil de riesgo. Para las entidades, la tecnología se contrata mediante acuerdo comercial.',
     faqs: [
       {
         question: '¿Qué es Upstart?',
@@ -7138,7 +7141,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Producto B2B: no es utilizable por particulares',
     ],
     pricingNote:
-      'CredoLab trabaja con un modelo de pago B2B, habitualmente basado en el volumen de puntuaciones consultadas o en una licencia acordada con la entidad. No hay planes públicos ni versión gratuita para usuarios finales, aunque suele ofrecer pruebas piloto a empresas. Consulta su web para conocer las condiciones actualizadas.',
+      'CredoLab trabaja con un modelo de pago B2B, habitualmente basado en el volumen de puntuaciones consultadas o en una licencia acordada con la entidad. No hay planes públicos ni versión gratuita para usuarios finales, aunque suele ofrecer pruebas piloto a empresas.',
     faqs: [
       {
         question: '¿Qué es CredoLab?',
@@ -7188,7 +7191,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'El tono informal no gusta a todo el mundo',
     ],
     pricingNote:
-      'Cleo sigue un modelo freemium: hay una versión gratuita con seguimiento de gastos y presupuestos básicos, y una suscripción de pago que desbloquea funciones adicionales de ahorro y análisis. La cuota mensual suele situarse en el entorno de unos pocos euros o dólares. Consulta su web para precios y disponibilidad actualizados.',
+      'Cleo sigue un modelo freemium: hay una versión gratuita con seguimiento de gastos y presupuestos básicos, y una suscripción de pago que desbloquea funciones adicionales de ahorro y análisis. La cuota mensual suele situarse en el entorno de unos pocos euros o dólares.',
     faqs: [
       {
         question: '¿Qué es Cleo?',
@@ -7238,7 +7241,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Invertir implica riesgo de pérdida, algo que la automatización puede hacer olvidar',
     ],
     pricingNote:
-      'Plum funciona con un modelo freemium: hay un plan gratuito con ahorro automático básico y varios niveles de suscripción que añaden reglas avanzadas, más opciones de inversión y análisis. Las cuotas mensuales suelen ser de unos pocos euros, y algunos productos de inversión llevan comisiones adicionales. Consulta su web para precios actualizados.',
+      'Plum funciona con un modelo freemium: hay un plan gratuito con ahorro automático básico y varios niveles de suscripción que añaden reglas avanzadas, más opciones de inversión y análisis. Las cuotas mensuales suelen ser de unos pocos euros, y algunos productos de inversión llevan comisiones adicionales.',
     faqs: [
       {
         question: '¿Qué es Plum?',
@@ -7337,7 +7340,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Precios no públicos y coste elevado',
     ],
     pricingNote:
-      'FICO comercializa sus soluciones de fraude con un modelo empresarial de pago, mediante licencias o contratos plurianuales adaptados a cada entidad. No hay planes públicos ni versión gratuita, y el coste depende del volumen de transacciones y de los módulos contratados. Consulta su web y contacta con su equipo comercial para conocer las condiciones actualizadas.',
+      'FICO comercializa sus soluciones de fraude con un modelo empresarial de pago, mediante licencias o contratos plurianuales adaptados a cada entidad. No hay planes públicos ni versión gratuita, y el coste depende del volumen de transacciones y de los módulos contratados.',
     faqs: [
       {
         question: '¿Qué es FICO?',
@@ -7387,7 +7390,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Precios no públicos, negociados caso por caso',
     ],
     pricingNote:
-      'Feedzai opera con un modelo de pago empresarial: licencias o contratos adaptados al volumen de transacciones y a los módulos contratados. No dispone de plan gratuito ni de tarifas publicadas. Lo habitual es solicitar una demostración y negociar las condiciones con su equipo comercial. Consulta su web para información actualizada.',
+      'Feedzai opera con un modelo de pago empresarial: licencias o contratos adaptados al volumen de transacciones y a los módulos contratados. No dispone de plan gratuito ni de tarifas publicadas. Lo habitual es solicitar una demostración y negociar las condiciones con su equipo comercial.',
     faqs: [
       {
         question: '¿Qué es Feedzai?',
@@ -7437,7 +7440,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Orientada a organizaciones con equipo de seguridad, no a usuarios individuales',
     ],
     pricingNote:
-      'Darktrace se vende con un modelo empresarial de pago mediante suscripción o licencia, con precios no publicados que dependen del tamaño de la organización, del número de dispositivos y de los módulos contratados. Suele ofrecer pruebas piloto antes de la contratación. Consulta su web y contacta con su equipo comercial para conocer las condiciones actualizadas.',
+      'Darktrace se vende con un modelo empresarial de pago mediante suscripción o licencia, con precios no publicados que dependen del tamaño de la organización, del número de dispositivos y de los módulos contratados. Suele ofrecer pruebas piloto antes de la contratación.',
     faqs: [
       {
         question: '¿Qué es Darktrace?',
@@ -7487,7 +7490,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'La calidad de las imágenes generadas es irregular según el caso',
     ],
     pricingNote:
-      'Fotor sigue un modelo freemium: hay una versión gratuita con funciones básicas, créditos limitados de IA y marca de agua en algunas salidas. Los planes de pago, con cuotas mensuales que suelen situarse en el rango bajo de las herramientas de diseño, eliminan esas limitaciones y amplían plantillas y almacenamiento. Consulta su web para precios actualizados.',
+      'Fotor sigue un modelo freemium: hay una versión gratuita con funciones básicas, créditos limitados de IA y marca de agua en algunas salidas. Los planes de pago, con cuotas mensuales que suelen situarse en el rango bajo de las herramientas de diseño, eliminan esas limitaciones y amplían plantillas y almacenamiento.',
     faqs: [
       {
         question: '¿Qué es Fotor?',
@@ -7537,7 +7540,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'No sustituye el criterio de diseño ni la investigación de usuario',
     ],
     pricingNote:
-      'Figma trabaja con un modelo freemium: hay un plan gratuito con limitaciones y planes de pago por editor, cuyo precio mensual varía según el nivel. El acceso a las funciones de IA y sus límites de uso dependen del plan contratado y han ido cambiando. Consulta su web para conocer los precios y la disponibilidad actualizados.',
+      'Figma trabaja con un modelo freemium: hay un plan gratuito con limitaciones y planes de pago por editor, cuyo precio mensual varía según el nivel. El acceso a las funciones de IA y sus límites de uso dependen del plan contratado y han ido cambiando.',
     faqs: [
       {
         question: '¿Qué es Figma AI?',
@@ -7587,7 +7590,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'El plan gratuito limita el número de proyectos',
     ],
     pricingNote:
-      'Uizard sigue un modelo freemium: un plan gratuito con un número limitado de proyectos y funciones, y planes de pago por usuario que amplían proyectos, generaciones de IA y opciones de colaboración. Los tramos de pago suelen situarse en el entorno de unas decenas de euros al mes por usuario. Consulta su web para precios actualizados.',
+      'Uizard sigue un modelo freemium: un plan gratuito con un número limitado de proyectos y funciones, y planes de pago por usuario que amplían proyectos, generaciones de IA y opciones de colaboración. Los tramos de pago suelen situarse en el entorno de unas decenas de euros al mes por usuario.',
     faqs: [
       {
         question: '¿Qué es Uizard?',
@@ -7687,7 +7690,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'No sustituye el trabajo estratégico de una identidad de marca real',
     ],
     pricingNote:
-      'Looka permite generar y previsualizar logos sin coste, pero la descarga de los archivos exige una compra puntual del logo o una suscripción al kit de marca. Los paquetes suelen situarse en el rango de unas decenas de euros para el logo y una cuota anual para el kit completo. Consulta su web para precios actualizados.',
+      'Looka permite generar y previsualizar logos sin coste, pero la descarga de los archivos exige una compra puntual del logo o una suscripción al kit de marca. Los paquetes suelen situarse en el rango de unas decenas de euros para el logo y una cuota anual para el kit completo.',
     faqs: [
       {
         question: '¿Qué es Looka?',
@@ -7737,7 +7740,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Personalización más limitada que en un editor profesional',
     ],
     pricingNote:
-      'Brandmark funciona con un esquema freemium: crear y previsualizar logos no cuesta nada, pero descargar los archivos requiere un pago único, con distintos paquetes según los formatos y extras incluidos. Los precios suelen situarse en el rango de unas decenas de dólares. Consulta su web para conocer los paquetes y precios actualizados.',
+      'Brandmark funciona con un esquema freemium: crear y previsualizar logos no cuesta nada, pero descargar los archivos requiere un pago único, con distintos paquetes según los formatos y extras incluidos. Los precios suelen situarse en el rango de unas decenas de dólares.',
     faqs: [
       {
         question: '¿Qué es Brandmark?',
@@ -7787,7 +7790,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'No entrega archivos vectoriales completos ni kit de marca avanzado',
     ],
     pricingNote:
-      'Hatchful es gratuito: puedes generar el logo y descargar los archivos sin pagar ni introducir tarjeta. Shopify lo ofrece como herramienta de captación para su plataforma de comercio electrónico. Al no haber planes de pago, no hay funciones premium que desbloquear. Consulta su web por si cambian las condiciones de uso.',
+      'Hatchful es gratuito: puedes generar el logo y descargar los archivos sin pagar ni introducir tarjeta. Shopify lo ofrece como herramienta de captación para su plataforma de comercio electrónico. Al no haber planes de pago, no hay funciones premium que desbloquear.',
     faqs: [
       {
         question: '¿Qué es Hatchful?',
@@ -7837,7 +7840,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Publicar con dominio propio requiere plan de pago',
     ],
     pricingNote:
-      'Durable emplea un modelo freemium: se puede generar y previsualizar la web sin coste, pero publicarla con dominio propio y usar las funciones de negocio requiere suscripción. Los planes de pago suelen situarse en el entorno de unas decenas de euros al mes, con descuento en pago anual. Consulta su web para precios actualizados.',
+      'Durable emplea un modelo freemium: se puede generar y previsualizar la web sin coste, pero publicarla con dominio propio y usar las funciones de negocio requiere suscripción. Los planes de pago suelen situarse en el entorno de unas decenas de euros al mes, con descuento en pago anual.',
     faqs: [
       {
         question: '¿Qué es Durable?',
@@ -7887,7 +7890,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Menos control sobre el código y el rendimiento que otras opciones',
     ],
     pricingNote:
-      'Wix funciona con un modelo freemium: puedes crear y publicar un sitio gratis con subdominio de Wix y anuncios de la plataforma. Para usar dominio propio, quitar la publicidad y activar comercio electrónico hay que contratar un plan de pago, con cuotas mensuales de un rango amplio. Consulta su web para precios actualizados.',
+      'Wix funciona con un modelo freemium: puedes crear y publicar un sitio gratis con subdominio de Wix y anuncios de la plataforma. Para usar dominio propio, quitar la publicidad y activar comercio electrónico hay que contratar un plan de pago, con cuotas mensuales de un rango amplio.',
     faqs: [
       {
         question: '¿Qué es Wix ADI?',
@@ -7937,7 +7940,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Los planes con más tráfico y funciones encarecen bastante el proyecto',
     ],
     pricingNote:
-      'Framer sigue un modelo freemium: suele ofrecer un plan gratuito con limitaciones (subdominio propio de la plataforma y límites de páginas o tráfico) y varios planes de pago mensuales según el número de sitios, visitas y funciones de CMS o colaboración. Las funciones de IA pueden estar sujetas a límites de uso según el plan. Consulta su web para precios actualizados.',
+      'Framer sigue un modelo freemium: suele ofrecer un plan gratuito con limitaciones (subdominio propio de la plataforma y límites de páginas o tráfico) y varios planes de pago mensuales según el número de sitios, visitas y funciones de CMS o colaboración. Las funciones de IA pueden estar sujetas a límites de uso según el plan.',
     faqs: [
       {
         question: '¿Qué es Framer AI?',
@@ -7986,7 +7989,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'El ajuste inicial para reducir falsos positivos lleva tiempo',
     ],
     pricingNote:
-      'Vectra AI es una plataforma comercial de pago dirigida al mercado empresarial. No publica tarifas cerradas: el coste se negocia con el fabricante o un partner y depende del número de usuarios, sensores, volumen de tráfico y módulos contratados. Lo habitual es solicitar una demostración y una propuesta a medida. Consulta su web para información actualizada.',
+      'Vectra AI es una plataforma comercial de pago dirigida al mercado empresarial. No publica tarifas cerradas: el coste se negocia con el fabricante o un partner y depende del número de usuarios, sensores, volumen de tráfico y módulos contratados. Lo habitual es solicitar una demostración y una propuesta a medida.',
     faqs: [
       {
         question: '¿Qué es Vectra AI?',
@@ -8035,7 +8038,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Sin plan gratuito: es un producto de pago para empresas',
     ],
     pricingNote:
-      'Cylance es un producto comercial de pago con licenciamiento por endpoint y suscripción anual, normalmente contratado a través de partners o distribuidores. El precio varía según el número de equipos, los módulos incluidos y si se añade servicio gestionado. No suele publicarse una tarifa pública cerrada; consulta su web o a un partner para precios actualizados.',
+      'Cylance es un producto comercial de pago con licenciamiento por endpoint y suscripción anual, normalmente contratado a través de partners o distribuidores. El precio varía según el número de equipos, los módulos incluidos y si se añade servicio gestionado. No suele publicarse una tarifa pública cerrada;',
     faqs: [
       {
         question: '¿Qué es Cylance?',
@@ -8084,7 +8087,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'El valor depende mucho de la calidad de los logs que se ingesten',
     ],
     pricingNote:
-      'Exabeam es una plataforma de pago para empresas. El precio se establece mediante presupuesto personalizado y suele depender del volumen de datos ingeridos o del número de usuarios monitorizados, además de los módulos contratados. No publica tarifas cerradas ni ofrece plan gratuito; consulta su web para información actualizada.',
+      'Exabeam es una plataforma de pago para empresas. El precio se establece mediante presupuesto personalizado y suele depender del volumen de datos ingeridos o del número de usuarios monitorizados, además de los módulos contratados. No publica tarifas cerradas ni ofrece plan gratuito;',
     faqs: [
       {
         question: '¿Qué es Exabeam?',
@@ -8133,7 +8136,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'La interfaz puede resultar densa para usuarios noveles',
     ],
     pricingNote:
-      'Securonix es una solución de pago dirigida al mercado empresarial. El coste se acuerda mediante presupuesto y suele calcularse por número de identidades o volumen de datos analizados, con contratos de suscripción anuales. No existe plan gratuito público; consulta su web para conocer las opciones actualizadas.',
+      'Securonix es una solución de pago dirigida al mercado empresarial. El coste se acuerda mediante presupuesto y suele calcularse por número de identidades o volumen de datos analizados, con contratos de suscripción anuales. No existe plan gratuito público;',
     faqs: [
       {
         question: '¿Qué es Securonix?',
@@ -8182,7 +8185,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Coste de licencia y de almacenamiento de logs a largo plazo',
     ],
     pricingNote:
-      'LogRhythm se comercializa mediante licencias de pago para empresas, con modelos que han combinado el número de dispositivos o el volumen de datos procesados. El precio se solicita al fabricante o a un partner y depende de la arquitectura elegida y de los módulos contratados. Consulta su web para precios actualizados.',
+      'LogRhythm se comercializa mediante licencias de pago para empresas, con modelos que han combinado el número de dispositivos o el volumen de datos procesados. El precio se solicita al fabricante o a un partner y depende de la arquitectura elegida y de los módulos contratados.',
     faqs: [
       {
         question: '¿Qué es LogRhythm?',
@@ -8231,7 +8234,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'La cantidad de módulos complica elegir la licencia adecuada',
     ],
     pricingNote:
-      'SentinelOne es un producto de pago con licenciamiento por endpoint y suscripción anual, disponible en varios niveles según las capacidades de EDR, XDR y servicios gestionados incluidos. El coste depende del número de dispositivos y de los módulos contratados, y suele negociarse con el fabricante o un partner. Consulta su web para precios actualizados.',
+      'SentinelOne es un producto de pago con licenciamiento por endpoint y suscripción anual, disponible en varios niveles según las capacidades de EDR, XDR y servicios gestionados incluidos. El coste depende del número de dispositivos y de los módulos contratados, y suele negociarse con el fabricante o un partner.',
     faqs: [
       {
         question: '¿Qué es SentinelOne?',
@@ -8280,7 +8283,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Aprovecharlo del todo exige un equipo de seguridad con experiencia',
     ],
     pricingNote:
-      'CrowdStrike se vende por suscripción con licenciamiento por endpoint y por módulos, en distintos paquetes según las capacidades incluidas (prevención, EDR, identidad, cloud, servicios gestionados). Los precios de lista existen para algunos paquetes, pero lo habitual en empresa es un presupuesto negociado. Consulta su web para precios actualizados.',
+      'CrowdStrike se vende por suscripción con licenciamiento por endpoint y por módulos, en distintos paquetes según las capacidades incluidas (prevención, EDR, identidad, cloud, servicios gestionados). Los precios de lista existen para algunos paquetes, pero lo habitual en empresa es un presupuesto negociado.',
     faqs: [
       {
         question: '¿Qué es CrowdStrike?',
@@ -8329,7 +8332,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Riesgo de dependencia del ecosistema del fabricante',
     ],
     pricingNote:
-      'Es una plataforma comercial de pago dirigida a empresas industriales. El coste depende del número de activos conectados, del volumen de datos y de los módulos o aplicaciones contratadas, y normalmente se articula mediante suscripción con presupuesto a medida. Consulta la web de Siemens para conocer las condiciones actualizadas.',
+      'Es una plataforma comercial de pago dirigida a empresas industriales. El coste depende del número de activos conectados, del volumen de datos y de los módulos o aplicaciones contratadas, y normalmente se articula mediante suscripción con presupuesto a medida.',
     faqs: [
       {
         question: '¿Qué es Siemens MindSphere?',
@@ -8378,7 +8381,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'La estrategia de producto ha ido cambiando con los años',
     ],
     pricingNote:
-      'Predix es una oferta comercial de pago para empresas industriales. No publica tarifas cerradas: el coste se define por proyecto, en función de los activos conectados, el volumen de datos y las aplicaciones contratadas, normalmente con contratos de suscripción. Consulta la web de GE Digital para información actualizada.',
+      'Predix es una oferta comercial de pago para empresas industriales. No publica tarifas cerradas: el coste se define por proyecto, en función de los activos conectados, el volumen de datos y las aplicaciones contratadas, normalmente con contratos de suscripción.',
     faqs: [
       {
         question: '¿Qué es Predix?',
@@ -8427,7 +8430,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'La integración con sistemas existentes puede ser laboriosa',
     ],
     pricingNote:
-      'Uptake se comercializa como solución de pago para empresas, con suscripciones cuyo precio depende del número y tipo de activos monitorizados y de los módulos contratados. No publica tarifas cerradas y lo habitual es solicitar una demostración y un presupuesto a medida. Consulta su web para información actualizada.',
+      'Uptake se comercializa como solución de pago para empresas, con suscripciones cuyo precio depende del número y tipo de activos monitorizados y de los módulos contratados. No publica tarifas cerradas y lo habitual es solicitar una demostración y un presupuesto a medida.',
     faqs: [
       {
         question: '¿Qué es Uptake?',
@@ -8476,7 +8479,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Requiere formación y trabajo de integración para aportar valor real',
     ],
     pricingNote:
-      'Spot es un producto de hardware de pago con un precio de adquisición alto, al que se suman cargas útiles, software y soporte. Boston Dynamics comercializa el robot mediante presupuesto y distribuidores, y el coste total depende de la configuración elegida. Consulta su web para conocer las condiciones y precios actualizados.',
+      'Spot es un producto de hardware de pago con un precio de adquisición alto, al que se suman cargas útiles, software y soporte. Boston Dynamics comercializa el robot mediante presupuesto y distribuidores, y el coste total depende de la configuración elegida.',
     faqs: [
       {
         question: '¿Qué es Spot de Boston Dynamics?',
@@ -8525,7 +8528,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Su futuro depende de los movimientos corporativos recientes',
     ],
     pricingNote:
-      'Covariant no es un producto de consumo con tarifa pública, sino una solución industrial de pago que se implanta mediante proyecto e integración con el hardware robótico del cliente. El coste depende del número de estaciones, del hardware y del alcance del despliegue. Consulta con la empresa para conocer las condiciones actualizadas.',
+      'Covariant no es un producto de consumo con tarifa pública, sino una solución industrial de pago que se implanta mediante proyecto e integración con el hardware robótico del cliente. El coste depende del número de estaciones, del hardware y del alcance del despliegue.',
     faqs: [
       {
         question: '¿Qué es Covariant?',
@@ -8574,7 +8577,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Depende de una integración cuidadosa con el flujo logístico',
     ],
     pricingNote:
-      'Osaro es una solución industrial de pago que se comercializa mediante proyecto y presupuesto personalizado, en función del número de estaciones robotizadas, el hardware empleado y el alcance de la integración. No publica tarifas públicas ni ofrece versión gratuita. Consulta su web para información actualizada.',
+      'Osaro es una solución industrial de pago que se comercializa mediante proyecto y presupuesto personalizado, en función del número de estaciones robotizadas, el hardware empleado y el alcance de la integración. No publica tarifas públicas ni ofrece versión gratuita.',
     faqs: [
       {
         question: '¿Qué es Osaro?',
@@ -8623,7 +8626,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Necesita un periodo de aprendizaje antes de rendir al máximo',
     ],
     pricingNote:
-      'Augury se comercializa como servicio de pago que combina hardware (sensores) y suscripción al software de diagnóstico. El precio suele calcularse por máquina monitorizada y no se publica en tarifa cerrada, por lo que hay que solicitar presupuesto. Consulta su web para conocer las condiciones actualizadas.',
+      'Augury se comercializa como servicio de pago que combina hardware (sensores) y suscripción al software de diagnóstico. El precio suele calcularse por máquina monitorizada y no se publica en tarifa cerrada, por lo que hay que solicitar presupuesto.',
     faqs: [
       {
         question: '¿Qué es Augury?',
@@ -8672,7 +8675,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Puede requerir integración con sistemas heredados de planta',
     ],
     pricingNote:
-      'Senseye Predictive Maintenance es un producto de pago por suscripción dentro del catálogo de Siemens. El coste suele depender del número de activos o máquinas monitorizadas y de los servicios de implantación asociados, y se acuerda mediante presupuesto. Consulta la web de Siemens para precios actualizados.',
+      'Senseye Predictive Maintenance es un producto de pago por suscripción dentro del catálogo de Siemens. El coste suele depender del número de activos o máquinas monitorizadas y de los servicios de implantación asociados, y se acuerda mediante presupuesto.',
     faqs: [
       {
         question: '¿Qué es Senseye?',
@@ -8721,7 +8724,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'El cambio de marca a Avathon puede generar confusión',
     ],
     pricingNote:
-      'Es una solución empresarial de pago, comercializada por proyecto y suscripción. El coste depende del alcance del despliegue, de los activos analizados y de los servicios de implantación necesarios, y se acuerda mediante presupuesto. No existe plan gratuito; consulta su web para información actualizada.',
+      'Es una solución empresarial de pago, comercializada por proyecto y suscripción. El coste depende del alcance del despliegue, de los activos analizados y de los servicios de implantación necesarios, y se acuerda mediante presupuesto. No existe plan gratuito;',
     faqs: [
       {
         question: '¿Qué es SparkCognition?',
@@ -8770,7 +8773,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'El uso serio requiere plan de pago y coste de despliegue',
     ],
     pricingNote:
-      'LandingLens funciona con un modelo de suscripción de pago para empresas, aunque suele existir un nivel de entrada o prueba con límites de uso para evaluar la plataforma. El precio depende del número de modelos, dispositivos de despliegue y usuarios. Consulta su web para precios actualizados.',
+      'LandingLens funciona con un modelo de suscripción de pago para empresas, aunque suele existir un nivel de entrada o prueba con límites de uso para evaluar la plataforma. El precio depende del número de modelos, dispositivos de despliegue y usuarios.',
     faqs: [
       {
         question: '¿Qué es LandingLens?',
@@ -8819,7 +8822,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Producto de pago orientado a empresas',
     ],
     pricingNote:
-      'Matroid es una plataforma comercial de pago, con planes por suscripción cuyo coste depende del número de detectores, cámaras o flujos de vídeo procesados y del tipo de despliegue. Puede facilitar pruebas o demostraciones, pero no un plan gratuito para uso productivo. Consulta su web para precios actualizados.',
+      'Matroid es una plataforma comercial de pago, con planes por suscripción cuyo coste depende del número de detectores, cámaras o flujos de vídeo procesados y del tipo de despliegue. Puede facilitar pruebas o demostraciones, pero no un plan gratuito para uso productivo.',
     faqs: [
       {
         question: '¿Qué es Matroid?',
@@ -8868,7 +8871,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Configurar inspecciones complejas requiere formación específica',
     ],
     pricingNote:
-      'Cognex vende hardware y licencias de software de pago, normalmente a través de distribuidores e integradores. El coste depende del modelo de cámara o sensor, del software de visión elegido y del proyecto de integración, sin tarifa pública única. Consulta su web o a un distribuidor para precios actualizados.',
+      'Cognex vende hardware y licencias de software de pago, normalmente a través de distribuidores e integradores. El coste depende del modelo de cámara o sensor, del software de visión elegido y del proyecto de integración, sin tarifa pública única.',
     faqs: [
       {
         question: '¿Qué es Cognex?',
@@ -8918,7 +8921,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'No incluye interfaz de usuario lista para producción',
     ],
     pricingNote:
-      'LLaVA es un proyecto de código abierto y sus pesos se distribuyen de forma gratuita, así que no hay planes ni suscripciones. El coste real es el de la infraestructura donde lo ejecutes: GPU propia o alquilada en la nube. Revisa las licencias del modelo y de los datos antes de un uso comercial y consulta su web para condiciones actualizadas.',
+      'LLaVA es un proyecto de código abierto y sus pesos se distribuyen de forma gratuita, así que no hay planes ni suscripciones. El coste real es el de la infraestructura donde lo ejecutes: GPU propia o alquilada en la nube. Revisa las licencias del modelo y de los datos antes de un uso comercial y',
     faqs: [
       {
         question: '¿Qué es LLaVA?',
@@ -8968,7 +8971,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Rendimiento inferior a los multimodales cerrados más avanzados',
     ],
     pricingNote:
-      'Fuyu se distribuye como modelo de pesos abiertos, sin suscripción ni pago por uso. El gasto proviene del hardware o del proveedor de nube en el que lo despliegues. Antes de un uso comercial conviene revisar la licencia publicada junto al modelo; consulta la ficha oficial en Hugging Face para las condiciones actualizadas.',
+      'Fuyu se distribuye como modelo de pesos abiertos, sin suscripción ni pago por uso. El gasto proviene del hardware o del proveedor de nube en el que lo despliegues. Antes de un uso comercial conviene revisar la licencia publicada junto al modelo;',
     faqs: [
       {
         question: '¿Qué es Fuyu?',
@@ -9170,7 +9173,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Menos soporte y actualizaciones que un producto de pago',
     ],
     pricingNote:
-      'IDEFICS se distribuye como modelo abierto y gratuito a través de Hugging Face, sin suscripción ni consumo por llamada. El coste es el de la infraestructura donde lo ejecutes, ya sea GPU propia o alquilada. Si prefieres no gestionar servidores, existen servicios de inferencia de pago; consulta la web para precios actualizados.',
+      'IDEFICS se distribuye como modelo abierto y gratuito a través de Hugging Face, sin suscripción ni consumo por llamada. El coste es el de la infraestructura donde lo ejecutes, ya sea GPU propia o alquilada. Si prefieres no gestionar servidores, existen servicios de inferencia de pago;',
     faqs: [
       {
         question: '¿Qué es IDEFICS?',
@@ -9220,7 +9223,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Las dependencias y versiones pueden dar problemas de compatibilidad',
     ],
     pricingNote:
-      'Transformers es una biblioteca de código abierto y su uso es gratuito, sin suscripción ni límites de llamadas. Hugging Face sí ofrece servicios de pago complementarios, como inferencia gestionada o funcionalidades para empresas, que se contratan aparte. Consulta su web para conocer los precios actualizados de esos servicios.',
+      'Transformers es una biblioteca de código abierto y su uso es gratuito, sin suscripción ni límites de llamadas. Hugging Face sí ofrece servicios de pago complementarios, como inferencia gestionada o funcionalidades para empresas, que se contratan aparte.',
     faqs: [
       {
         question: '¿Qué es Transformers de Hugging Face?',
@@ -9270,7 +9273,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Requiere conocimientos de MLOps para escalar bien',
     ],
     pricingNote:
-      'OpenLLM es software de código abierto y su uso no tiene coste de licencia. El gasto real está en las GPU y servidores donde despliegues los modelos. BentoML ofrece además servicios gestionados de pago para quien no quiera administrar la infraestructura; consulta su web para conocer los precios actualizados.',
+      'OpenLLM es software de código abierto y su uso no tiene coste de licencia. El gasto real está en las GPU y servidores donde despliegues los modelos. BentoML ofrece además servicios gestionados de pago para quien no quiera administrar la infraestructura;',
     faqs: [
       {
         question: '¿Qué es OpenLLM?',
@@ -9320,7 +9323,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'El proyecto ha evolucionado y cambiado de nombre y alcance',
     ],
     pricingNote:
-      'MemGPT nació como proyecto de código abierto y su uso no tiene coste de licencia. Lo que sí supone gasto es el consumo del modelo de lenguaje que utilices por debajo y la base de datos donde guardes la memoria. El proyecto ha ido evolucionando hacia una plataforma con opciones alojadas: consulta su web para precios actualizados.',
+      'MemGPT nació como proyecto de código abierto y su uso no tiene coste de licencia. Lo que sí supone gasto es el consumo del modelo de lenguaje que utilices por debajo y la base de datos donde guardes la memoria. El proyecto ha ido evolucionando hacia una plataforma con opciones alojadas:',
     faqs: [
       {
         question: '¿Qué es MemGPT?',
@@ -9370,7 +9373,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Los planes gestionados tienen límites de uso en el nivel gratuito',
     ],
     pricingNote:
-      'Mem0 sigue un modelo freemium: existe una versión de código abierto que puedes autoalojar sin coste de licencia y un servicio gestionado con plan gratuito limitado y planes de pago por volumen de memorias o consultas. Los precios cambian con frecuencia, así que consulta su web para las condiciones actualizadas.',
+      'Mem0 sigue un modelo freemium: existe una versión de código abierto que puedes autoalojar sin coste de licencia y un servicio gestionado con plan gratuito limitado y planes de pago por volumen de memorias o consultas. Los precios cambian con frecuencia, así que',
     faqs: [
       {
         question: '¿Qué es Mem0?',
@@ -9420,7 +9423,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Requiere perfil técnico para sacarle partido',
     ],
     pricingNote:
-      'Zep funciona con un modelo freemium: suele ofrecer un plan gratuito con límites de uso para pruebas y desarrollo, y planes de pago escalonados según el volumen de mensajes o usuarios, además de opciones para empresas. También hay componentes de código abierto autoalojables. Consulta su web para precios actualizados.',
+      'Zep funciona con un modelo freemium: suele ofrecer un plan gratuito con límites de uso para pruebas y desarrollo, y planes de pago escalonados según el volumen de mensajes o usuarios, además de opciones para empresas. También hay componentes de código abierto autoalojables.',
     faqs: [
       {
         question: '¿Qué es Zep AI?',
@@ -9520,7 +9523,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'La calidad del grafo depende mucho del texto de entrada',
     ],
     pricingNote:
-      'GraphGPT es un proyecto de código abierto sin coste de licencia ni planes de suscripción. Normalmente necesitarás aportar tu propia clave de API del modelo de lenguaje que utilice por debajo, y ese consumo sí se factura por parte del proveedor correspondiente. Consulta el repositorio para los requisitos actualizados.',
+      'GraphGPT es un proyecto de código abierto sin coste de licencia ni planes de suscripción. Normalmente necesitarás aportar tu propia clave de API del modelo de lenguaje que utilice por debajo, y ese consumo sí se factura por parte del proveedor correspondiente.',
     faqs: [
       {
         question: '¿Qué es GraphGPT?',
@@ -9570,7 +9573,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'La API ha evolucionado bastante entre versiones',
     ],
     pricingNote:
-      'DSPy es un framework de código abierto y su uso no tiene coste de licencia ni suscripción. El gasto proviene del modelo de lenguaje que utilices por debajo, y conviene tenerlo en cuenta porque los procesos de optimización pueden generar bastantes llamadas a la API. Consulta la documentación oficial para las recomendaciones actualizadas.',
+      'DSPy es un framework de código abierto y su uso no tiene coste de licencia ni suscripción. El gasto proviene del modelo de lenguaje que utilices por debajo, y conviene tenerlo en cuenta porque los procesos de optimización pueden generar bastantes llamadas a la API.',
     faqs: [
       {
         question: '¿Qué es DSPy?',
@@ -9670,7 +9673,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'La API ha cambiado de forma notable entre versiones',
     ],
     pricingNote:
-      'AutoGen es un framework de código abierto y su uso no tiene coste de licencia. El gasto real está en las llamadas al modelo de lenguaje que utilices, que pueden crecer bastante en sistemas con varios agentes conversando. Consulta la documentación oficial para conocer las opciones y recomendaciones actualizadas.',
+      'AutoGen es un framework de código abierto y su uso no tiene coste de licencia. El gasto real está en las llamadas al modelo de lenguaje que utilices, que pueden crecer bastante en sistemas con varios agentes conversando.',
     faqs: [
       {
         question: '¿Qué es AutoGen?',
@@ -9720,7 +9723,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Requiere saber Python y entender la lógica de agentes',
     ],
     pricingNote:
-      'El framework de CrewAI es de código abierto y puede usarse sin coste de licencia; solo pagas el consumo del modelo de lenguaje que conectes. La empresa ofrece además una plataforma comercial con funciones de despliegue y gestión para empresas. Consulta su web para conocer los planes y precios actualizados.',
+      'El framework de CrewAI es de código abierto y puede usarse sin coste de licencia; solo pagas el consumo del modelo de lenguaje que conectes. La empresa ofrece además una plataforma comercial con funciones de despliegue y gestión para empresas.',
     faqs: [
       {
         question: '¿Qué es CrewAI?',
@@ -9771,7 +9774,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Las funciones de despliegue gestionado tienen coste aparte',
     ],
     pricingNote:
-      'La librería LangGraph es de código abierto y puede usarse sin coste de licencia; el gasto es el del modelo de lenguaje que conectes. LangChain ofrece además una plataforma de despliegue y observabilidad con plan gratuito limitado y planes de pago. Consulta su web para conocer los precios actualizados.',
+      'La librería LangGraph es de código abierto y puede usarse sin coste de licencia; el gasto es el del modelo de lenguaje que conectes. LangChain ofrece además una plataforma de despliegue y observabilidad con plan gratuito limitado y planes de pago.',
     faqs: [
       {
         question: '¿Qué es LangGraph?',
@@ -9821,7 +9824,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'La cantidad de funciones puede abrumar al principio',
     ],
     pricingNote:
-      'Weights & Biases sigue un modelo freemium: suele ofrecer un plan gratuito para uso personal y proyectos académicos, con límites de almacenamiento e historial, y planes de pago por usuario para equipos, además de opciones para empresas con despliegue privado. Los precios cambian con frecuencia, así que consulta su web para las condiciones actualizadas.',
+      'Weights & Biases sigue un modelo freemium: suele ofrecer un plan gratuito para uso personal y proyectos académicos, con límites de almacenamiento e historial, y planes de pago por usuario para equipos, además de opciones para empresas con despliegue privado. Los precios cambian con frecuencia, así que',
     faqs: [
       {
         question: '¿Qué es Weights & Biases?',
@@ -9871,7 +9874,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Las funciones avanzadas quedan reservadas a los planes de pago',
     ],
     pricingNote:
-      'ClearML funciona con un modelo freemium: el núcleo es de código abierto y autoalojable sin coste de licencia, y el servicio en la nube suele incluir un plan gratuito con límites y planes de pago por usuario o por capacidad, además de opciones para empresas. Consulta su web para conocer los precios actualizados.',
+      'ClearML funciona con un modelo freemium: el núcleo es de código abierto y autoalojable sin coste de licencia, y el servicio en la nube suele incluir un plan gratuito con límites y planes de pago por usuario o por capacidad, además de opciones para empresas.',
     faqs: [
       {
         question: '¿Qué es ClearML?',
@@ -9922,7 +9925,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'La interfaz es funcional pero poco pulida frente a alternativas comerciales',
     ],
     pricingNote:
-      'MLflow es un proyecto de código abierto y su uso es gratuito, tanto en local como autoalojado en tu propia infraestructura. El coste real proviene de los servidores y el almacenamiento que dediques. Existen versiones gestionadas dentro de plataformas comerciales con planes de pago; consulta su web para precios actualizados.',
+      'MLflow es un proyecto de código abierto y su uso es gratuito, tanto en local como autoalojado en tu propia infraestructura. El coste real proviene de los servidores y el almacenamiento que dediques. Existen versiones gestionadas dentro de plataformas comerciales con planes de pago;',
     faqs: [
       {
         question: '¿Qué es MLflow?',
@@ -9973,7 +9976,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Genera dependencia del ecosistema de AWS',
     ],
     pricingNote:
-      'SageMaker es de pago por uso: se factura según las horas de cómputo, el almacenamiento y las peticiones de inferencia que consumas, sin cuota fija de licencia. AWS suele ofrecer una capa gratuita limitada para empezar. El coste real depende mucho del tipo de instancia; consulta su web para precios actualizados.',
+      'SageMaker es de pago por uso: se factura según las horas de cómputo, el almacenamiento y las peticiones de inferencia que consumas, sin cuota fija de licencia. AWS suele ofrecer una capa gratuita limitada para empezar. El coste real depende mucho del tipo de instancia;',
     faqs: [
       {
         question: '¿Qué es Amazon SageMaker?',
@@ -10074,7 +10077,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'El autoalojamiento requiere mantenimiento propio',
     ],
     pricingNote:
-      'Helicone funciona con un modelo freemium: suele tener un plan gratuito con un límite de peticiones registradas al mes y planes de pago que crecen según el volumen y la retención de datos. Al ser open source, también puedes autoalojarlo y pagar solo la infraestructura. Consulta su web para precios actualizados.',
+      'Helicone funciona con un modelo freemium: suele tener un plan gratuito con un límite de peticiones registradas al mes y planes de pago que crecen según el volumen y la retención de datos. Al ser open source, también puedes autoalojarlo y pagar solo la infraestructura.',
     faqs: [
       {
         question: '¿Qué es Helicone?',
@@ -10124,7 +10127,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Puede ser excesivo para proyectos con muy pocos prompts',
     ],
     pricingNote:
-      'PromptLayer sigue un modelo freemium: suele ofrecer un plan gratuito con un número limitado de peticiones registradas y planes de pago por usuario o por volumen para equipos. Las funciones de colaboración y retención larga suelen estar en los planes superiores. Consulta su web para precios actualizados.',
+      'PromptLayer sigue un modelo freemium: suele ofrecer un plan gratuito con un número limitado de peticiones registradas y planes de pago por usuario o por volumen para equipos. Las funciones de colaboración y retención larga suelen estar en los planes superiores.',
     faqs: [
       {
         question: '¿Qué es PromptLayer?',
@@ -10175,7 +10178,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Requiere instrumentar la aplicación para sacarle partido',
     ],
     pricingNote:
-      'Arize AI trabaja con un modelo freemium: suele haber una opción gratuita o de código abierto con límites para empezar a instrumentar, y planes de pago para equipos y empresas con más volumen, retención y soporte. Los precios empresariales se negocian según el caso; consulta su web para información actualizada.',
+      'Arize AI trabaja con un modelo freemium: suele haber una opción gratuita o de código abierto con límites para empezar a instrumentar, y planes de pago para equipos y empresas con más volumen, retención y soporte. Los precios empresariales se negocian según el caso;',
     faqs: [
       {
         question: '¿Qué es Arize AI?',
@@ -10275,7 +10278,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Necesitas montar tú la infraestructura de vectores y despliegue',
     ],
     pricingNote:
-      'Haystack es un framework de código abierto y su uso es gratuito. Los costes vienen de la infraestructura donde lo despliegues y de las llamadas a los modelos o servicios que utilices dentro del pipeline. deepset ofrece además productos comerciales con planes de pago; consulta su web para precios actualizados.',
+      'Haystack es un framework de código abierto y su uso es gratuito. Los costes vienen de la infraestructura donde lo despliegues y de las llamadas a los modelos o servicios que utilices dentro del pipeline. deepset ofrece además productos comerciales con planes de pago;',
     faqs: [
       {
         question: '¿Qué es Haystack?',
@@ -10325,7 +10328,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'La API gestionada tiene coste según el volumen procesado',
     ],
     pricingNote:
-      'Unstructured ofrece una librería de código abierto gratuita que puedes ejecutar por tu cuenta, y además una API y plataforma gestionadas de pago que suelen facturarse según el número de páginas o documentos procesados. Suele existir un tramo gratuito para probar; consulta su web para precios actualizados.',
+      'Unstructured ofrece una librería de código abierto gratuita que puedes ejecutar por tu cuenta, y además una API y plataforma gestionadas de pago que suelen facturarse según el número de páginas o documentos procesados. Suele existir un tramo gratuito para probar;',
     faqs: [
       {
         question: '¿Qué es Unstructured?',
@@ -10375,7 +10378,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Requiere programar y entender bien qué mide cada métrica',
     ],
     pricingNote:
-      'RAGAS es un proyecto de código abierto y su uso no tiene coste de licencia. El gasto proviene de las llamadas a los modelos de lenguaje que actúan como evaluadores, facturadas por el proveedor correspondiente según los tokens consumidos. Consulta su web y la de tu proveedor de modelos para costes actualizados.',
+      'RAGAS es un proyecto de código abierto y su uso no tiene coste de licencia. El gasto proviene de las llamadas a los modelos de lenguaje que actúan como evaluadores, facturadas por el proveedor correspondiente según los tokens consumidos.',
     faqs: [
       {
         question: '¿Qué es RAGAS?',
@@ -10426,7 +10429,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'El plan gratuito tiene límites de uso ajustados',
     ],
     pricingNote:
-      'Writesonic funciona con un modelo freemium: suele tener un plan gratuito con créditos limitados y planes de pago mensuales que escalan según el volumen de palabras o créditos y el número de usuarios. Los planes básicos suelen situarse en unas pocas decenas de euros al mes; consulta su web para precios actualizados.',
+      'Writesonic funciona con un modelo freemium: suele tener un plan gratuito con créditos limitados y planes de pago mensuales que escalan según el volumen de palabras o créditos y el número de usuarios. Los planes básicos suelen situarse en unas pocas decenas de euros al mes;',
     faqs: [
       {
         question: '¿Qué es Writesonic?',
@@ -10476,7 +10479,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Los planes de pago pueden ser altos para usuarios individuales',
     ],
     pricingNote:
-      'Hypotenuse AI sigue un modelo freemium: suele ofrecer una prueba gratuita limitada y después planes de pago mensuales según el volumen de palabras o productos generados y el número de usuarios. Los planes para ecommerce con grandes catálogos son los más caros; consulta su web para precios actualizados.',
+      'Hypotenuse AI sigue un modelo freemium: suele ofrecer una prueba gratuita limitada y después planes de pago mensuales según el volumen de palabras o productos generados y el número de usuarios. Los planes para ecommerce con grandes catálogos son los más caros;',
     faqs: [
       {
         question: '¿Qué es Hypotenuse AI?',
@@ -10526,7 +10529,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'El coste de HubSpot escala rápido al crecer los contactos',
     ],
     pricingNote:
-      'HubSpot funciona con un modelo freemium: hay herramientas gratuitas de CRM y algunas funciones de IA accesibles con límites, mientras que las capacidades avanzadas se reservan a los planes de pago, que escalan según el número de contactos y usuarios. Consulta su web para precios actualizados.',
+      'HubSpot funciona con un modelo freemium: hay herramientas gratuitas de CRM y algunas funciones de IA accesibles con límites, mientras que las capacidades avanzadas se reservan a los planes de pago, que escalan según el número de contactos y usuarios.',
     faqs: [
       {
         question: '¿Qué es HubSpot AI?',
@@ -10577,7 +10580,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Solo tiene sentido dentro del ecosistema Salesforce',
     ],
     pricingNote:
-      'Einstein AI es de pago y suele comercializarse como parte de las ediciones superiores de Salesforce o como complemento sobre la licencia existente, con precio por usuario y mes. El coste final depende mucho de la edición y de los módulos contratados; consulta su web o a su equipo comercial para precios actualizados.',
+      'Einstein AI es de pago y suele comercializarse como parte de las ediciones superiores de Salesforce o como complemento sobre la licencia existente, con precio por usuario y mes. El coste final depende mucho de la edición y de los módulos contratados;',
     faqs: [
       {
         question: '¿Qué es Salesforce Einstein AI?',
@@ -10627,7 +10630,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Menos versátil que un redactor de IA de propósito general',
     ],
     pricingNote:
-      'Smart Copy sigue un modelo freemium: suele haber una opción gratuita con un número limitado de generaciones y planes de pago para uso ilimitado, además de estar disponible dentro de los planes de la plataforma Unbounce. Consulta su web para precios actualizados y para ver qué incluye cada plan.',
+      'Smart Copy sigue un modelo freemium: suele haber una opción gratuita con un número limitado de generaciones y planes de pago para uso ilimitado, además de estar disponible dentro de los planes de la plataforma Unbounce.',
     faqs: [
       {
         question: '¿Qué es Unbounce Smart Copy?',
@@ -10677,7 +10680,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Los planes escalan con el tamaño de la lista de contactos',
     ],
     pricingNote:
-      'GetResponse sigue un modelo freemium: dispone de un plan gratuito con funciones básicas y límite de contactos, y planes de pago mensuales que escalan según el tamaño de la lista y las funcionalidades incluidas. Algunas capacidades de IA se reservan a los planes superiores; consulta su web para precios actualizados.',
+      'GetResponse sigue un modelo freemium: dispone de un plan gratuito con funciones básicas y límite de contactos, y planes de pago mensuales que escalan según el tamaño de la lista y las funcionalidades incluidas. Algunas capacidades de IA se reservan a los planes superiores;',
     faqs: [
       {
         question: '¿Qué es GetResponse AI?',
@@ -10727,7 +10730,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'El contenido generado suele necesitar retoques',
     ],
     pricingNote:
-      'Mailchimp funciona con un modelo freemium: hay un plan gratuito con límites de contactos y envíos, y planes de pago mensuales que escalan según el tamaño de la lista y las funciones. Algunas capacidades de IA solo están en los planes superiores; consulta su web para precios actualizados.',
+      'Mailchimp funciona con un modelo freemium: hay un plan gratuito con límites de contactos y envíos, y planes de pago mensuales que escalan según el tamaño de la lista y las funciones. Algunas capacidades de IA solo están en los planes superiores;',
     faqs: [
       {
         question: '¿Qué es Mailchimp AI?',
@@ -10777,7 +10780,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Necesita revisión humana en textos técnicos o legales',
     ],
     pricingNote:
-      'DeepL sigue un modelo freemium: hay una versión gratuita con límite de caracteres y de documentos traducidos, y planes de pago por usuario y mes con más volumen, glosarios ampliados y garantías de privacidad. La API tiene también un tramo gratuito y otro de pago por uso; consulta su web para precios actualizados.',
+      'DeepL sigue un modelo freemium: hay una versión gratuita con límite de caracteres y de documentos traducidos, y planes de pago por usuario y mes con más volumen, glosarios ampliados y garantías de privacidad. La API tiene también un tramo gratuito y otro de pago por uso;',
     faqs: [
       {
         question: '¿Qué es DeepL?',
@@ -10827,7 +10830,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'El uso profesional vía API sí tiene coste',
     ],
     pricingNote:
-      'Google Translate es gratuito para uso personal desde la web y la aplicación móvil, sin necesidad de suscripción. El uso profesional a través de la API de Google Cloud sí es de pago, facturado por volumen de caracteres traducidos, con un tramo gratuito inicial. Consulta su web para precios actualizados.',
+      'Google Translate es gratuito para uso personal desde la web y la aplicación móvil, sin necesidad de suscripción. El uso profesional a través de la API de Google Cloud sí es de pago, facturado por volumen de caracteres traducidos, con un tramo gratuito inicial.',
     faqs: [
       {
         question: '¿Qué es Google Translate?',
@@ -10877,7 +10880,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Menos conocido que los traductores generalistas',
     ],
     pricingNote:
-      'ModernMT trabaja con un modelo freemium: suele ofrecer un plan gratuito o de prueba con límites de caracteres y planes de pago por volumen, además de licencias empresariales para grandes flujos de localización. El coste depende mucho del uso previsto; consulta su web para precios actualizados.',
+      'ModernMT trabaja con un modelo freemium: suele ofrecer un plan gratuito o de prueba con límites de caracteres y planes de pago por volumen, además de licencias empresariales para grandes flujos de localización. El coste depende mucho del uso previsto;',
     faqs: [
       {
         question: '¿Qué es ModernMT?',
@@ -10927,7 +10930,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'El coste puede crecer con volúmenes muy grandes',
     ],
     pricingNote:
-      'Amazon Translate sigue el modelo de pago por uso habitual de AWS: se factura según el volumen de caracteres traducidos. AWS suele ofrecer un nivel gratuito inicial con un límite mensual de caracteres durante los primeros meses. Consulta su web para precios actualizados y para calcular el coste según tu volumen.',
+      'Amazon Translate sigue el modelo de pago por uso habitual de AWS: se factura según el volumen de caracteres traducidos. AWS suele ofrecer un nivel gratuito inicial con un límite mensual de caracteres durante los primeros meses.',
     faqs: [
       {
         question: '¿Qué es Amazon Translate?',
@@ -10976,7 +10979,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'La voz sintética puede no encajar en contenido muy expresivo',
     ],
     pricingNote:
-      'Papercup trabaja con un modelo de pago orientado a empresas, normalmente mediante presupuesto a medida según el volumen de vídeo y los idiomas necesarios. No suele publicar tarifas cerradas ni ofrecer un plan gratuito de autoservicio. Consulta su web para pedir información y precios actualizados.',
+      'Papercup trabaja con un modelo de pago orientado a empresas, normalmente mediante presupuesto a medida según el volumen de vídeo y los idiomas necesarios. No suele publicar tarifas cerradas ni ofrecer un plan gratuito de autoservicio.',
     faqs: [
       {
         question: '¿Qué es Papercup?',
@@ -11026,7 +11029,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'El resultado puede sonar artificial en contenidos muy expresivos',
     ],
     pricingNote:
-      'HeyGen funciona con un modelo freemium: suele ofrecer un plan gratuito con un número limitado de vídeos y marca de agua, y planes de pago por suscripción con más minutos, avatares y funciones. Las tarifas de entrada suelen situarse en el entorno de unas decenas de euros al mes. Consulta su web para precios actualizados.',
+      'HeyGen funciona con un modelo freemium: suele ofrecer un plan gratuito con un número limitado de vídeos y marca de agua, y planes de pago por suscripción con más minutos, avatares y funciones. Las tarifas de entrada suelen situarse en el entorno de unas decenas de euros al mes.',
     faqs: [
       {
         question: '¿Qué es HeyGen?',
@@ -11075,7 +11078,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'La precisión baja con audios ruidosos o acentos marcados',
     ],
     pricingNote:
-      'Subly usa un modelo freemium: suele haber un plan gratuito con una cantidad limitada de minutos de transcripción al mes y planes de pago por suscripción que amplían minutos, idiomas y funciones de exportación. Los planes de entrada rondan las pocas decenas de euros mensuales. Consulta su web para precios actualizados.',
+      'Subly usa un modelo freemium: suele haber un plan gratuito con una cantidad limitada de minutos de transcripción al mes y planes de pago por suscripción que amplían minutos, idiomas y funciones de exportación. Los planes de entrada rondan las pocas decenas de euros mensuales.',
     faqs: [
       {
         question: '¿Qué es Subly?',
@@ -11124,7 +11127,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Ninguna detección de IA es infalible: hay falsos positivos',
     ],
     pricingNote:
-      'Hive es un servicio de pago orientado a empresas, con precios normalmente basados en el volumen de contenido procesado y presupuestos a medida. No suele ofrecer un plan gratuito abierto, aunque sí permite probar algunos modelos. Consulta su web para condiciones y precios actualizados.',
+      'Hive es un servicio de pago orientado a empresas, con precios normalmente basados en el volumen de contenido procesado y presupuestos a medida. No suele ofrecer un plan gratuito abierto, aunque sí permite probar algunos modelos.',
     faqs: [
       {
         question: '¿Qué es Hive AI?',
@@ -11173,7 +11176,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'El resultado es una estimación, no una prueba concluyente',
     ],
     pricingNote:
-      'AI or Not funciona con un modelo freemium: suele permitir un número limitado de comprobaciones gratuitas y ofrece planes de pago con más análisis mensuales y acceso a la API. Los planes de entrada suelen ser económicos, en el entorno de unos pocos euros al mes. Consulta su web para precios actualizados.',
+      'AI or Not funciona con un modelo freemium: suele permitir un número limitado de comprobaciones gratuitas y ofrece planes de pago con más análisis mensuales y acceso a la API. Los planes de entrada suelen ser económicos, en el entorno de unos pocos euros al mes.',
     faqs: [
       {
         question: '¿Qué es AI or Not?',
@@ -11222,7 +11225,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Requiere integración técnica para aprovecharlo del todo',
     ],
     pricingNote:
-      'Sensity AI es un servicio de pago dirigido a empresas, con planes normalmente a medida según el volumen de análisis y los módulos contratados. No suele publicar tarifas cerradas ni ofrecer un plan gratuito abierto, aunque permite solicitar demostraciones. Consulta su web para precios actualizados.',
+      'Sensity AI es un servicio de pago dirigido a empresas, con planes normalmente a medida según el volumen de análisis y los módulos contratados. No suele publicar tarifas cerradas ni ofrecer un plan gratuito abierto, aunque permite solicitar demostraciones.',
     faqs: [
       {
         question: '¿Qué es Sensity AI?',
@@ -11271,7 +11274,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Los planes completos están pensados para empresas',
     ],
     pricingNote:
-      'TruEra ha ofrecido un modelo freemium, con una versión gratuita o de prueba limitada para equipos pequeños y planes de pago para empresas con más volumen y funciones de gobernanza. Las tarifas empresariales suelen negociarse a medida. Consulta su web para precios actualizados y disponibilidad de la versión gratuita.',
+      'TruEra ha ofrecido un modelo freemium, con una versión gratuita o de prueba limitada para equipos pequeños y planes de pago para empresas con más volumen y funciones de gobernanza. Las tarifas empresariales suelen negociarse a medida.',
     faqs: [
       {
         question: '¿Qué es TruEra?',
@@ -11320,7 +11323,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Requiere integrar la plataforma con tu infraestructura',
     ],
     pricingNote:
-      'Fiddler AI combina una versión de acceso gratuito o de prueba con planes de pago empresariales cuyo precio depende del número de modelos, el volumen de datos y las funciones de gobernanza. Las tarifas suelen acordarse mediante presupuesto. Consulta su web para precios actualizados.',
+      'Fiddler AI combina una versión de acceso gratuito o de prueba con planes de pago empresariales cuyo precio depende del número de modelos, el volumen de datos y las funciones de gobernanza. Las tarifas suelen acordarse mediante presupuesto.',
     faqs: [
       {
         question: '¿Qué es Fiddler AI?',
@@ -11369,7 +11372,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Exige un esfuerzo interno de documentación y proceso',
     ],
     pricingNote:
-      'Credo AI se dirige principalmente a empresas y trabaja con planes a medida según el número de sistemas de IA y las necesidades de gobernanza. Suele existir alguna vía de acceso gratuito o de prueba para explorar la plataforma. Consulta su web para precios actualizados y condiciones.',
+      'Credo AI se dirige principalmente a empresas y trabaja con planes a medida según el número de sistemas de IA y las necesidades de gobernanza. Suele existir alguna vía de acceso gratuito o de prueba para explorar la plataforma.',
     faqs: [
       {
         question: '¿Qué es Credo AI?',
@@ -11418,7 +11421,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'No sustituye la lectura completa en documentos críticos',
     ],
     pricingNote:
-      'ChatPDF sigue un modelo freemium: ofrece un plan gratuito con límites diarios de documentos, páginas y preguntas, y una suscripción de pago que amplía esos límites. El plan de pago suele situarse en el entorno de unos pocos euros al mes. Consulta su web para precios actualizados.',
+      'ChatPDF sigue un modelo freemium: ofrece un plan gratuito con límites diarios de documentos, páginas y preguntas, y una suscripción de pago que amplía esos límites. El plan de pago suele situarse en el entorno de unos pocos euros al mes.',
     faqs: [
       {
         question: '¿Qué es ChatPDF?',
@@ -11467,7 +11470,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Conviene verificar las respuestas en usos críticos',
     ],
     pricingNote:
-      'AskYourPDF funciona con un modelo freemium: hay un plan gratuito con límites en número de documentos, tamaño y preguntas, y planes de suscripción que amplían capacidad y dan acceso a la API. Los planes de pago suelen situarse en unos pocos euros al mes. Consulta su web para precios actualizados.',
+      'AskYourPDF funciona con un modelo freemium: hay un plan gratuito con límites en número de documentos, tamaño y preguntas, y planes de suscripción que amplían capacidad y dan acceso a la API. Los planes de pago suelen situarse en unos pocos euros al mes.',
     faqs: [
       {
         question: '¿Qué es AskYourPDF?',
@@ -11516,7 +11519,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'El coste por usuario puede ser elevado en plantillas grandes',
     ],
     pricingNote:
-      'Glean es una plataforma orientada a empresas, con precios habitualmente por usuario y presupuestos a medida según el número de conectores y el tamaño de la organización. No suele haber un plan gratuito de autoservicio, sino demostraciones y pruebas guiadas. Consulta su web para precios actualizados.',
+      'Glean es una plataforma orientada a empresas, con precios habitualmente por usuario y presupuestos a medida según el número de conectores y el tamaño de la organización. No suele haber un plan gratuito de autoservicio, sino demostraciones y pruebas guiadas.',
     faqs: [
       {
         question: '¿Qué es Glean?',
@@ -11565,7 +11568,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Añade una capa más de dependencia externa',
     ],
     pricingNote:
-      'Klu emplea un modelo freemium: suele ofrecer un plan gratuito con límites de uso para probar la plataforma y planes de pago por suscripción según el volumen y las funciones de equipo. Las tarifas de entrada rondan las pocas decenas de euros al mes. Consulta su web para precios actualizados.',
+      'Klu emplea un modelo freemium: suele ofrecer un plan gratuito con límites de uso para probar la plataforma y planes de pago por suscripción según el volumen y las funciones de equipo. Las tarifas de entrada rondan las pocas decenas de euros al mes.',
     faqs: [
       {
         question: '¿Qué es Klu?',
@@ -11614,7 +11617,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Menos pulido que las alternativas comerciales cerradas',
     ],
     pricingNote:
-      'Danswer es un proyecto de código abierto, por lo que el software puede usarse sin coste de licencia si se autoaloja; los gastos vienen de la infraestructura y de los modelos que se utilicen. Suele existir además una opción gestionada en la nube de pago. Consulta su web para precios actualizados.',
+      'Danswer es un proyecto de código abierto, por lo que el software puede usarse sin coste de licencia si se autoaloja; los gastos vienen de la infraestructura y de los modelos que se utilicen. Suele existir además una opción gestionada en la nube de pago.',
     faqs: [
       {
         question: '¿Qué es Danswer?',
@@ -11663,7 +11666,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'El índice web es menor que el de los grandes buscadores',
     ],
     pricingNote:
-      'You.com funciona con un modelo freemium: ofrece búsqueda gratuita con límites en las funciones de IA y planes de suscripción que dan más consultas y acceso a modelos avanzados. Los planes de pago suelen rondar los 15-20 euros al mes. Consulta su web para precios actualizados.',
+      'You.com funciona con un modelo freemium: ofrece búsqueda gratuita con límites en las funciones de IA y planes de suscripción que dan más consultas y acceso a modelos avanzados. Los planes de pago suelen rondar los 15-20 euros al mes.',
     faqs: [
       {
         question: '¿Qué es You.com?',
@@ -11712,7 +11715,7 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Menos útil fuera del ámbito técnico',
     ],
     pricingNote:
-      'Phind sigue un modelo freemium: permite un número de búsquedas gratuitas al día y ofrece una suscripción de pago con más consultas y acceso a modelos más potentes. El plan de pago suele situarse en torno a los 20 euros mensuales. Consulta su web para precios actualizados.',
+      'Phind sigue un modelo freemium: permite un número de búsquedas gratuitas al día y ofrece una suscripción de pago con más consultas y acceso a modelos más potentes. El plan de pago suele situarse en torno a los 20 euros mensuales.',
     faqs: [
       {
         question: '¿Qué es Phind?',

--- a/src/data/tool-pricing.ts
+++ b/src/data/tool-pricing.ts
@@ -1,0 +1,1814 @@
+import type { ToolPricing } from '../types/tool';
+
+/**
+ * Precios verificados en la web oficial de cada herramienta.
+ *
+ * Solo estan las que pudimos comprobar con cifras publicas: el resto
+ * se queda con el texto cualitativo de su ficha. Al revisar precios,
+ * actualiza tambien PRICING_LAST_CHECKED.
+ */
+export const PRICING_LAST_CHECKED = 'agosto de 2026';
+
+export const toolPricing: Record<string, ToolPricing> = {
+  ChatGPT: {
+    name: 'ChatGPT',
+    model: 'freemium',
+    freeTier:
+      'Plan gratuito abierto a cualquiera, con acceso básico a ChatGPT y límites de mensajes, subidas y generación de imágenes más bajos que los de pago.',
+    plans: [
+      {
+        name: 'Free',
+        price: '0 $/mes',
+        notes: 'Uso general con límites; suficiente para consultas puntuales.',
+      },
+      {
+        name: 'Go',
+        price: '8 $/mes',
+        notes:
+          'Plan económico (precio de EE. UU.) que sube el tope de mensajes, subidas, imágenes y memoria frente al gratuito.',
+      },
+      {
+        name: 'Plus',
+        price: '20 $/mes',
+        notes:
+          'Para uso personal intensivo: más límites y funciones avanzadas como Deep Research, modo agente y GPTs personalizados.',
+      },
+      {
+        name: 'Pro',
+        price: '100 $/mes o 200 $/mes',
+        notes: 'Para profesionales que necesitan 5x (100 $) o 20x (200 $) el uso de Plus.',
+      },
+      {
+        name: 'Business',
+        price: '25 $/usuario/mes',
+        notes:
+          'Plan de equipo desde 2 usuarios, con administración central; más barato con facturación anual.',
+      },
+      {
+        name: 'Enterprise',
+        price: 'Presupuesto a medida',
+        notes: 'Para grandes organizaciones, con contrato y condiciones negociadas con ventas.',
+      },
+    ],
+    notes:
+      'openai.com y chatgpt.com devuelven 403 a la descarga directa, así que las cifras se han obtenido mediante búsqueda restringida a los dominios oficiales openai.com y help.openai.com. Business se factura por usuario y sale más barato en anual; el uso de la API de OpenAI se paga aparte.',
+    sourceUrl: 'https://openai.com/chatgpt/pricing',
+  },
+  Claude: {
+    name: 'Claude',
+    model: 'freemium',
+    freeTier:
+      'Plan gratuito con chat en web, iOS, Android y escritorio, búsqueda web, memoria, creación de archivos y razonamiento extendido, con límite de uso diario.',
+    plans: [
+      {
+        name: 'Free',
+        price: '0 $/mes',
+        notes: 'Uso básico de Claude en todas las plataformas con límites de mensajes.',
+      },
+      {
+        name: 'Pro',
+        price: '20 $/mes (17 $/mes en anual)',
+        notes:
+          'Para uso individual intensivo: más uso, Claude Code, proyectos ilimitados, Research y varios modelos.',
+      },
+      {
+        name: 'Max',
+        price: 'Desde 100 $/mes',
+        notes: 'Para usuarios muy intensivos: 5x o 20x el uso de Pro y acceso prioritario.',
+      },
+      {
+        name: 'Team (asiento estándar)',
+        price: '25 $/asiento/mes (20 $/asiento/mes en anual)',
+        notes: 'Equipos de 2 a 150 personas con administración central, SSO y controles de admin.',
+      },
+      {
+        name: 'Team (asiento premium)',
+        price: '125 $/asiento/mes (100 $/asiento/mes en anual)',
+        notes: 'Asiento con mucho más uso incluido para los perfiles que más exprimen Claude.',
+      },
+      {
+        name: 'Enterprise',
+        price: '20 $/asiento + uso a tarifas de API',
+        notes:
+          'Para grandes organizaciones: permisos por rol, SCIM, registros de auditoría y opciones compatibles con HIPAA.',
+      },
+    ],
+    notes:
+      'La facturación anual abarata Pro y Team. En Enterprise el coste real depende del consumo, que se factura a tarifas de API; los precios se muestran en dólares y sin impuestos.',
+    sourceUrl: 'https://claude.com/pricing',
+  },
+  Gemini: {
+    name: 'Gemini',
+    model: 'freemium',
+    freeTier:
+      'Plan gratuito con acceso a los modelos Flash, generación de imagen y vídeo, Deep Research, Gemini Live, Canvas, Gems y 15 GB de almacenamiento.',
+    plans: [
+      {
+        name: 'Gratis',
+        price: '0 €/mes',
+        notes: 'Uso diario con límites y acceso variable a los modelos Pro.',
+      },
+      {
+        name: 'Google AI Plus',
+        price: '4,99 €/mes',
+        notes:
+          'Entrada de gama: duplica los límites del plan gratuito y sube a 400 GB de almacenamiento.',
+      },
+      {
+        name: 'Google AI Pro',
+        price: '21,99 €/mes',
+        notes:
+          'Para uso intensivo: 4x los límites, acceso a Gemini 3 Pro y 5 TB de almacenamiento.',
+      },
+      {
+        name: 'Google AI Ultra',
+        price: 'Desde 99,99 €/mes (219,99 €/mes en el nivel superior)',
+        notes:
+          'Para profesionales y creadores: hasta 20x los límites de Pro, 20+ TB y acceso anticipado a funciones como Deep Think.',
+      },
+    ],
+    notes:
+      'Precios consultados desde España, en euros e integrados en las suscripciones Google One (almacenamiento incluido). El uso de la API de Gemini en Google AI Studio o Vertex AI se paga aparte por tokens.',
+    sourceUrl: 'https://gemini.google/subscriptions/',
+  },
+  Mistral: {
+    name: 'Mistral',
+    model: 'freemium',
+    freeTier:
+      'Le Chat (Vibe) gratis con mensajes, búsquedas web y sesiones de código limitados, pero acceso a los modelos punteros.',
+    plans: [
+      {
+        name: 'Free',
+        price: '0 $/mes',
+        notes: 'Uso limitado de chat, búsqueda web y programación.',
+      },
+      {
+        name: 'Pro',
+        price: '14,99 $/mes',
+        notes:
+          'Para uso individual intensivo: más mensajes, búsquedas, imágenes y soporte por chat y email.',
+      },
+      {
+        name: 'Education',
+        price: '5,99 $/mes',
+        notes:
+          'Tarifa para estudiantes verificados de centros superiores, con validez máxima de 12 meses.',
+      },
+      {
+        name: 'Team',
+        price: '24,99 $/usuario/mes (mínimo 50 $/mes)',
+        notes:
+          'Para equipos: 30 GB de almacenamiento por usuario, verificación de dominio y exportación de datos.',
+      },
+      {
+        name: 'Enterprise',
+        price: 'Presupuesto a medida',
+        notes:
+          'Modelos, agentes y flujos a medida, SSO SAML, registros de auditoría y marca blanca.',
+      },
+    ],
+    notes:
+      'Aparte de la suscripción, la API se paga por millón de tokens (por ejemplo Mistral Large a 2 $/M de entrada y 6 $/M de salida), con 50 % de descuento en procesamiento por lotes. La web muestra los importes en $ o € según la región seleccionada; aquí se recogen en dólares.',
+    sourceUrl: 'https://mistral.ai/pricing',
+  },
+  Grok: {
+    name: 'Grok',
+    model: 'freemium',
+    freeTier:
+      'Grok se puede usar gratis con límites de uso semanales antes de tener que pasar a un plan SuperGrok.',
+    plans: [
+      {
+        name: 'Free',
+        price: '0 $/mes',
+        notes: 'Acceso inicial a Grok dentro de límites generosos pero acotados.',
+      },
+      {
+        name: 'SuperGrok',
+        price: '30 $/mes',
+        notes: 'Desbloquea límites más altos y acceso a los modelos frontera.',
+      },
+    ],
+    notes:
+      'x.ai/pricing y grok.com/pricing devuelven 403 a la descarga directa; solo se ha podido confirmar el precio de SuperGrok (30 $/mes) mediante búsqueda restringida al dominio oficial x.ai. La página lista además SuperGrok Lite, SuperGrok Heavy, Business y Enterprise, cuyos importes no se han podido verificar (Enterprise es presupuesto a medida). Todos los planes de pago consumen una bolsa de uso semanal compartida entre productos; la API de xAI se factura aparte por tokens.',
+    sourceUrl: 'https://x.ai/pricing',
+  },
+  Jasper: {
+    name: 'Jasper',
+    model: 'paid',
+    freeTier: null,
+    plans: [
+      {
+        name: 'Pro',
+        price: '69 $/asiento/mes (59 $/asiento/mes en anual)',
+        notes: 'Plan principal para marketers y equipos pequeños que crean contenido de marca.',
+      },
+      {
+        name: 'Business',
+        price: 'Presupuesto a medida',
+        notes:
+          'Para empresas, con compromiso mínimo de 12 meses y condiciones negociadas con ventas.',
+      },
+    ],
+    notes:
+      'No hay plan gratuito, solo prueba de 7 días del plan Pro. El anual ahorra en torno a un 20 % pero obliga a 12 meses; los precios están en dólares y se convierten al tipo de cambio del momento en otras divisas.',
+    sourceUrl: 'https://www.jasper.ai/pricing',
+  },
+  'Copy.ai': {
+    name: 'Copy.ai',
+    model: 'paid',
+    freeTier: null,
+    plans: [
+      {
+        name: 'Chat',
+        price: '29 $/mes (24 $/mes en anual, 288 $/año)',
+        notes:
+          'Entrada de gama: 5 usuarios, palabras ilimitadas en chat y acceso a modelos de OpenAI, Anthropic y Gemini.',
+      },
+      {
+        name: 'Growth',
+        price: '1.000 $/mes (12.000 $/año)',
+        notes:
+          'Para equipos de marketing y ventas: 75 usuarios y 20.000 créditos de flujos al mes.',
+      },
+      {
+        name: 'Expansion',
+        price: '2.000 $/mes (24.000 $/año)',
+        notes: '150 usuarios y 45.000 créditos de flujos al mes.',
+      },
+      {
+        name: 'Scale',
+        price: '3.000 $/mes (36.000 $/año)',
+        notes: '200 usuarios y 75.000 créditos de flujos al mes.',
+      },
+      {
+        name: 'Enterprise',
+        price: 'Presupuesto a medida',
+        notes:
+          'Implantación guiada, API, integraciones, flujos ilimitados y seguridad de nivel empresarial.',
+      },
+    ],
+    notes:
+      'Ya no hay plan gratuito permanente: solo se puede probar pidiendo una demo o contactando con ventas. Los planes Growth y superiores se facturan de forma anual y el consumo se mide en créditos de flujos de trabajo.',
+    sourceUrl: 'https://www.copy.ai/prices',
+  },
+  'DALL·E': {
+    name: 'DALL·E',
+    model: 'freemium',
+    freeTier:
+      'El plan Free de ChatGPT incluye generación de imágenes, pero limitada y más lenta que en los planes de pago.',
+    plans: [
+      {
+        name: 'Free',
+        price: '0 $/mes',
+        notes: 'Para probar ChatGPT: mensajes, subidas y generación de imágenes limitadas.',
+      },
+      {
+        name: 'Go',
+        price: '8 $/mes',
+        notes:
+          'Más mensajes, más subidas y más creación de imágenes que el plan gratuito; puede incluir anuncios.',
+      },
+      {
+        name: 'Plus',
+        price: '20 $/mes',
+        notes: 'Para trabajo avanzado y productividad, con límites de uso mucho más altos.',
+      },
+      {
+        name: 'Pro',
+        price: '100 $/mes o 200 $/mes',
+        notes: 'Dos niveles: 100 $ da 5 veces más uso que Plus y 200 $ hasta 20 veces más.',
+      },
+      {
+        name: 'Business',
+        price: '25 $/usuario/mes (20 $/usuario/mes con facturación anual)',
+        notes: 'Para equipos, con espacio de trabajo compartido y administración.',
+      },
+      {
+        name: 'Enterprise',
+        price: 'Presupuesto a medida',
+        notes: 'Para grandes organizaciones; hay que contactar con ventas.',
+      },
+    ],
+    notes:
+      'openai.com devuelve 403 a WebFetch y además inyecta los importes por JavaScript, así que la página se leyó vía lector de texto (se confirmaron los nombres de plan Free/Go/Plus/Pro/Business/Enterprise) y las cifras se obtuvieron con WebSearch restringido a openai.com y help.openai.com. El uso por API se paga aparte: en developers.openai.com el modelo de imagen gpt-image-1 se factura por tokens (10 $ por 1M de tokens de imagen de entrada, 5 $ por 1M de texto de entrada y 40 $ por 1M de salida).',
+    sourceUrl: 'https://openai.com/chatgpt/pricing/',
+  },
+  'Stable Diffusion': {
+    name: 'Stable Diffusion',
+    model: 'freemium',
+    freeTier:
+      'Plan gratuito de 0 $/mes con 10 créditos al día, con anuncios, marca de agua y sin licencia comercial.',
+    plans: [
+      {
+        name: 'Free',
+        price: '0 $/mes',
+        notes: '10 créditos diarios para probar el generador online.',
+      },
+      {
+        name: 'PRO',
+        price: '20 $/mes (facturado anualmente)',
+        notes:
+          '2.000 créditos al mes, sin anuncios ni marca de agua, licencia comercial e imágenes privadas.',
+      },
+    ],
+    notes:
+      'stablediffusionweb.com devuelve 403 a WebFetch y a curl, y su /pricing no se sirve a lectores de texto, así que las cifras proceden de WebSearch restringido al propio dominio oficial. Existe además un plan MAX con 5.000 créditos al mes, pero los resultados se contradicen sobre su precio y no lo incluyo. El modelo Stable Diffusion en sí es de pesos abiertos: se puede ejecutar en local sin coste de licencia, pagando solo hardware o API de terceros.',
+    sourceUrl: 'https://stablediffusionweb.com/pricing',
+  },
+  'Adobe Firefly': {
+    name: 'Adobe Firefly',
+    model: 'freemium',
+    freeTier: null,
+    plans: [
+      {
+        name: 'Firefly Standard',
+        price: '9,99 US$/mes',
+        notes: '2.000 créditos generativos al mes; entrada para uso ocasional de imagen y vídeo.',
+      },
+      {
+        name: 'Firefly Pro',
+        price: '19,99 US$/mes',
+        notes: '4.000 créditos al mes, para quien genera vídeo y audio con frecuencia.',
+      },
+      {
+        name: 'Firefly Pro Plus',
+        price: '49,99 US$/mes (oferta a 34,97 US$/mes)',
+        notes: '10.000 créditos al mes y generaciones ilimitadas en más modelos el primer año.',
+      },
+      {
+        name: 'Firefly Premium',
+        price: '199,99 US$/mes (oferta a 139,91 US$/mes)',
+        notes: '50.000 créditos al mes; para producción intensiva de vídeo 4K y modelos premium.',
+      },
+    ],
+    notes:
+      'Todos los precios son mensuales y en US$: la página de planes no ofrece selector anual. Pro Plus y Premium tienen una oferta limitada del 30% de descuento el primer año, vigente hasta el 26 de agosto. adobe.com bloquea WebFetch y curl (timeout), así que la tabla se leyó a través del fragmento oficial de contenido alojado en www.adobe.com. La página de planes solo enlaza a prueba gratuita y no detalla los límites de un plan gratuito permanente, por eso dejo freeTier a null.',
+    sourceUrl: 'https://www.adobe.com/products/firefly/plans.html',
+  },
+  FLUX: {
+    name: 'FLUX',
+    model: 'freemium',
+    freeTier: '10 créditos gratis al registrarse, sin necesidad de tarjeta.',
+    plans: [
+      {
+        name: 'Basic',
+        price: '11,90 $/mes',
+        notes: '300 créditos al mes; entrada para uso puntual.',
+      },
+      { name: 'Pro', price: '18,90 $/mes', notes: '800 créditos al mes.' },
+      {
+        name: 'Max',
+        price: '25,90 $/mes',
+        notes: '2.000 créditos al mes, el equilibrio para uso habitual.',
+      },
+      {
+        name: 'Pro Max',
+        price: '59,90 $/mes',
+        notes: '6.000 créditos al mes y el mejor coste por crédito.',
+      },
+    ],
+    notes:
+      'Los precios listados corresponden a facturación anual con el 30% de descuento vigente; la tarifa mensual sin descuento va de 16,90 $ a 86,90 $. También se pueden comprar créditos sueltos de un solo pago y hay planes mayores a medida. Los modelos FLUX oficiales de Black Forest Labs (bfl.ai) se venden aparte como API de pago por uso, sin suscripciones.',
+    sourceUrl: 'https://genimg.ai/es/price',
+  },
+  Ideogram: {
+    name: 'Ideogram',
+    model: 'freemium',
+    freeTier:
+      'Plan gratuito con 10 créditos lentos por semana, 1 generación simultánea y 2 lienzos, sin créditos prioritarios ni generación privada.',
+    plans: [
+      {
+        name: 'Plus',
+        price: '15 $/mes (facturado anualmente, ahorro del 25%)',
+        notes:
+          '1.000 créditos prioritarios al mes, créditos lentos ilimitados y generación privada.',
+      },
+      {
+        name: 'Pro',
+        price: '42 $/mes (facturado anualmente, ahorro del 30%)',
+        notes:
+          '3.500 créditos prioritarios al mes, generación por lotes y la cola más rápida; el mejor coste por crédito.',
+      },
+      {
+        name: 'Team',
+        price: '20 $/usuario/mes (facturado anualmente, ahorro del 33%)',
+        notes:
+          '1.500 créditos prioritarios por usuario, facturación y administración centralizadas.',
+      },
+      {
+        name: 'Enterprise',
+        price: 'Presupuesto a medida',
+        notes:
+          'Modelos privados entrenados con datos propios, descuentos por volumen en la API y soporte prioritario.',
+      },
+    ],
+    notes:
+      'La página muestra por defecto la facturación anual y esos son los importes recogidos; el selector mensual no se pudo capturar, así que sin compromiso anual los precios son más altos (los descuentos indicados son del 25%, 30% y 33%). Se pueden recargar créditos sueltos: 150 créditos prioritarios por 4 $ en Plus y 250 por 4 $ en Pro y Team. La API se factura aparte. ideogram.ai devuelve 403 a WebFetch y a curl, así que la página oficial se leyó mediante un lector de texto.',
+    sourceUrl: 'https://ideogram.ai/pricing',
+  },
+  ElevenLabs: {
+    name: 'ElevenLabs',
+    model: 'freemium',
+    freeTier:
+      '10.000 créditos al mes con texto a voz, voz a texto, efectos de sonido, música e imagen, y 3 proyectos en Studio.',
+    plans: [
+      {
+        name: 'Free',
+        price: '0 $/mes',
+        notes: '10.000 créditos al mes para probar la plataforma, sin licencia comercial.',
+      },
+      {
+        name: 'Starter',
+        price: '6 $/mes',
+        notes: '30.000 créditos, licencia comercial, clonación instantánea de voz y doblaje.',
+      },
+      {
+        name: 'Creator',
+        price: '22 $/mes',
+        notes:
+          '121.000 créditos y clonación profesional de voz; primer mes con 50% de descuento (11 $).',
+      },
+      {
+        name: 'Pro',
+        price: '99 $/mes',
+        notes: '600.000 créditos y salida de audio de alta calidad, para producción profesional.',
+      },
+      {
+        name: 'Scale',
+        price: '299 $/mes',
+        notes: '1,8 M de créditos, 3 asientos de espacio de trabajo y colaboración en equipo.',
+      },
+      {
+        name: 'Business',
+        price: '990 $/mes',
+        notes:
+          '6 M de créditos, texto a voz de baja latencia, 10 clones profesionales y 10 asientos.',
+      },
+      {
+        name: 'Enterprise',
+        price: 'Presupuesto a medida',
+        notes: 'Para grandes volúmenes y necesidades específicas; contactar con ventas.',
+      },
+    ],
+    notes:
+      'Con facturación anual se pagan 10 meses en lugar de 12, es decir dos meses gratis. El consumo se mide en créditos, de modo que el coste real depende del volumen de audio generado.',
+    sourceUrl: 'https://elevenlabs.io/pricing',
+  },
+  'Resemble AI': {
+    name: 'Resemble AI',
+    model: 'freemium',
+    freeTier:
+      'Plan Flex a 0 $/mes sin tarjeta, con acceso a la plataforma y a la API y 1 usuario, comprando créditos según uso.',
+    plans: [
+      {
+        name: 'Flex',
+        price: '0 $/mes',
+        notes:
+          'Pago por uso con tarifas por segundo procesado; para probar detección e insights con 1 usuario.',
+      },
+      {
+        name: 'Team',
+        price: '350 $/mes (280 $/mes con facturación anual)',
+        notes: 'Tarifas de uso más bajas, subidas por lotes y 5 asientos, para equipos pequeños.',
+      },
+      {
+        name: 'Business',
+        price: '1.000 $/mes (800 $/mes con facturación anual)',
+        notes: 'Integración de calendario para toda la organización, SSO y 20 asientos.',
+      },
+      {
+        name: 'Enterprise',
+        price: 'Presupuesto a medida',
+        notes: 'Precio por volumen, SLA, modelos entrenados a medida y despliegue on-premise.',
+      },
+    ],
+    notes:
+      'La facturación anual supone un 20% de descuento (ahorro de 840 $ al año en Team y 2.400 $ en Business). Además del precio del plan se consumen créditos por segundo procesado, así que el coste real depende del volumen.',
+    sourceUrl: 'https://www.resemble.ai/pricing/',
+  },
+  Murf: {
+    name: 'Murf',
+    model: 'freemium',
+    freeTier:
+      '10 minutos de generación de voz con más de 200 voces y 20 idiomas, sin descargas ni derechos comerciales.',
+    plans: [
+      {
+        name: 'Free',
+        price: '0 $/mes',
+        notes:
+          'Para probar el estudio sin tarjeta; incluye todo lo del plan Business salvo las descargas.',
+      },
+      {
+        name: 'Creator',
+        price: '19 $/mes (228 $ facturados anualmente)',
+        notes:
+          'Plan de entrada para autónomos y creadores, con descargas ilimitadas y derechos comerciales.',
+      },
+      {
+        name: 'Business',
+        price: '66 $/mes (792 $ facturados anualmente)',
+        notes: 'Licencia de empresa y funciones avanzadas para equipos con mucho volumen.',
+      },
+      {
+        name: 'Enterprise',
+        price: 'Presupuesto a medida',
+        notes: 'Acceso ilimitado, seguridad y soporte de nivel corporativo; contactar con ventas.',
+      },
+    ],
+    notes:
+      'Los importes mostrados corresponden a facturación anual, con un ahorro del 33% frente al pago mensual. La API de Murf tiene planes y límites propios aparte. murf.ai es una SPA que devuelve solo el esqueleto HTML a WebFetch y a curl, así que la página oficial se leyó mediante un lector de texto que ejecuta JavaScript.',
+    sourceUrl: 'https://murf.ai/pricing',
+  },
+  Colossyan: {
+    name: 'Colossyan',
+    model: 'freemium',
+    freeTier:
+      'Plan Starter gratuito sin tarjeta: 20 min/mes con NEO, 15 avatares personalizados, 3 voces y 10 vídeos interactivos al mes.',
+    plans: [
+      {
+        name: 'Starter',
+        price: 'Gratis',
+        notes:
+          "Para quien quiere probar la generación de vídeo con avatares; la web lo presenta como '27 $/mes de valor' pero no se cobra.",
+      },
+      {
+        name: 'Professional',
+        price: '59 $/mes',
+        notes:
+          'Para equipos de formación: 30 min/mes con NEO, 10 min/mes con NEO2, sin marca de agua, exportación SCORM y hasta 3 editores.',
+      },
+      {
+        name: 'Enterprise',
+        price: 'Presupuesto a medida',
+        notes: 'Minutos y avatares ilimitados, SSO/SAML, SOC 2 Tipo II y soporte 24/7.',
+      },
+    ],
+    notes:
+      'El precio de Professional mostrado (59 $/mes) corresponde a facturación anual, anunciada con un 34 % de descuento frente al mensual; cada miembro adicional cuesta 30 $/mes. Enterprise solo se factura de forma anual.',
+    sourceUrl: 'https://www.colossyan.com/pricing',
+  },
+  Sora: {
+    name: 'Sora',
+    model: 'paid',
+    freeTier: null,
+    plans: [
+      {
+        name: 'API sora-2 (720p)',
+        price: '0,10 $/segundo',
+        notes: 'Generación de vídeo estándar por API; 0,05 $/segundo en modo batch.',
+      },
+      {
+        name: 'API sora-2-pro',
+        price: '0,30 $/segundo (720p) a 0,70 $/segundo (1080p)',
+        notes: 'Calidad superior por API; en modo batch va de 0,15 a 0,35 $/segundo.',
+      },
+    ],
+    notes:
+      'OpenAI discontinuó la app y la web de Sora el 26 de abril de 2026, así que ya no se accede vía suscripción de ChatGPT. Solo queda la API de vídeo, facturada por segundo generado, y OpenAI ya ha anunciado su retirada definitiva el 24 de septiembre de 2026. openai.com devuelve 403 a la consulta automatizada, así que las fechas se han confirmado en el centro de ayuda oficial y los precios en la documentación de la API.',
+    sourceUrl: 'https://developers.openai.com/api/docs/pricing',
+  },
+  Veo: {
+    name: 'Veo',
+    model: 'paid',
+    freeTier: null,
+    plans: [
+      {
+        name: 'Google AI Plus',
+        price: '4,99 €/mes',
+        notes:
+          'Entrada de gama con acceso básico a generación de vídeo y 400 GB de almacenamiento.',
+      },
+      {
+        name: 'Google AI Pro',
+        price: '21,99 €/mes',
+        notes:
+          'Para uso creativo habitual: generación de vídeo ampliada, prueba limitada de Veo 3.1 Lite, 1.000 créditos mensuales de Flow y 5 TB.',
+      },
+      {
+        name: 'Google AI Ultra',
+        price: '99,99 €/mes o 219,99 €/mes',
+        notes:
+          'Para producción intensiva: límites 5x o 20x, 10.000-25.000 créditos de Flow y acceso anticipado a funciones avanzadas.',
+      },
+      {
+        name: 'API Veo 3.1 (estándar)',
+        price: '0,40 $/segundo (720p y 1080p), 0,60 $/segundo (4K)',
+        notes: 'Uso por Gemini API para integrarlo en productos propios.',
+      },
+      {
+        name: 'API Veo 3.1 Fast',
+        price: '0,10 $/segundo (720p), 0,12 $/segundo (1080p), 0,30 $/segundo (4K)',
+        notes: 'Variante rápida y más barata para volumen.',
+      },
+      {
+        name: 'API Veo 3.1 Lite',
+        price: '0,05 $/segundo (720p), 0,08 $/segundo (1080p)',
+        notes: 'La opción más económica por API, sin 4K.',
+      },
+    ],
+    notes:
+      "Veo no se vende suelto: se accede vía suscripciones Google AI (precios en euros para España, tomados de gemini.google/subscriptions) o vía Gemini API pagando por segundo de vídeo generado (precios en dólares). La documentación de la Gemini API indica expresamente 'no disponible' para Veo en el nivel gratuito, y solo se cobra si el vídeo se genera correctamente. El modelo vigente es Veo 3.1.",
+    sourceUrl: 'https://gemini.google/subscriptions/',
+  },
+  Runway: {
+    name: 'Runway',
+    model: 'freemium',
+    freeTier:
+      'Plan gratuito con 125 créditos de un solo uso (no se renuevan), 5 GB de almacenamiento y una selección de modelos generativos.',
+    plans: [
+      {
+        name: 'Free',
+        price: '0 $/mes',
+        notes: 'Para probar la herramienta: 125 créditos únicos y modelos limitados.',
+      },
+      {
+        name: 'Standard',
+        price: '12 $/mes',
+        notes:
+          'Para creadores individuales: 625 créditos al mes, todos los modelos de imagen y vídeo, reescalado a 4K y sin marca de agua.',
+      },
+      {
+        name: 'Pro',
+        price: '28 $/mes',
+        notes:
+          'Para uso profesional: 2.250 créditos al mes, voces personalizadas para lip sync y 500 GB de almacenamiento.',
+      },
+      {
+        name: 'Max',
+        price: '76 $/mes',
+        notes:
+          'Para producción a volumen: 9.500 créditos al mes, arrastre de créditos un mes y acceso anticipado a modelos nuevos.',
+      },
+      {
+        name: 'Enterprise',
+        price: 'Presupuesto a medida',
+        notes:
+          'Para empresas: créditos a medida, SSO, espacios de equipo, analítica y soporte prioritario.',
+      },
+    ],
+    notes:
+      'Los precios indicados son con facturación anual (20 % de descuento); en mensual son 15 $, 35 $ y 95 $ respectivamente. El dominio runwayml.com redirige a runway.com, que es donde está la página de precios actual.',
+    sourceUrl: 'https://runway.com/pricing',
+  },
+  'Pika Labs': {
+    name: 'Pika Labs',
+    model: 'freemium',
+    freeTier:
+      '80 créditos de vídeo al mes, solo Pika 2.5 a 480p e imagen a vídeo, con marca de agua y sin uso comercial.',
+    plans: [
+      {
+        name: 'Free',
+        price: '0 $/mes',
+        notes:
+          'Para probar: 80 créditos mensuales, 480p, descargas con marca de agua y sin uso comercial.',
+      },
+      {
+        name: 'Standard',
+        price: '8 $/mes',
+        notes:
+          'Para uso casual: 700 créditos al mes, todas las resoluciones, generaciones rápidas, sin marca de agua y uso comercial permitido.',
+      },
+      {
+        name: 'Pro',
+        price: '28 $/mes',
+        notes:
+          'La opción con mejor relación valor/precio: 2.300 créditos al mes y generaciones más rápidas.',
+      },
+      {
+        name: 'Fancy',
+        price: '76 $/mes',
+        notes: 'Para volumen alto: 6.000 créditos al mes y las generaciones más rápidas.',
+      },
+    ],
+    notes:
+      'Los precios mostrados corresponden a facturación anual. Se pueden comprar créditos adicionales que se acumulan, y el plan se puede cambiar en cualquier momento.',
+    sourceUrl: 'https://pika.art/pricing',
+  },
+  Synthesia: {
+    name: 'Synthesia',
+    model: 'freemium',
+    freeTier: 'Plan Basic gratuito sin tarjeta: 10 minutos de vídeo y 1.200 créditos al mes.',
+    plans: [
+      {
+        name: 'Basic',
+        price: '0 $/mes',
+        notes:
+          'Para probar la plataforma: 10 minutos de vídeo y 1.200 créditos al mes, sin tarjeta.',
+      },
+      {
+        name: 'Starter',
+        price: '29 $/mes (18 $/mes anual)',
+        notes:
+          'Para uso individual: 10 min/mes (120 min/año en anual) y más de 125 avatares de IA.',
+      },
+      {
+        name: 'Creator',
+        price: '89 $/mes (64 $/mes anual)',
+        notes:
+          'El plan más popular: 30 min/mes (360 min/año en anual), más de 180 avatares, 5 avatares personales y acceso a la API.',
+      },
+      {
+        name: 'Enterprise',
+        price: 'Presupuesto a medida',
+        notes:
+          'Para grandes organizaciones: minutos ilimitados, avatares personales ilimitados y gestor de cuenta dedicado.',
+      },
+    ],
+    notes:
+      'La facturación anual abarata bastante (Starter de 29 $ a 18 $/mes, Creator de 89 $ a 64 $/mes). El consumo se mide tanto en minutos de vídeo como en créditos.',
+    sourceUrl: 'https://www.synthesia.io/pricing',
+  },
+  'GitHub Copilot': {
+    name: 'GitHub Copilot',
+    model: 'freemium',
+    freeTier:
+      'Plan Free sin suscripción: 2.000 completados de código y 50 peticiones de chat al mes, con varios modelos y Copilot CLI.',
+    plans: [
+      {
+        name: 'Free',
+        price: '0 $/mes',
+        notes: 'Para empezar: 2.000 completados y 50 peticiones de chat al mes.',
+      },
+      {
+        name: 'Pro',
+        price: '10 $/usuario/mes',
+        notes:
+          'Para desarrolladores individuales: completados ilimitados, agente en la nube, revisión de código y 15 $ de créditos mensuales.',
+      },
+      {
+        name: 'Pro+',
+        price: '39 $/usuario/mes',
+        notes:
+          'Para uso intensivo: acceso a modelos premium como Opus, registros de auditoría y 70 $ de créditos mensuales.',
+      },
+      {
+        name: 'Max',
+        price: '100 $/usuario/mes',
+        notes:
+          'Para power users: acceso prioritario a modelos nuevos y 200 $ de créditos mensuales.',
+      },
+      {
+        name: 'Business',
+        price: '19 $/usuario/mes',
+        notes: 'Para equipos: créditos compartidos, gestión de licencias y controles de política.',
+      },
+      {
+        name: 'Enterprise',
+        price: '39 $/usuario/mes',
+        notes:
+          'Para despliegue en toda la organización: créditos compartidos mayores (2x Business) e indemnización de propiedad intelectual.',
+      },
+    ],
+    notes:
+      'Desde los planes Pro el consumo agéntico se gestiona con créditos mensuales incluidos; superarlos implica facturación por uso adicional. Los precios están en dólares por usuario y mes.',
+    sourceUrl: 'https://github.com/features/copilot/plans',
+  },
+  Cursor: {
+    name: 'Cursor',
+    model: 'freemium',
+    freeTier:
+      'Plan Hobby gratuito sin tarjeta, con un número limitado de peticiones al agente y acceso a Composer.',
+    plans: [
+      {
+        name: 'Hobby',
+        price: '0 $/mes',
+        notes: 'Para probar el editor: peticiones limitadas al agente, sin tarjeta.',
+      },
+      {
+        name: 'Pro',
+        price: '20 $/mes',
+        notes:
+          'Para desarrolladores individuales: límites ampliados de agente, modelos frontera, MCPs, skills, hooks y agentes en la nube.',
+      },
+      {
+        name: 'Pro+',
+        price: '60 $/mes',
+        notes:
+          'Para quien usa el agente a diario: 3x los límites de Pro y 70 $ de uso de API incluido.',
+      },
+      {
+        name: 'Ultra',
+        price: '200 $/mes',
+        notes:
+          'Para uso muy intensivo: 20x los límites de Pro, 400 $ de uso de API incluido y acceso prioritario a novedades.',
+      },
+      {
+        name: 'Teams',
+        price: '40 $/usuario/mes',
+        notes:
+          'Para equipos: facturación centralizada, Bugbot para revisión de código, analítica de uso, modo privacidad y SSO SAML/OIDC.',
+      },
+      {
+        name: 'Enterprise',
+        price: 'Presupuesto a medida',
+        notes:
+          'Para grandes organizaciones: uso compartido, facturación por factura/PO, SCIM, registros de auditoría y soporte dedicado.',
+      },
+    ],
+    notes:
+      'Los planes incluyen una bolsa de uso de API y a partir de ahí se factura por consumo; Bugbot se cobra aparte por uso. El dominio del lote (cursor.sh) redirige al oficial cursor.com. Los importes de Pro+ y Ultra no se renderizan en la página de precios vía consulta automatizada, así que se han confirmado con búsqueda restringida al dominio oficial cursor.com.',
+    sourceUrl: 'https://cursor.com/pricing',
+  },
+  Tabnine: {
+    name: 'Tabnine',
+    model: 'paid',
+    freeTier: null,
+    plans: [
+      {
+        name: 'Code Assistant Platform',
+        price: '39 $/usuario/mes',
+        notes:
+          'Para equipos que quieren completado de código y chat en el IDE con control de seguridad: cero retención de código, cifrado extremo a extremo y despliegue SaaS o autoalojado.',
+      },
+      {
+        name: 'Agentic Platform',
+        price: '59 $/usuario/mes',
+        notes:
+          'Para equipos que quieren automatización: todo lo anterior más flujos agénticos, Tabnine CLI, Context Engine con conexiones ilimitadas al repositorio e integración MCP.',
+      },
+    ],
+    notes:
+      'Ambos precios son con suscripción anual y la web pide contactar con ventas para cerrar presupuesto. El consumo de LLM se paga aparte: si usas los modelos que provee Tabnine, se factura una cuota de tokens reservada al precio real del proveedor más un 5 % de gestión. Existe además un complemento opcional de Headless Agents para CI/CD con precio separado.',
+    sourceUrl: 'https://www.tabnine.com/pricing/',
+  },
+  Codium: {
+    name: 'Codium',
+    model: 'paid',
+    freeTier:
+      'Prueba gratuita de 14 días sin tarjeta con reviews y créditos ilimitados; gratis de forma permanente solo para proyectos open source aceptados en el programa Qodo for Open Source.',
+    plans: [
+      {
+        name: 'Free 14-Day Trial',
+        price: '0 $',
+        notes:
+          'Prueba de 14 días sin tarjeta con reviews y créditos ilimitados sobre las funciones principales.',
+      },
+      {
+        name: 'Pro Team',
+        price: '30 $/mes',
+        notes:
+          'Para equipos de hasta 30 personas: review agéntico de PRs, reglas ilimitadas, integraciones Git e IDE y panel de analítica.',
+      },
+      {
+        name: 'Enterprise',
+        price: 'Presupuesto a medida',
+        notes:
+          'Para más de 30 usuarios: SSO/SAML, logs de auditoría, BYOK, despliegue single-tenant u on-premise y CSM dedicado.',
+      },
+      {
+        name: 'Qodo for Open Source',
+        price: '0 $',
+        notes: 'Gratuito para proyectos open source que cumplan los requisitos del programa.',
+      },
+    ],
+    notes:
+      'El plan Pro Team es de 30 $/mes sin compromiso anual e incluye packs de créditos que se compran aparte (aprox. 0,012 $ por crédito, unos 2.500 créditos ≈ 18 reviews/mes, 5.000 ≈ 36, 20.000 ≈ 144), compartidos por todo el equipo y con tope de excedente configurable.',
+    sourceUrl: 'https://www.qodo.ai/pricing/',
+  },
+  LangChain: {
+    name: 'LangChain',
+    model: 'open-source',
+    freeTier:
+      'El framework LangChain es open source y gratuito; en la plataforma LangSmith el plan Developer es de 0 $/usuario al mes con 1 asiento y hasta 5.000 trazas base al mes.',
+    plans: [
+      {
+        name: 'Developer',
+        price: '0 $/usuario al mes',
+        notes:
+          'Un solo asiento, hasta 5.000 trazas base al mes y después pago por uso; soporte de comunidad.',
+      },
+      {
+        name: 'Plus',
+        price: '39 $/usuario al mes',
+        notes:
+          'Asientos ilimitados, hasta 10.000 trazas base al mes, acceso a Deployment y Engine, un despliegue serverless pequeño gratis y soporte por email.',
+      },
+      {
+        name: 'Enterprise',
+        price: 'Presupuesto a medida',
+        notes:
+          'Despliegue self-hosted o híbrido, SSO/ABAC/RBAC a medida, SLA de soporte, formación y facturación anual.',
+      },
+    ],
+    notes:
+      'Las librerías de LangChain y LangGraph son gratuitas; lo que se paga es la plataforma LangSmith. Al superar las trazas incluidas se factura por uso, y el cómputo y almacenamiento se cobran en unidades propias (1,50 $ por LCU y 1,00 $ por LSU). El coste de los modelos de IA (OpenAI, Anthropic, etc.) va aparte.',
+    sourceUrl: 'https://www.langchain.com/pricing',
+  },
+  Perplexity: {
+    name: 'Perplexity',
+    model: 'freemium',
+    freeTier:
+      'Plan gratuito con búsquedas ilimitadas y un número limitado de búsquedas Pro al día.',
+    plans: [
+      {
+        name: 'Pro',
+        price: '20 $/mes',
+        notes:
+          'Para uso individual intensivo: búsquedas Pro ampliadas, elección de modelos y subida de archivos.',
+      },
+      {
+        name: 'Max',
+        price: '200 $/mes (2.000 $/año)',
+        notes:
+          'Nivel superior para usuarios avanzados, con los límites más altos y acceso prioritario a novedades.',
+      },
+      {
+        name: 'Enterprise Pro',
+        price: '40 $/usuario al mes (400 $/usuario al año)',
+        notes:
+          'Para empresas: controles de administración y seguridad; unos 30 $/usuario al mes para centros educativos y entidades sin ánimo de lucro.',
+      },
+      {
+        name: 'Enterprise Max',
+        price: '325 $/usuario al mes (3.250 $/usuario al año)',
+        notes: 'Plan empresarial de gama alta con los límites y capacidades máximas.',
+      },
+    ],
+    notes:
+      'La facturación anual supone en torno a un 20 % de descuento frente a la mensual. Todas las URL de perplexity.ai devolvieron 403 a la consulta directa, así que las cifras proceden de búsquedas restringidas al dominio oficial (páginas de precios y centro de ayuda de Perplexity), no de la lectura directa de la página; por eso la confianza se marca como baja. La API de Perplexity (Sonar) se factura aparte por uso.',
+    sourceUrl: 'https://www.perplexity.ai/hub/pricing',
+  },
+  AutoGPT: {
+    name: 'AutoGPT',
+    model: 'open-source',
+    freeTier:
+      'La versión autoalojada es gratuita y open source (se despliega con Docker Compose aportando tus propias claves de API); en la nube no hay plan gratuito permanente.',
+    plans: [
+      {
+        name: 'Self-Hosted',
+        price: '0 $',
+        notes:
+          'Instalación propia con Docker Compose; pagas solo la infraestructura y las API de terceros que uses.',
+      },
+      {
+        name: 'Pro',
+        price: '42,50 $/mes (facturación anual)',
+        notes:
+          'Nube gestionada con acceso a los principales modelos, constructor visual, agentes continuos, programación y disparadores por eventos.',
+      },
+      {
+        name: 'Max',
+        price: '272,00 $/mes (facturación anual)',
+        notes:
+          'Todo lo de Pro con 8,5 veces más capacidad de uso, 5 veces más almacenamiento, integraciones ampliadas y soporte prioritario.',
+      },
+      {
+        name: 'Team',
+        price: 'Presupuesto a medida',
+        notes:
+          'Anunciado como próximamente: espacios multiusuario, controles de administración y facturación centralizada.',
+      },
+    ],
+    notes:
+      'La página oficial solo muestra precios con facturación anual (no publica el importe mensual suelto). Además de la cuota, la ejecución de agentes se paga por uso desde un monedero de créditos en todos los planes, y en la versión autoalojada el coste real son la infraestructura y las claves de API de los modelos.',
+    sourceUrl: 'https://agpt.co/pricing',
+  },
+  AgentGPT: {
+    name: 'AgentGPT',
+    model: 'freemium',
+    freeTier: 'Uso gratuito limitado a 5 ejecuciones de agente al día en la web (versión Beta).',
+    plans: [
+      {
+        name: 'Pro',
+        price: '40 $/mes',
+        notes:
+          '30 agentes al día, acceso a GPT-4 y GPT-3.5-Turbo 16k, 25 bucles por agente, búsqueda web ilimitada, plugins y soporte prioritario.',
+      },
+    ],
+    notes:
+      'Los precios se leyeron en la página de suscripción del propio producto (agentgpt.reworkd.ai/plan), ya que la portada no publica tarifas. El proyecto sigue etiquetado como Beta y su código es open source, por lo que también puede autoalojarse asumiendo el coste de las claves de API.',
+    sourceUrl: 'https://agentgpt.reworkd.ai/plan',
+  },
+  Zapier: {
+    name: 'Zapier',
+    model: 'freemium',
+    freeTier:
+      'Plan Free con 100 tareas al mes, Zaps ilimitados pero solo de dos pasos y acceso básico a las funciones de IA.',
+    plans: [
+      {
+        name: 'Free',
+        price: '0 $/mes',
+        notes: '100 tareas al mes y automatizaciones de dos pasos, para probar la herramienta.',
+      },
+      {
+        name: 'Professional',
+        price: 'Desde 19,99 $/mes (750 tareas, facturación anual)',
+        notes:
+          'Flujos multipaso, apps premium ilimitadas, webhooks, filtros y rutas; escala por volumen (39 $ por 1.500 tareas, 89 $ por 5.000, 489 $ por 100.000).',
+      },
+      {
+        name: 'Team',
+        price: 'Desde 69,00 $/mes (2.000 tareas, facturación anual)',
+        notes:
+          'Todo lo de Professional para hasta 25 usuarios, con Zaps y conexiones compartidas, SAML SSO y soporte prioritario.',
+      },
+      {
+        name: 'Enterprise',
+        price: 'Presupuesto a medida',
+        notes:
+          'Usuarios ilimitados, controles avanzados de administración, SCIM, retención de datos personalizada y gestor técnico de cuenta.',
+      },
+    ],
+    notes:
+      'Los precios mostrados corresponden a facturación anual, que supone un 33 % de descuento frente a la mensual; el coste sube según el número de tareas contratadas (hasta 3.389 $/mes por 2.000.000 de tareas en Professional). Zapier factura en 19 monedas, así que el importe en euros puede variar según el país.',
+    sourceUrl: 'https://zapier.com/pricing',
+  },
+  n8n: {
+    name: 'n8n',
+    model: 'open-source',
+    freeTier:
+      'La Community Edition autoalojada es gratuita y sin límite de ejecuciones; en la nube solo hay prueba gratuita sin tarjeta, no un plan gratuito permanente.',
+    plans: [
+      {
+        name: 'Community Edition (autoalojada)',
+        price: '0 €',
+        notes:
+          'Versión gratuita para instalar en tu propio servidor; pagas solo la infraestructura.',
+      },
+      {
+        name: 'Starter',
+        price: '20 €/mes (facturación anual)',
+        notes:
+          '2.500 ejecuciones con pasos ilimitados, 1 proyecto compartido, 5 ejecuciones concurrentes y usuarios ilimitados.',
+      },
+      {
+        name: 'Pro',
+        price: '50 €/mes (facturación anual)',
+        notes:
+          '10.000 ejecuciones, 3 proyectos, 20 ejecuciones concurrentes, roles de administración, variables globales e historial de flujos.',
+      },
+      {
+        name: 'Business',
+        price: '667 €/mes (facturación anual)',
+        notes:
+          '40.000 ejecuciones, opción autoalojada con licencia, 6 proyectos, SSO/SAML/LDAP y control de versiones con Git.',
+      },
+      {
+        name: 'Enterprise',
+        price: 'Presupuesto a medida',
+        notes:
+          'Volumen de ejecuciones a medida, proyectos ilimitados, 200+ ejecuciones concurrentes, gestor de secretos externo y soporte con SLA.',
+      },
+    ],
+    notes:
+      'Los precios publicados son con facturación anual y en euros; incluyen créditos de IA mensuales (2.300 en Starter, hasta 13.700 en Pro). Las pruebas de Starter y Pro no piden tarjeta. n8n es fair-code, no OSI estricto, pero su código está disponible y la edición comunitaria es gratuita.',
+    sourceUrl: 'https://n8n.io/pricing/',
+  },
+  Make: {
+    name: 'Make',
+    model: 'freemium',
+    freeTier:
+      'Plan Free con hasta 1.000 créditos al mes, constructor visual, más de 3.000 apps e intervalo mínimo de 15 minutos entre ejecuciones.',
+    plans: [
+      {
+        name: 'Free',
+        price: '0 $/mes',
+        notes:
+          'Hasta 1.000 créditos al mes con routers y filtros, pensado para probar la plataforma.',
+      },
+      {
+        name: 'Core',
+        price: '9 $/mes',
+        notes:
+          '10.000 créditos ampliables, escenarios activos ilimitados, programación al minuto y acceso a la API de Make.',
+      },
+      {
+        name: 'Pro',
+        price: '16 $/mes',
+        notes:
+          'Todo lo de Core más ejecución prioritaria, variables personalizadas y búsqueda de texto completo en los registros.',
+      },
+      {
+        name: 'Teams',
+        price: '29 $/mes',
+        notes:
+          'Todo lo de Pro más gestión de equipos y roles y plantillas de escenarios compartidas.',
+      },
+      {
+        name: 'Enterprise',
+        price: 'Presupuesto a medida',
+        notes:
+          'Funciones personalizadas, integraciones empresariales, soporte 24/7, protección frente a excedentes y seguridad avanzada.',
+      },
+    ],
+    notes:
+      'La facturación anual supone un ahorro del 15 % o más frente a la mensual, y todos los planes de pago escalan el precio según los créditos contratados. Los importes se consultaron en la versión internacional de la web, en dólares.',
+    sourceUrl: 'https://www.make.com/en/pricing',
+  },
+  'Power Automate': {
+    name: 'Power Automate',
+    model: 'freemium',
+    freeTier:
+      'Prueba gratuita de 30 días para experimentar con flujos en la nube y conectores estándar; los usuarios con licencia de Microsoft 365 tienen capacidades básicas incluidas.',
+    plans: [
+      {
+        name: 'Prueba gratuita',
+        price: '0 $',
+        notes: '30 días para probar flujos en la nube basados en interfaz y conectores estándar.',
+      },
+      {
+        name: 'Power Automate Premium',
+        price: '15,00 $/usuario al mes (pago anual)',
+        notes:
+          'Flujos en la nube y de escritorio asistidos (RPA), minería de procesos y tareas y acceso a Dataverse.',
+      },
+      {
+        name: 'Power Automate Process',
+        price: '150,00 $/bot al mes (pago anual)',
+        notes:
+          'Flujos de escritorio desatendidos (RPA) asociados a un proceso concreto, no a un usuario.',
+      },
+      {
+        name: 'Power Automate Hosted Process',
+        price: '215,00 $/bot al mes (pago anual)',
+        notes: 'Como Process pero con máquina virtual alojada por Microsoft en Azure.',
+      },
+      {
+        name: 'Process Mining Add-on',
+        price: '5.000,00 $/inquilino al mes (pago anual)',
+        notes:
+          'Complemento de minería de procesos con 100 GB de almacenamiento; requiere el plan Premium.',
+      },
+      {
+        name: 'Microsoft Copilot Studio',
+        price: '200,00 $/mes por 25.000 créditos (pago anual)',
+        notes:
+          'Capacidades de IA generativa y conversacional, creación de diálogos y analítica integrada.',
+      },
+    ],
+    notes:
+      'Los precios corresponden a la web estadounidense de Microsoft y son con pago anual; en la web española los importes se muestran en euros y pueden variar. Los conectores premium y la RPA desatendida requieren licencias adicionales, y el consumo de IA se paga con créditos aparte.',
+    sourceUrl: 'https://www.microsoft.com/en-us/power-platform/products/power-automate/pricing',
+  },
+  'Notion AI': {
+    name: 'Notion AI',
+    model: 'freemium',
+    freeTier:
+      'Plan Free con bloques ilimitados para uso individual (limitados a partir de 2 miembros), archivos de hasta 5 MB y acceso de prueba limitado a las funciones de IA.',
+    plans: [
+      {
+        name: 'Free',
+        price: '0 €/mes',
+        notes:
+          'Para uso individual, con acceso de prueba a la IA y funciones básicas de bases de datos, sitios y formularios.',
+      },
+      {
+        name: 'Plus',
+        price: '9,50 €/miembro/mes',
+        notes:
+          'Para equipos pequeños: bloques ilimitados, historial de 30 días, sitios y formularios personalizados; la IA sigue siendo de prueba.',
+      },
+      {
+        name: 'Business',
+        price: '19,50 €/miembro/mes',
+        notes:
+          'Primer plan con Notion AI completo: Notion Agent, notas de reunión con IA, búsqueda empresarial y SAML SSO.',
+      },
+      {
+        name: 'Enterprise',
+        price: 'Presupuesto a medida',
+        notes:
+          'Para grandes organizaciones: retención cero de datos con los proveedores de LLM, SCIM y controles de seguridad avanzados.',
+      },
+    ],
+    notes:
+      'Notion AI ya no se vende como complemento con precio propio: viene incluido en Business y Enterprise, y en Free/Plus solo como prueba limitada. Los agentes personalizados consumen créditos aparte, a 10 € por cada 1.000 créditos al mes. Los precios mostrados corresponden a facturación anual.',
+    sourceUrl: 'https://www.notion.com/pricing',
+  },
+  'Microsoft 365 Copilot': {
+    name: 'Microsoft 365 Copilot',
+    model: 'paid',
+    freeTier: null,
+    plans: [
+      {
+        name: 'Microsoft 365 Copilot (complemento)',
+        price: '15,60 €/usuario/mes',
+        notes:
+          'Precio con compromiso anual (21,84 €/usuario/mes sin compromiso); se añade sobre una suscripción de Microsoft 365 Business ya existente.',
+      },
+      {
+        name: 'Microsoft 365 Business Standard + Copilot',
+        price: '20,36 €/usuario/mes',
+        notes: 'Paquete con Teams incluido y compromiso anual (24,43 €/usuario/mes en mensual).',
+      },
+      {
+        name: 'Microsoft 365 Business Premium + Copilot',
+        price: '27,73 €/usuario/mes',
+        notes:
+          'Paquete con Teams y seguridad avanzada, compromiso anual (33,28 €/usuario/mes en mensual).',
+      },
+      {
+        name: 'Microsoft 365 Business Standard EEA (sin Teams) + Copilot',
+        price: '17,58 €/usuario/mes',
+        notes:
+          'Variante para el Espacio Económico Europeo sin Teams, con compromiso anual (21,10 €/usuario/mes en mensual).',
+      },
+      {
+        name: 'Microsoft 365 Business Premium EEA (sin Teams) + Copilot',
+        price: '24,94 €/usuario/mes',
+        notes:
+          'Variante EEE sin Teams con seguridad avanzada, compromiso anual (29,93 €/usuario/mes en mensual).',
+      },
+    ],
+    notes:
+      'Todos los precios son sin IVA y para España. No existe versión gratuita de Microsoft 365 Copilot: requiere licencia de Microsoft 365 Business elegible además del complemento.',
+    sourceUrl: 'https://www.microsoft.com/es-es/microsoft-365/copilot/business',
+  },
+  Gamma: {
+    name: 'Gamma',
+    model: 'freemium',
+    freeTier:
+      'Plan Free con funciones básicas de IA (límite de 50.000 tokens de entrada), sin tarjeta y con la marca de Gamma en las presentaciones publicadas.',
+    plans: [
+      {
+        name: 'Free',
+        price: '0 $/mes',
+        notes: 'Para probar la herramienta: IA básica con tope de tokens y badge de Gamma.',
+      },
+      {
+        name: 'Plus',
+        price: '8 $/mes',
+        notes: '1.000 créditos al mes y eliminación de la marca de Gamma.',
+      },
+      {
+        name: 'Pro',
+        price: '20 $/mes',
+        notes:
+          '4.000 créditos al mes, modelos de imagen premium, marca propia, analíticas, dominios personalizados y acceso a la API.',
+      },
+      {
+        name: 'Teams / Business',
+        price: 'Presupuesto a medida',
+        notes: 'Opciones para organizaciones con facturación por miembro.',
+      },
+    ],
+    notes:
+      'gamma.app devuelve 403 a la consulta automática, así que los precios provienen de búsqueda restringida al dominio oficial (gamma.app y help.gamma.app) y no de la página vista directamente; conviene revalidarlos. La facturación anual aplica un 28 % de descuento con los mismos créditos mensuales, la facturación es por miembro y los créditos no usados se acumulan hasta el doble del plan.',
+    sourceUrl: 'https://gamma.app/pricing',
+  },
+  'Canva Magic Studio': {
+    name: 'Canva Magic Studio',
+    model: 'freemium',
+    freeTier:
+      'Canva Free da acceso al editor y a un uso limitado de las funciones de IA de Magic Studio (créditos mensuales limitados).',
+    plans: [
+      {
+        name: 'Free',
+        price: '0 $/mes',
+        notes: 'Editor completo con plantillas básicas y uso limitado de las herramientas de IA.',
+      },
+      {
+        name: 'Business',
+        price: '20 $/persona/mes',
+        notes:
+          'Sin mínimo de usuarios: kit de marca, colaboración y funciones de IA para equipos pequeños.',
+      },
+      {
+        name: 'Enterprise',
+        price: 'Presupuesto a medida',
+        notes: 'Para grandes organizaciones con control de marca, permisos y seguridad avanzada.',
+      },
+    ],
+    notes:
+      'canva.com devuelve 403 a la consulta automática tanto en la página de precios en español como en la inglesa; el precio de Business procede de una búsqueda restringida al dominio oficial (canva.com/newsroom) y no he podido confirmar la cifra exacta de Canva Pro. Magic Studio no se vende por separado: es el conjunto de funciones de IA integradas y su uso se mide en créditos según el plan. Canva Teams ya no admite nuevas altas.',
+    sourceUrl: 'https://www.canva.com/en/pricing/',
+  },
+  'Power BI': {
+    name: 'Power BI',
+    model: 'freemium',
+    freeTier:
+      'Cuenta gratuita para crear informes interactivos de forma individual, sin tarjeta, pero sin poder compartirlos con otros usuarios.',
+    plans: [
+      {
+        name: 'Cuenta gratuita',
+        price: '0 €/mes',
+        notes: 'Creación y análisis de informes en solitario; para compartir hay que subir a Pro.',
+      },
+      {
+        name: 'Power BI Pro',
+        price: '12,10 €/usuario/mes',
+        notes:
+          'Publicar y compartir informes; incluido de serie en Microsoft 365 E5 y Office 365 E5.',
+      },
+      {
+        name: 'Power BI Premium por usuario',
+        price: '20,80 €/usuario/mes',
+        notes:
+          'Todo lo de Pro más modelos de mayor tamaño y actualizaciones más frecuentes, para perfiles de datos.',
+      },
+      {
+        name: 'Power BI Embedded / capacidad Microsoft Fabric',
+        price: 'Presupuesto a medida',
+        notes:
+          'Capacidad reservada o de pago por uso para incrustar informes en aplicaciones propias.',
+      },
+    ],
+    notes:
+      'Precios para España con facturación anual y sin IVA. Las funciones de Copilot en Power BI no se facturan por usuario: requieren capacidad de Microsoft Fabric, que se paga aparte.',
+    sourceUrl: 'https://www.microsoft.com/es-es/power-platform/products/power-bi/pricing',
+  },
+  Tableau: {
+    name: 'Tableau',
+    model: 'paid',
+    freeTier: null,
+    plans: [
+      {
+        name: 'Tableau Cloud Standard - Creator',
+        price: '75 $/usuario/mes',
+        notes:
+          'Licencia de autor completa (facturación anual); toda implantación necesita al menos un Creator.',
+      },
+      {
+        name: 'Tableau Cloud Standard - Explorer',
+        price: '42 $/usuario/mes',
+        notes: 'Para quien explora y modifica cuadros de mando existentes, facturado anualmente.',
+      },
+      {
+        name: 'Tableau Cloud Standard - Viewer',
+        price: '15 $/usuario/mes',
+        notes: 'Solo consulta de informes publicados, facturado anualmente.',
+      },
+      {
+        name: 'Tableau Cloud Enterprise - Creator',
+        price: '115 $/usuario/mes',
+        notes: 'Edición Enterprise con gobernanza y funciones avanzadas, facturación anual.',
+      },
+      {
+        name: 'Tableau Cloud Enterprise - Explorer',
+        price: '70 $/usuario/mes',
+        notes: 'Explorer dentro de la edición Enterprise, facturación anual.',
+      },
+      {
+        name: 'Tableau Cloud Enterprise - Viewer',
+        price: '35 $/usuario/mes',
+        notes: 'Viewer dentro de la edición Enterprise, facturación anual.',
+      },
+    ],
+    notes:
+      'tableau.com devuelve 403 a la consulta automática, así que las cifras provienen de una búsqueda restringida al dominio oficial (tableau.com) y no de la página vista directamente. Todos los productos exigen contrato anual. La página de IA de Tableau no publica precio propio para Tableau AI/Agentforce: se comercializa dentro de las ediciones superiores o con presupuesto, y no hay plan gratuito más allá de la prueba.',
+    sourceUrl: 'https://www.tableau.com/pricing/cloud',
+  },
+  Bolt: {
+    name: 'Bolt',
+    model: 'freemium',
+    freeTier:
+      'Plan gratuito con 300.000 tokens diarios y hasta 1.000.000 al mes, proyectos públicos y privados, bases de datos ilimitadas y hosting con la marca de Bolt.',
+    plans: [
+      {
+        name: 'Free',
+        price: '0 $/mes',
+        notes:
+          'Para probar: 300.000 tokens al día, subidas de hasta 10 MB y badge de Bolt en el sitio publicado.',
+      },
+      {
+        name: 'Pro',
+        price: '25 $/mes',
+        notes:
+          'Desde 10 millones de tokens al mes sin límite diario, sin marca de Bolt, dominio propio y edición de imágenes con IA.',
+      },
+      {
+        name: 'Teams',
+        price: '30 $/miembro/mes',
+        notes:
+          'Todo lo de Pro con facturación centralizada, control de acceso por equipo y registros NPM privados.',
+      },
+      {
+        name: 'Enterprise',
+        price: 'Presupuesto a medida',
+        notes:
+          'SSO, auditorías, soporte dedicado 24/7 e integraciones y gobernanza de datos a medida.',
+      },
+    ],
+    notes:
+      'El consumo se mide en tokens y los no usados se acumulan al mes siguiente en los planes de pago; hay niveles superiores de tokens dentro de Pro y Teams con precio creciente.',
+    sourceUrl: 'https://bolt.new/pricing',
+  },
+  Grammarly: {
+    name: 'Grammarly',
+    model: 'freemium',
+    freeTier:
+      'Plan gratuito con corrección de ortografía y gramática, detección de tono y 100 indicaciones de IA al mes.',
+    plans: [
+      {
+        name: 'Free',
+        price: '0 €/mes',
+        notes: 'Corrección básica y 100 usos de IA al mes, suficiente para uso ocasional.',
+      },
+      {
+        name: 'Pro',
+        price: '12 €/mes',
+        notes:
+          '2.000 indicaciones de IA por miembro y mes, reescritura de frases, ajuste de tono, detección de plagio y de texto generado por IA; incluye 7 días de prueba.',
+      },
+      {
+        name: 'Enterprise',
+        price: 'Presupuesto a medida',
+        notes:
+          'IA ilimitada por miembro, SAML/SCIM, cifrado BYOK, prevención de pérdida de datos y soporte dedicado.',
+      },
+    ],
+    notes:
+      'El precio se muestra en euros para España y corresponde a facturación anual; la modalidad mensual es más cara. Las funciones avanzadas de reescritura siguen limitadas al inglés.',
+    sourceUrl: 'https://www.grammarly.com/plans',
+  },
+  Looka: {
+    name: 'Looka',
+    model: 'freemium',
+    freeTier:
+      'Puedes generar y personalizar logos ilimitados gratis; solo pagas cuando quieres descargar los archivos.',
+    plans: [
+      {
+        name: 'Basic Logo Package',
+        price: '20 $ pago unico',
+        notes:
+          'Un archivo PNG del logo, con ediciones ilimitadas de color, fuente y disposicion incluso despues de comprar.',
+      },
+      {
+        name: 'Premium Logo Package',
+        price: '65 $ pago unico',
+        notes:
+          'Multiples formatos y variaciones del logo (vectoriales incluidos) para quien necesita el kit completo de archivos.',
+      },
+      {
+        name: 'Brand Kit Subscription',
+        price: '96 $/año',
+        notes:
+          'Suscripcion anual con acceso a todas las plantillas y activos de marca generados con tu logo, colores y tipografias.',
+      },
+      {
+        name: 'Brand Kit Web',
+        price: '129 $/año',
+        notes: 'Todo el Brand Kit mas la creacion y alojamiento de una web de marca.',
+      },
+      {
+        name: 'Brand Kit Web (Ecommerce)',
+        price: '299 $/año',
+        notes: 'Brand Kit mas web con funciones de tienda online.',
+      },
+    ],
+    notes:
+      'Los paquetes de logo son pago unico y el Brand Kit es suscripcion facturada anualmente; son productos distintos y compatibles. La web de Looka devuelve 403 a la consulta automatica, asi que los precios se han obtenido mediante busqueda restringida al dominio oficial looka.com (pagina looka.com/pricing y centro de ayuda help.looka.com), coincidentes en dos consultas independientes.',
+    sourceUrl: 'https://looka.com/pricing/',
+  },
+  Brandmark: {
+    name: 'Brandmark',
+    model: 'freemium',
+    freeTier:
+      'Genera logos ilimitados gratis y sin crear cuenta; solo pagas si quieres descargar los archivos.',
+    plans: [
+      {
+        name: 'Basic',
+        price: '35 $ pago unico',
+        notes: 'Archivos del logo en PNG y formato vectorial, para quien solo necesita el logo.',
+      },
+      {
+        name: 'Designer',
+        price: '95 $ pago unico',
+        notes:
+          'Archivos fuente editables, revisiones de diseño ilimitadas, guia de marca, diseños web, tarjetas, activos para redes y presentaciones.',
+      },
+      {
+        name: 'Enterprise',
+        price: '195 $ pago unico',
+        notes:
+          'Todo lo del plan Designer mas hasta 10 conceptos hechos a mano y la descarga de la tipografia.',
+      },
+    ],
+    notes:
+      "Todos los planes son pago unico, sin cuotas mensuales ni suscripcion: se indica expresamente 'No monthly charges' y el acceso a las herramientas de marca es permanente tras la compra.",
+    sourceUrl: 'https://brandmark.io/pricing/',
+  },
+  SentinelOne: {
+    name: 'SentinelOne',
+    model: 'paid',
+    freeTier: null,
+    plans: [
+      {
+        name: 'Singularity Core',
+        price: '69,99 $/endpoint al año',
+        notes:
+          'EDR de entrada pensado para sustituir al antivirus tradicional en equipos de trabajo.',
+      },
+      {
+        name: 'Singularity Complete',
+        price: '179,99 $/endpoint al año',
+        notes:
+          'EDR y XDR completo con respuesta automatizada, para empresas con equipo de seguridad.',
+      },
+      {
+        name: 'Singularity Commercial',
+        price: '229,99 $/endpoint al año',
+        notes: 'Añade capacidades avanzadas de deteccion y visibilidad sobre el paquete Complete.',
+      },
+      {
+        name: 'Singularity Enterprise',
+        price: 'Presupuesto a medida',
+        notes:
+          'Nivel superior con analista SOC de IA agentica, visibilidad forense total y onboarding guiado; hay que contactar con ventas.',
+      },
+    ],
+    notes:
+      'Los precios publicados corresponden a la franja de 5 a 100 puestos de trabajo y son anuales por endpoint. SentinelOne avisa de que toda compra se formaliza a traves de un partner autorizado, por lo que las cifras de la web no son el precio final. La url /platform/pricing/ da 404: la pagina viva es /platform-packages/.',
+    sourceUrl: 'https://www.sentinelone.com/platform-packages/',
+  },
+  CrowdStrike: {
+    name: 'CrowdStrike',
+    model: 'paid',
+    freeTier: null,
+    plans: [
+      {
+        name: 'Falcon Go',
+        price: '59,99 $/dispositivo al año (7,99 $/dispositivo al mes)',
+        notes:
+          'Antivirus de nueva generacion para pymes, con un maximo de 100 dispositivos por compra.',
+      },
+      {
+        name: 'Falcon Pro',
+        price: '99,99 $/dispositivo al año (14,99 $/dispositivo al mes)',
+        notes:
+          'Añade EDR e inteligencia de amenazas para equipos de TI que quieren investigar incidentes.',
+      },
+      {
+        name: 'Falcon Enterprise',
+        price: '184,99 $/dispositivo al año (19,99 $/dispositivo al mes)',
+        notes: 'EDR/XDR completo con busqueda de amenazas gestionada, para organizaciones con SOC.',
+      },
+      {
+        name: 'Falcon Complete Next-Gen MDR',
+        price: 'Presupuesto a medida',
+        notes:
+          'Servicio gestionado 24/7 en el que CrowdStrike opera la deteccion y respuesta por ti.',
+      },
+    ],
+    notes:
+      'Prueba gratuita de 15 dias con Falcon Prevent, Device Control y soporte Express, sin tarjeta. Existe facturacion mensual y anual, y las suscripciones anuales admiten cancelacion con reembolso completo durante los primeros 30 dias. Los modulos adicionales se contratan aparte.',
+    sourceUrl: 'https://www.crowdstrike.com/en-us/pricing/',
+  },
+  CrewAI: {
+    name: 'CrewAI',
+    model: 'open-source',
+    freeTier:
+      'Plan Basic gratuito (0 $) con 50 ejecuciones de flujo al mes, editor visual, copiloto de IA e integracion con GitHub.',
+    plans: [
+      {
+        name: 'Basic',
+        price: '0 $',
+        notes: 'Gratis, hasta 50 ejecuciones de flujo al mes, para probar y proyectos pequeños.',
+      },
+      {
+        name: 'Enterprise',
+        price: 'Presupuesto a medida',
+        notes:
+          'Añade gobernanza (SSO, RBAC, identidad de cargas, redaccion de PII), despliegue flexible y un onboarding de 45 dias; sin cifras publicas.',
+      },
+    ],
+    notes:
+      'El framework CrewAI es codigo abierto y gratuito de instalar; lo que se cobra es la plataforma alojada CrewAI AMP. El coste real de usarlo incluye siempre las llamadas a la API del modelo que conectes, que se facturan aparte por el proveedor.',
+    sourceUrl: 'https://www.crewai.com/pricing',
+  },
+  LangGraph: {
+    name: 'LangGraph',
+    model: 'open-source',
+    freeTier:
+      'La libreria LangGraph es MIT y de uso gratuito; en la nube, el plan Developer cuesta 0 $ por puesto e incluye 5.000 trazas base al mes y hasta 10 sandboxes.',
+    plans: [
+      {
+        name: 'Developer',
+        price: '0 $/puesto al mes',
+        notes:
+          'Un solo usuario, 5.000 trazas base al mes y despues pago por uso; soporte de comunidad.',
+      },
+      {
+        name: 'Plus',
+        price: '39 $/puesto al mes',
+        notes:
+          'Puestos ilimitados, 10.000 trazas base al mes, despliegue con una instancia serverless pequeña incluida.',
+      },
+      {
+        name: 'Enterprise',
+        price: 'Presupuesto a medida',
+        notes:
+          'Facturacion anual por factura, despliegue autoalojado o hibrido, SSO propio, control de accesos por rol, SLA y soporte dedicado.',
+      },
+    ],
+    notes:
+      'LangGraph en si es open source bajo licencia MIT y gratis; lo que se paga es la plataforma LangSmith donde se despliegan y observan los agentes. Al margen del puesto se factura el consumo: 1,50 $ por LCU de computo y 1,00 $ por LSU de almacenamiento, mas las trazas que superen la cuota base. Hay programa para startups con tarifas reducidas y 10.000 $ en creditos.',
+    sourceUrl: 'https://www.langchain.com/pricing',
+  },
+  Haystack: {
+    name: 'Haystack',
+    model: 'open-source',
+    freeTier:
+      'El framework Haystack es open source y gratuito; deepset Studio ofrece un plan gratuito de 0 $ con 1 espacio de trabajo, 1 usuario, 100 horas de pipeline, 50 archivos (máx. 10 MB) y 2 pipelines de desarrollo.',
+    plans: [
+      {
+        name: 'Haystack (framework)',
+        price: 'Gratis',
+        notes: 'Framework open source para construir agentes y aplicaciones RAG; se autoaloja.',
+      },
+      {
+        name: 'Studio',
+        price: '0 $',
+        notes:
+          'Para prototipar en la nube de deepset: 1 usuario, 1 workspace, 100 horas de pipeline y soporte comunitario.',
+      },
+      {
+        name: 'Enterprise',
+        price: 'Presupuesto a medida',
+        notes:
+          'Para equipos en producción: workspaces y usuarios ilimitados, pipelines ilimitados, equipo de cuenta y canal privado de Slack.',
+      },
+    ],
+    notes:
+      'El framework no cuesta nada: el gasto real es la infraestructura donde lo despliegas y las APIs de LLM de terceros que uses. La plataforma comercial de deepset no publica cifras para Enterprise (precio flexible según tamaño de empresa) y también hay soporte Haystack Enterprise sin precio público.',
+    sourceUrl: 'https://www.deepset.ai/pricing',
+  },
+  Writesonic: {
+    name: 'Writesonic',
+    model: 'paid',
+    freeTier: null,
+    plans: [
+      {
+        name: 'Starter',
+        price: '79 $/mes',
+        notes:
+          'Facturado anualmente (ahorra 240 $/año): seguimiento en ChatGPT, Gemini y Google AI Overviews, 50 prompts y 50 respuestas diarias, 15 artículos IA/mes y 10 auditorías de sitio.',
+      },
+      {
+        name: 'Basic',
+        price: '199 $/mes',
+        notes:
+          'Facturado anualmente (ahorra 600 $/año): SEO + GEO en una plataforma, 100 prompts y 300 respuestas diarias, 25 artículos IA/mes, 2 usuarios.',
+      },
+      {
+        name: 'Growth',
+        price: '399 $/mes',
+        notes:
+          'Facturado anualmente (ahorra 1.200 $/año): añade análisis de sentimiento, Action Center y flujos agénticos, 200 prompts y 600 respuestas diarias, 50 artículos IA/mes.',
+      },
+      {
+        name: 'Enterprise',
+        price: 'Presupuesto a medida',
+        notes:
+          'Seguimiento en 10 plataformas de IA, Action Center completo, workflows agénticos sin límite y equipo de estrategia dedicado.',
+      },
+    ],
+    notes:
+      'Los precios mostrados son con facturación anual (descuento del 20 %); con pago mensual son más caros. No hay plan gratuito permanente, solo prueba gratuita sin tarjeta y algunas herramientas sueltas gratis (generador de llms.txt, AI Crawl Checker).',
+    sourceUrl: 'https://writesonic.com/pricing',
+  },
+  DeepL: {
+    name: 'DeepL',
+    model: 'freemium',
+    freeTier:
+      'Versión gratuita del traductor con 50.000 caracteres por usuario al mes y 1 traducción de archivo.',
+    plans: [
+      {
+        name: 'Individual',
+        price: '8,74 US$/mes',
+        notes:
+          'Facturación anual: 300.000 caracteres/mes, 3 traducciones de archivo, 1 glosario y traducción de páginas web completas; para usuarios sueltos.',
+      },
+      {
+        name: 'Team',
+        price: '28,74 US$ por usuario/mes',
+        notes:
+          'Facturación anual: 1.000.000 de caracteres por usuario/mes, 20 archivos, 5 glosarios, gestión de usuarios, estadísticas y SSO.',
+      },
+      {
+        name: 'Business',
+        price: '57,49 US$ por usuario/mes',
+        notes:
+          'Facturación anual: sin límite de caracteres (uso razonable), 100 archivos/mes, memorias de traducción, Write Pro incluido y 99,0 % de disponibilidad.',
+      },
+      {
+        name: 'Enterprise',
+        price: 'Precio personalizado',
+        notes:
+          'Límites a medida, BYOK, 99,9 % de disponibilidad, equipo de cuenta exclusivo y soporte premium.',
+      },
+      {
+        name: 'Complemento DeepL Write Pro',
+        price: '7,49 US$ por usuario/mes',
+        notes:
+          'Add-on de asistente de escritura con facturación anual, se suma a Individual o Team.',
+      },
+    ],
+    notes:
+      'DeepL ha renombrado sus planes: ya no son Starter/Advanced/Ultimate sino Individual/Team/Business/Enterprise. Los precios listados son con facturación anual (DeepL indica un ahorro del 16 % frente a la mensual) y la página los sirvió en dólares por geolocalización de EE. UU.; desde España se muestran en euros. La API de DeepL se factura aparte con sus propios planes. La página es 100 % JavaScript y devolvía HTML sin cifras a WebFetch: se leyó vía proxy de texto de la misma URL oficial.',
+    sourceUrl: 'https://www.deepl.com/es/pro?cta=header-pro',
+  },
+  HeyGen: {
+    name: 'HeyGen',
+    model: 'freemium',
+    freeTier:
+      'Plan Free de 0 $/mes con 3 vídeos al mes de hasta 1 minuto, 1 avatar personalizado, más de 30 idiomas y 500+ avatares de stock.',
+    plans: [
+      {
+        name: 'Free',
+        price: '0 $/mes',
+        notes: 'Para probar: 3 vídeos/mes de máximo 1 minuto y 1 avatar personalizado.',
+      },
+      {
+        name: 'Creator',
+        price: '29 $/mes (24 $/mes anual)',
+        notes:
+          '600 créditos al mes, vídeos de hasta 30 min, exportación en 1080p, clonación de voz y 175+ idiomas.',
+      },
+      {
+        name: 'Pro',
+        price: '49 $/mes',
+        notes:
+          '1.000 créditos al mes, exportación 4K y acceso a modelos de IA avanzados; para creadores intensivos.',
+      },
+      {
+        name: 'Business',
+        price: '149 $/mes + 20 $ por asiento adicional',
+        notes:
+          '1.500 créditos al mes, vídeos de hasta 60 min, 5 avatares personalizados, colaboración en equipo e integraciones SCORM.',
+      },
+      {
+        name: 'Enterprise',
+        price: 'Contactar con ventas',
+        notes:
+          'Sin límite de duración de vídeo, funciones a medida, soporte prioritario y gestor dedicado.',
+      },
+    ],
+    notes:
+      'HeyGen funciona por créditos y el consumo depende del avatar usado (Avatar III cuesta 3 créditos/min y Avatar IV/V hasta 20 créditos/min), así que el coste real varía mucho según el tipo de vídeo. La facturación anual abarata el plan Creator.',
+    sourceUrl: 'https://www.heygen.com/pricing',
+  },
+  AskYourPDF: {
+    name: 'AskYourPDF',
+    model: 'freemium',
+    freeTier:
+      'Plan gratuito de 0 $/mes con 1 documento al día de hasta 100 páginas y 15 MB, 50 preguntas y 3 conversaciones diarias, con GPT-5 Mini.',
+    plans: [
+      {
+        name: 'Free',
+        price: '0 $/mes',
+        notes:
+          'Para probar: 1 documento diario de hasta 100 páginas, 50 preguntas y 3 conversaciones al día.',
+      },
+      {
+        name: 'Premium',
+        price: '11,99 $/mes',
+        notes:
+          'Facturación anual: hasta 2.500 páginas por documento, 50 documentos diarios, 10 créditos, extensión de Chrome, OCR y modelos como Claude 4.5 Sonnet y Opus mediante créditos.',
+      },
+      {
+        name: 'Pro',
+        price: '14,99 $/mes',
+        notes:
+          'Facturación anual: 6.000 páginas por documento, 150 documentos diarios, 100.000 preguntas al día, 30 créditos y soporte prioritario.',
+      },
+      {
+        name: 'Enterprise',
+        price: 'Presupuesto a medida',
+        notes:
+          'Páginas, preguntas y conversaciones ilimitadas, 1.000 documentos diarios y créditos personalizados.',
+      },
+    ],
+    notes:
+      'Los precios mostrados corresponden a la facturación anual, que aplica un 25 % de descuento frente al pago mensual. Los modelos más potentes (Claude Sonnet/Opus) consumen créditos aparte de la cuota.',
+    sourceUrl: 'https://askyourpdf.com/pricing',
+  },
+  'You.com': {
+    name: 'You.com',
+    model: 'freemium',
+    freeTier:
+      'Nivel gratuito de la Web Search API con 100 consultas al día sin clave de API, más 100 $ de crédito inicial para probar las APIs de pago.',
+    plans: [
+      {
+        name: 'Web Search API',
+        price: '5,00 $ por cada 1.000 llamadas',
+        notes:
+          'Búsqueda web y noticias en tiempo real con hasta 100 resultados por llamada, para dar contexto web a agentes y LLMs.',
+      },
+      {
+        name: 'Contents API',
+        price: '1,00 $ por cada 1.000 páginas',
+        notes: 'Extrae texto limpio, resúmenes y metadatos de varias URLs por petición.',
+      },
+      {
+        name: 'Answer API',
+        price: '5,00 $ por cada 1.000 llamadas',
+        notes: 'Devuelve una respuesta sintetizada con citas a partir de la búsqueda web.',
+      },
+      {
+        name: 'Research API',
+        price: '12,00 $ por cada 1.000 llamadas',
+        notes: 'Investigación multipaso con niveles Lite, Standard, Deep, Exhaustive y Frontier.',
+      },
+      {
+        name: 'Finance Research API',
+        price: '110,00 $ por cada 1.000 llamadas',
+        notes:
+          'Investigación financiera profunda sobre informes, macro y mercados, para flujos de trabajo financieros.',
+      },
+    ],
+    notes:
+      'El precio es por uso, con descuentos por volumen y ahorro adicional en contratos anuales. La página oficial de precios ya solo recoge las APIs para desarrolladores: no aparece ninguna suscripción de consumidor.',
+    sourceUrl: 'https://you.com/pricing',
+  },
+};

--- a/src/types/tool.ts
+++ b/src/types/tool.ts
@@ -31,6 +31,12 @@ export type SubcategoryContent = {
   body: string;
 };
 
+export type ComparisonSection = {
+  title: string;
+  paragraphs?: string[];
+  bullets?: string[];
+};
+
 export type Comparison = {
   slug: string;
   a: string;
@@ -41,5 +47,26 @@ export type Comparison = {
   table: { headers: string[]; rows: string[][] };
   whenA: string[];
   whenB: string[];
+  sections?: ComparisonSection[];
   faqs: ToolFaq[];
+};
+
+export type PricingPlan = {
+  name: string;
+  price: string;
+  notes?: string;
+};
+
+/**
+ * Precios verificados en la web oficial de la herramienta.
+ * Solo existen para las herramientas que hemos podido comprobar:
+ * el resto se queda con el pricingNote cualitativo de su ficha.
+ */
+export type ToolPricing = {
+  name: string;
+  model: 'free' | 'freemium' | 'paid' | 'open-source';
+  freeTier: string | null;
+  plans: PricingPlan[];
+  notes: string;
+  sourceUrl: string;
 };

--- a/src/utils/pricing.ts
+++ b/src/utils/pricing.ts
@@ -1,0 +1,8 @@
+import { PRICING_LAST_CHECKED, toolPricing } from '../data/tool-pricing';
+import type { ToolPricing } from '../types/tool';
+
+export { PRICING_LAST_CHECKED };
+
+export function getToolPricing(toolName: string): ToolPricing | undefined {
+  return toolPricing[toolName];
+}

--- a/src/utils/toolUtils.ts
+++ b/src/utils/toolUtils.ts
@@ -30,7 +30,7 @@ export const filterTools = (
   let filtered = tools;
   if (activeFilter === 'free') filtered = filtered.filter((t) => t.pricing === 'free');
   if (activeFilter === 'paid') filtered = filtered.filter((t) => t.pricing === 'paid');
-  
+
   const trimmedSearchTerm = searchTerm.trim();
   if (trimmedSearchTerm) {
     filtered = filtered.filter(
@@ -80,7 +80,7 @@ export const getFeaturedTools = (): AITool[] => {
     'Claude', // #2 - Anthropic, competidor directo de ChatGPT
     'Midjourney', // #3 - Líder en generación de imágenes
     'DALL·E', // #4 - OpenAI, pionero en generación de imágenes
-    'Sora', // #5 - OpenAI, líder en generación de video
+    'Runway', // #5 - Generación y edición de vídeo (sustituye a Sora, descatalogada)
     'Gemini', // #6 - Google, competidor principal
     'Stable Diffusion', // #7 - Open source, muy popular
     'ElevenLabs', // #8 - Líder en síntesis de voz y audio IA

--- a/src/utils/tools.ts
+++ b/src/utils/tools.ts
@@ -1,5 +1,6 @@
 import { aiCategories, AITool } from '../data/ai-tools';
 import { toolDetails } from '../data/tool-details';
+import { discontinuedTools } from '../data/discontinued';
 import type { ToolDetail } from '../types/tool';
 import { slugify } from './slugify';
 
@@ -54,7 +55,11 @@ export function getRelatedTools(tool: ToolWithContext, limit = 6): ToolWithConte
   return getAllTools()
     .filter(
       (t) =>
-        t.slug !== tool.slug && t.category === tool.category && t.subcategory === tool.subcategory,
+        t.slug !== tool.slug &&
+        t.category === tool.category &&
+        t.subcategory === tool.subcategory &&
+        // No recomendamos como alternativa algo que ha cerrado
+        !discontinuedTools[t.name],
     )
     .slice(0, limit);
 }


### PR DESCRIPTION
## Por qué

Search Console marcaba las páginas como **"rastreada: actualmente sin indexar"**: Google las leía y decidía que no aportaban nada nuevo. Al revisar el contenido salieron tres causas concretas:

1. Las fichas prometían "precios" en el `<title>` y no daban ni una cifra.
2. La frase *"Consulta su web para precios actualizados"* aparecía **literalmente 121 veces**: la huella típica de contenido de plantilla.
3. Las comparativas tenían ~420 palabras, frente a las 1.500+ de lo que rankea para "X vs Y".

## Precios reales

- Nueva tabla de precios **verificados en la web oficial** de cada herramienta: **53 herramientas, 219 planes**, todos con enlace a la fuente y fecha de consulta.
- Las que no publican tarifas (B2B, presupuesto a medida) se quedan con su texto cualitativo más un aviso honesto de que no hemos verificado cifras.
- La coletilla repetida desaparece de los datos y pasa a la plantilla, que es donde le corresponde. De 121 repeticiones de la misma frase a 0.

## Comparativas

5 secciones nuevas por comparativa (diferencias de fondo, calidad de resultados, estructuras de precio, comportamiento en español y uso combinado). **De 421 a 1.285 palabras de media.**

## Auditoría del catálogo

Buscar los precios destapó que el catálogo tenía datos obsoletos. Todo verificado contra las webs oficiales:

**Herramientas cerradas** — ahora con aviso en su ficha, sin bloque de precios y fuera de las recomendaciones:

| Herramienta | Cerró |
|---|---|
| Sora | abril de 2026 (era una de las 8 destacadas de la portada) |
| Phind | enero de 2026 |
| Play.ht | diciembre de 2025 |

**URLs corregidas**: LLaMA, Codium (→ Qodo), Cursor, Runway, y FLUX y Stable Diffusion, que apuntaban a webs de terceros en lugar de a las oficiales.

**`pricing` corregido en 15 herramientas**: Tabnine y Writesonic ya no tienen plan gratuito; GitHub Copilot, Synthesia y Colossyan sí lo tienen; Veo es de pago; etc.

**Comparativas de Codium reescritas**: describían Codeium, que es otro producto. Codium es CodiumAI (hoy Qodo), de generación de tests, no de autocompletado.

## Otros

La ficha ya muestra la captura de la herramienta, que quedaba tapada por el logo al resolver `tool.logo || tool.image`.

## Verificación

- Build: 392 páginas, sin errores
- `tsc --noEmit`: limpio
- Lint: 0 errores
- Tests: 270/270
- Comprobado en servidor local: aviso de cierre y sin bloque de precios en Sora/Phind/Play.ht, tabla de precios en ChatGPT, 10 encabezados H2 por comparativa (antes 5), y ninguna herramienta cerrada entre las destacadas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added verified pricing details, plans, free tiers, notes, and source links for tools.
  - Added availability notices and replacement links for discontinued tools.
  - Added optional paragraphs and bullet lists to comparison pages.
  - Added tool interface images and improved pricing displays.

- **Bug Fixes**
  - Discontinued tools no longer show visit buttons, pricing sections, or structured offers.
  - Related-tool results now exclude discontinued tools.
  - Updated tool links, pricing classifications, and featured recommendations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->