### PR TITLE
fix(seo): sacar las subcategorías del índice y del sitemap

### DIFF
--- a/src/app/categoria/[slug]/[subcategory]/page.tsx
+++ b/src/app/categoria/[slug]/[subcategory]/page.tsx
@@ -8,6 +8,7 @@ import { slugify, findCategoryBySlug } from '../../../../utils/slugify';
 import { getSiteUrl } from '../../../../utils/siteUrl';
 import { getSubcategoryContent } from '../../../../utils/categoryContent';
 import { getToolsBySubcategory } from '../../../../utils/tools';
+import { NOINDEX_ROBOTS } from '../../../../utils/publishing';
 
 type Props = {
   params: Promise<{ slug: string; subcategory: string }>;
@@ -67,6 +68,9 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   return {
     title,
     description,
+    // Las subcategorías son índices de enlaces con poco texto propio: se
+    // rastrean y se siguen sus enlaces, pero no compiten por entrar al índice.
+    robots: NOINDEX_ROBOTS,
     alternates: {
       canonical: `${baseUrl}/categoria/${slug}/${subcategorySlug}`,
     },

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -56,15 +56,8 @@ export default function sitemap(): MetadataRoute.Sitemap {
     priority: 0.85,
   }));
 
-  // Páginas de subcategorías (SEO optimizado)
-  const subcategoryPages: MetadataRoute.Sitemap = aiCategories.flatMap((category) =>
-    category.subcategories.map((subcategory) => ({
-      url: `${base}/categoria/${slugify(category.name)}/${slugify(subcategory.name)}`,
-      lastModified,
-      changeFrequency: 'monthly',
-      priority: 0.8,
-    })),
-  );
+  // Las subcategorías se quedan fuera del sitemap: van con noindex porque su
+  // texto propio es demasiado corto para sostener una página por sí solo.
 
   // Fichas de herramienta: solo las tandas ya publicadas (el resto va con noindex)
   const toolPages: MetadataRoute.Sitemap = getAllTools()
@@ -119,7 +112,6 @@ export default function sitemap(): MetadataRoute.Sitemap {
   return [
     ...mainPages,
     ...categoryPages,
-    ...subcategoryPages,
     ...toolPages,
     ...comparisonPages,
     ...articlePages,


### PR DESCRIPTION
## Diagnóstico

Search Console a 14/8/26: "Rastreada: actualmente sin indexar" baja de **48 a 32**, y ni una sola ficha ni comparativa aparece en la lista. Lo que sí aparece, una y otra vez, son páginas de categoría y subcategoría.

Medido sobre el contenido real (prosa propia, sin contar el payload de React):

| Tipo | Cuántas | Prosa propia | ¿Se indexan? |
|---|---|---|---|
| Fichas | 87 | ~360 palabras | **Sí, 100 %** |
| Categorías | 18 | ~341 palabras | A medias |
| **Subcategorías** | **59** | **~162 palabras** | **Casi ninguna** |

La clave no es la longitud: las fichas tienen prácticamente las mismas palabras que las categorías y sí entran. La diferencia es el contenido propio. Una ficha aporta precios con fuente y fecha, pros y contras, casos de uso, alternativas y FAQs. Una subcategoría aporta 162 palabras y una rejilla de enlaces, sin FAQs.

## Cambio

- Las 59 subcategorías pasan a `noindex, follow`. Se siguen rastreando y siguen pasando enlace a las fichas; solo dejan de competir por entrar al índice.
- Salen del sitemap: **232 → 173 URLs**.
- Las 18 categorías principales se quedan exactamente como estaban.

## Expectativa realista

Esto **no** libera presupuesto de rastreo de forma inmediata: Google sigue entrando en una página `noindex` para leer la etiqueta. El beneficio es sacar 59 páginas flojas de la valoración del índice y dejar el sitemap conteniendo solo lo que se quiere posicionar. Es una mejora de calidad de señal, modesta.

## Verificación

- `tsc --noEmit` limpio, ESLint sin avisos en los archivos tocados
- Build OK, 391 páginas, 270/270 tests
- Comprobado sobre el HTML generado: **59/59 subcategorías con `noindex, follow`**, **18/18 categorías con `index, follow`**, fichas publicadas sin tocar
- Sitemap: 18 categorías + 87 fichas + 52 comparativas + 9 artículos + institucionales = 173