### PR TITLE
fix(web): footer al final, home sin herramientas muertas y catálogo al día

### DIFF
--- a/src/app/api/send-welcome-email/route.ts
+++ b/src/app/api/send-welcome-email/route.ts
@@ -293,7 +293,7 @@ export async function POST(request: NextRequest) {
             <a href="${siteUrl}/unsubscribe?token=${unsubscribeToken}" style="color: #64748b; text-decoration: none;">Cancelar suscripción</a>
           </p>
                       <p style="margin: 16px 0 0; color: #64748b; font-size: 12px;">
-                        © 2024 AIFinder
+                        © ${new Date().getFullYear()} AIFinder
                       </p>
                     </td>
                   </tr>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -59,77 +59,81 @@ export default async function HomePage({
         dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
       />
 
-      <HomeContainer initialSearchTerm={q} initialCategory={sp.category || ''} />
+      {/* La sección SEO va como children: HomeContainer la renderiza en el HTML
+          del servidor (donde la app aún no se ha hidratado y Google la lee) y,
+          ya en cliente, las vistas la colocan justo antes del footer. */}
+      <HomeContainer initialSearchTerm={q} initialCategory={sp.category || ''}>
+        <section className="bg-black text-white border-t border-zinc-800">
+          <div className="max-w-5xl mx-auto px-4 py-12">
+            <h1 className="text-3xl md:text-4xl font-extrabold leading-tight mb-4">
+              Directorio de herramientas de IA en español
+            </h1>
+            <p className="text-zinc-300 leading-relaxed mb-4">
+              AIFinder reúne {toolCount} herramientas de inteligencia artificial organizadas por
+              categorías y subcategorías. Cada herramienta tiene su ficha con qué es, para qué
+              sirve, características, ventajas, inconvenientes, precios y alternativas, para que
+              puedas comparar sin dar vueltas por webs en inglés.
+            </p>
+            <p className="text-zinc-300 leading-relaxed mb-8">
+              Encontrarás IA para escribir y generar texto, crear imágenes y vídeo, clonar y
+              sintetizar voz, programar, automatizar tareas de negocio, estudiar o analizar datos.
+              Puedes filtrar por herramientas gratuitas y de pago, y explorar por categoría.
+            </p>
 
-      {/* Contenido servido desde el servidor: es el único HTML de la portada que
-          Google puede leer, porque HomeContainer sólo se renderiza en cliente. */}
-      <section className="bg-black text-white border-t border-zinc-800">
-        <div className="max-w-5xl mx-auto px-4 py-12">
-          <h1 className="text-3xl md:text-4xl font-extrabold leading-tight mb-4">
-            Directorio de herramientas de IA en español
-          </h1>
-          <p className="text-zinc-300 leading-relaxed mb-4">
-            AIFinder reúne {toolCount} herramientas de inteligencia artificial organizadas por
-            categorías y subcategorías. Cada herramienta tiene su ficha con qué es, para qué sirve,
-            características, ventajas, inconvenientes, precios y alternativas, para que puedas
-            comparar sin dar vueltas por webs en inglés.
-          </p>
-          <p className="text-zinc-300 leading-relaxed mb-8">
-            Encontrarás IA para escribir y generar texto, crear imágenes y vídeo, clonar y
-            sintetizar voz, programar, automatizar tareas de negocio, estudiar o analizar datos.
-            Puedes filtrar por herramientas gratuitas y de pago, y explorar por categoría.
-          </p>
+            <h2 className="text-2xl font-bold mb-4">Categorías de herramientas de IA</h2>
+            <ul className="grid grid-cols-2 md:grid-cols-3 gap-3 list-none p-0 mb-12">
+              {aiCategories.map((category) => {
+                const count = category.subcategories.reduce(
+                  (acc, sub) => acc + sub.tools.length,
+                  0,
+                );
+                return (
+                  <li key={category.name}>
+                    <Link
+                      href={`/categoria/${slugify(category.name)}`}
+                      className="block rounded-lg border border-zinc-800 bg-zinc-900/40 px-4 py-3 hover:border-zinc-600 transition-colors"
+                    >
+                      <span className="font-semibold">{category.name}</span>
+                      <span className="block text-zinc-500 text-sm">{count} herramientas</span>
+                    </Link>
+                  </li>
+                );
+              })}
+            </ul>
 
-          <h2 className="text-2xl font-bold mb-4">Categorías de herramientas de IA</h2>
-          <ul className="grid grid-cols-2 md:grid-cols-3 gap-3 list-none p-0 mb-12">
-            {aiCategories.map((category) => {
-              const count = category.subcategories.reduce((acc, sub) => acc + sub.tools.length, 0);
-              return (
-                <li key={category.name}>
+            <h2 className="text-2xl font-bold mb-4">Comparativas más buscadas</h2>
+            <ul className="grid grid-cols-1 md:grid-cols-2 gap-3 list-none p-0 mb-4">
+              {featuredComparisons.map((comparison) => (
+                <li key={comparison.slug}>
                   <Link
-                    href={`/categoria/${slugify(category.name)}`}
+                    href={`/comparativa/${comparison.slug}`}
                     className="block rounded-lg border border-zinc-800 bg-zinc-900/40 px-4 py-3 hover:border-zinc-600 transition-colors"
                   >
-                    <span className="font-semibold">{category.name}</span>
-                    <span className="block text-zinc-500 text-sm">{count} herramientas</span>
+                    <span className="font-semibold">
+                      {comparison.a} vs {comparison.b}
+                    </span>
                   </Link>
                 </li>
-              );
-            })}
-          </ul>
+              ))}
+            </ul>
+            <p className="text-zinc-500 text-sm mb-12">
+              <Link href="/comparativas" className="text-blue-400 hover:underline">
+                Ver las {comparisonCount} comparativas
+              </Link>
+            </p>
 
-          <h2 className="text-2xl font-bold mb-4">Comparativas más buscadas</h2>
-          <ul className="grid grid-cols-1 md:grid-cols-2 gap-3 list-none p-0 mb-4">
-            {featuredComparisons.map((comparison) => (
-              <li key={comparison.slug}>
-                <Link
-                  href={`/comparativa/${comparison.slug}`}
-                  className="block rounded-lg border border-zinc-800 bg-zinc-900/40 px-4 py-3 hover:border-zinc-600 transition-colors"
-                >
-                  <span className="font-semibold">
-                    {comparison.a} vs {comparison.b}
-                  </span>
-                </Link>
-              </li>
-            ))}
-          </ul>
-          <p className="text-zinc-500 text-sm mb-12">
-            <Link href="/comparativas" className="text-blue-400 hover:underline">
-              Ver las {comparisonCount} comparativas
-            </Link>
-          </p>
-
-          <h2 className="text-2xl font-bold mb-4">Preguntas frecuentes</h2>
-          <div className="space-y-4">
-            {homeFaqs.map((faq) => (
-              <div key={faq.question} className="rounded-xl border border-zinc-800 p-5">
-                <h3 className="font-bold mb-2">{faq.question}</h3>
-                <p className="text-zinc-300 leading-relaxed">{faq.answer}</p>
-              </div>
-            ))}
+            <h2 className="text-2xl font-bold mb-4">Preguntas frecuentes</h2>
+            <div className="space-y-4">
+              {homeFaqs.map((faq) => (
+                <div key={faq.question} className="rounded-xl border border-zinc-800 p-5">
+                  <h3 className="font-bold mb-2">{faq.question}</h3>
+                  <p className="text-zinc-300 leading-relaxed">{faq.answer}</p>
+                </div>
+              ))}
+            </div>
           </div>
-        </div>
-      </section>
+        </section>
+      </HomeContainer>
     </>
   );
 }

--- a/src/app/terminos/page.tsx
+++ b/src/app/terminos/page.tsx
@@ -33,10 +33,10 @@ export default function TermsAndConditionsPage() {
             <section>
               <h2 className="text-2xl font-bold mb-3">1. Aviso de copyright</h2>
               <p className="text-zinc-300">
-                Copyright © 2025, AIFinder. Todos los derechos reservados. Las herramientas y
-                recursos mencionados en AIFinder son propiedad de sus respectivas entidades. El
-                contenido publicado en este sitio (textos, gráficos, logotipos e imágenes) se ofrece
-                con fines meramente informativos.
+                Copyright © {new Date().getFullYear()}, AIFinder. Todos los derechos reservados.
+                Las herramientas y recursos mencionados en AIFinder son propiedad de sus respectivas
+                entidades. El contenido publicado en este sitio (textos, gráficos, logotipos e
+                imágenes) se ofrece con fines meramente informativos.
               </p>
             </section>
 

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -99,6 +99,7 @@ export default function Footer({
     'Marketing',
     'Traducción',
     'Ética',
+    'Conocimiento',
   ];
 
   // Mapeo de nombres del footer a nombres reales de categorías
@@ -116,10 +117,11 @@ export default function Footer({
     Multimodal: 'Multimodal',
     OpenSource: 'OpenSource',
     Cognitiva: 'IA Cognitiva y Razonamiento',
-    MLOps: 'MLOps y Desarrollo de Modelos',
-    Marketing: 'IA para Marketing y Ventas',
+    MLOps: 'Desarrollo de Modelos',
+    Marketing: 'Marketing y Ventas',
     Traducción: 'Traducción y Localización Automática',
     Ética: 'Ética y Detección de IA',
+    Conocimiento: 'Gestión del Conocimiento',
   };
 
   const handleCategoryClick = (categoryName: string) => {
@@ -163,10 +165,8 @@ export default function Footer({
   };
 
   const tools = [
-    { label: 'Comparador de IAs', onClick: () => navigateToTools() },
-    { label: 'Calculadora de costos', onClick: () => navigateToTools() },
-    { label: 'Generador de prompts', onClick: () => navigateToTools() },
-    { label: 'Evaluador de calidad', onClick: () => navigateToTools() },
+    { label: 'Todas las herramientas', onClick: () => navigateToTools() },
+    { label: 'Comparador de IAs', onClick: () => navigateToTools('/comparativas') },
   ];
 
   const openFeedback = () => {
@@ -207,7 +207,7 @@ export default function Footer({
     { label: 'Contactar', href: 'mailto:navarrojavi107@gmail.com' },
   ];
 
-  const navigateToTools = () => {
+  const navigateToTools = (destino = '/herramientas') => {
     // Cerrar overlays
     if (setShowAddAITool) setShowAddAITool(false);
     contextSetShowFeedback(false);
@@ -215,9 +215,8 @@ export default function Footer({
     // Limpiar selección de categorías
     setActiveCategory && setActiveCategory(null);
     setActiveSubcategory && setActiveSubcategory(null);
-    // Ir a Herramientas
     try {
-      router.push('/herramientas');
+      router.push(destino);
     } catch {}
   };
 
@@ -519,7 +518,7 @@ export default function Footer({
         <div className="max-w-7xl mx-auto px-4 pt-1.5 pb-8 md:pb-4">
           {/* Mobile */}
           <div className="md:hidden text-left space-y-2 mb-6">
-            <div className="text-zinc-400 text-sm">© 2026 AIFinder</div>
+            <div className="text-zinc-400 text-sm">© {new Date().getFullYear()} AIFinder</div>
             <div className="space-y-1">
               {legalLinks.map((link) => (
                 <Link
@@ -555,7 +554,7 @@ export default function Footer({
           {/* Desktop */}
           <div className="hidden md:flex flex-col md:flex-row justify-between items-center relative">
             <div className="flex items-center mb-4 md:mb-0">
-              <span className="text-zinc-400 text-sm">© 2026 AIFinder</span>
+              <span className="text-zinc-400 text-sm">© {new Date().getFullYear()} AIFinder</span>
             </div>
             <div className="flex items-center space-x-4">
               {legalLinks.map((link) => (

--- a/src/components/Footer/__tests__/Footer.test.tsx
+++ b/src/components/Footer/__tests__/Footer.test.tsx
@@ -76,10 +76,8 @@ describe('Footer', () => {
   it('should render tools section', () => {
     renderWithProvider(React.createElement(Footer, defaultProps));
 
+    expect(screen.getAllByText('Todas las herramientas')).toHaveLength(2);
     expect(screen.getAllByText('Comparador de IAs')).toHaveLength(2);
-    expect(screen.getAllByText('Calculadora de costos')).toHaveLength(2);
-    expect(screen.getAllByText('Generador de prompts')).toHaveLength(2);
-    expect(screen.getAllByText('Evaluador de calidad')).toHaveLength(2);
   });
 
   it('should render connect section', () => {

--- a/src/components/Sections/AIAudioSection.tsx
+++ b/src/components/Sections/AIAudioSection.tsx
@@ -18,7 +18,7 @@ export default function AIAudioSection({ onViewAll }: AIAudioSectionProps) {
       description: 'Generación de música IA',
       image: '/images/suno-web.webp',
       logo: '/logos/suno-movil.png',
-      url: 'https://suno.ai',
+      url: 'https://suno.com',
     },
     {
       name: 'ElevenLabs',

--- a/src/components/Sections/AIRecommendationsSection.tsx
+++ b/src/components/Sections/AIRecommendationsSection.tsx
@@ -16,7 +16,7 @@ export default function AIRecommendationsSection({
       description: 'Editor de código IA',
       image: '/images/cursor-web.webp',
       logo: '/logos/cursor-movil.png',
-      url: 'https://cursor.sh',
+      url: 'https://cursor.com',
       isNew: true,
     },
     {
@@ -72,7 +72,7 @@ export default function AIRecommendationsSection({
       description: 'Gestión de tareas',
       image: '/images/clickup-web.webp',
       logo: '/logos/clickup-movil.jpeg',
-      url: 'https://clickup.com',
+      url: 'https://clickup.com/brain',
       isNew: true,
     },
   ];

--- a/src/components/Sections/AITestingMedicalSection.tsx
+++ b/src/components/Sections/AITestingMedicalSection.tsx
@@ -17,7 +17,7 @@ export default function AITestingMedicalSection({
       name: 'Codium',
       logo: '/logos/codium-movil.png',
       description: 'Testing IA',
-      url: 'https://www.codium.ai',
+      url: 'https://www.qodo.ai',
     },
     {
       name: 'Testim',

--- a/src/components/Sections/AITextImageSection.tsx
+++ b/src/components/Sections/AITextImageSection.tsx
@@ -17,7 +17,7 @@ export default function AITextImageSection({
       name: 'Qwen',
       logo: '/logos/qwen-movil.webp',
       description: 'Modelo de texto',
-      url: 'https://qwenlm.github.io',
+      url: 'https://qwen.ai',
     },
     {
       name: 'Mistral',
@@ -62,7 +62,7 @@ export default function AITextImageSection({
       name: 'FLUX',
       logo: '/logos/flux-movil.png',
       description: 'Arte generativo',
-      url: 'https://flux1.ai/es',
+      url: 'https://bfl.ai',
     },
     {
       name: 'Ideogram',

--- a/src/components/Sections/NewestAdditionsSection.tsx
+++ b/src/components/Sections/NewestAdditionsSection.tsx
@@ -4,93 +4,36 @@ import React from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
 import { slugify } from '../../utils/slugify';
+import { aiCategories, AITool } from '../../data/ai-tools';
+import { discontinuedTools } from '../../data/discontinued';
 
-// Obtener las 10 herramientas más recientes (puedes modificar esta lógica)
+// Las últimas incorporaciones reales: fichas de la tanda publicada más
+// reciente. Solo se fijan los nombres; los datos (logo, descripción, URL)
+// salen del catálogo para que no vuelvan a divergir de él.
+const NEWEST_NAMES = [
+  'DeepSeek',
+  'Suno',
+  'Descript',
+  'Kling',
+  'Google Flow',
+  'Leonardo AI',
+  'Speechify',
+  'Recraft',
+];
+
 const getNewestTools = () => {
-  const newestTools = [
-    {
-      name: 'ChatGPT',
-      description: 'Asistente IA conversacional',
-      image: '/images/chatpgt-web.webp',
-      logo: '/logos/chatgpt-movil.png',
-      url: 'https://chatgpt.com',
-      pricing: 'freemium' as const,
-    },
-    {
-      name: 'Claude',
-      description: 'IA avanzada para conversación',
-      image: '/images/claude-web.webp',
-      logo: '/logos/claude-movil.png',
-      url: 'https://claude.ai',
-      pricing: 'freemium' as const,
-    },
-    {
-      name: 'Midjourney',
-      description: 'Generación de imágenes IA',
-      image: '/images/midjourney-web.webp',
-      logo: '/logos/midjourney-movil.png',
-      url: 'https://midjourney.com',
-      pricing: 'paid' as const,
-    },
-    {
-      name: 'GitHub Copilot',
-      description: 'Asistente de código IA',
-      image: '/images/githubcopilot-web.webp',
-      logo: '/logos/githubcopilto-movil.png',
-      url: 'https://github.com/features/copilot',
-      pricing: 'paid' as const,
-    },
-    {
-      name: 'Perplexity',
-      description: 'Buscador con IA',
-      image: '/images/perplexity-web.webp',
-      logo: '/logos/perplexity-movil.png',
-      url: 'https://perplexity.ai',
-      pricing: 'freemium' as const,
-    },
-    {
-      name: 'Cursor',
-      description: 'Editor de código IA',
-      image: '/images/cursor-web.webp',
-      logo: '/logos/cursor-movil.png',
-      url: 'https://cursor.sh',
-      pricing: 'freemium' as const,
-    },
-    {
-      name: 'Notion',
-      description: 'Workspace inteligente',
-      image: '/images/notion-web.webp',
-      logo: '/logos/notion-movil.jpg',
-      url: 'https://notion.so',
-      pricing: 'freemium' as const,
-    },
-    {
-      name: 'Gamma',
-      description: 'Presentaciones con IA',
-      image: '/images/gamma-web.webp',
-      logo: '/logos/gamma-movil.jpeg',
-      url: 'https://gamma.app',
-      pricing: 'freemium' as const,
-    },
-    {
-      name: 'Runway',
-      description: 'Video generativo IA',
-      image: '/images/runway-web.webp',
-      logo: '/logos/runway-movil.webp',
-      url: 'https://runwayml.com',
-      pricing: 'freemium' as const,
-    },
-    {
-      name: 'Jasper',
-      description: 'Escritura con IA',
-      image: '/images/jasper-web.webp',
-      logo: '/logos/jasper-movil.png',
-      url: 'https://jasper.ai',
-      pricing: 'paid' as const,
-    },
-  ];
-
-  return newestTools;
+  const byName = new Map<string, AITool>();
+  for (const category of aiCategories) {
+    for (const subcategory of category.subcategories) {
+      for (const tool of subcategory.tools) {
+        if (!byName.has(tool.name)) byName.set(tool.name, tool);
+      }
+    }
+  }
+  return NEWEST_NAMES.map((name) => byName.get(name)).filter(
+    (tool): tool is AITool & { logo: string } =>
+      Boolean(tool && tool.logo && !discontinuedTools[tool.name]),
+  );
 };
 
 export default function NewestAdditionsSection() {

--- a/src/components/Sections/SpotlightSection.tsx
+++ b/src/components/Sections/SpotlightSection.tsx
@@ -10,13 +10,13 @@ interface SpotlightSectionProps {
 export default function SpotlightSection({ onViewAll }: SpotlightSectionProps) {
   const videoTools = [
     {
-      name: 'Sora',
-      image: '/images/sora-web.webp',
-      logo: '/logos/sora-movil.png',
+      name: 'Kling',
+      image: '/images/kling-web.webp',
+      logo: '/logos/fling-movil.png',
       description: 'Video generativo',
       category: 'Generación de Video',
-      url: 'https://openai.com/sora',
-      pricing: 'Gratis',
+      url: 'https://kling.ai',
+      pricing: 'Freemium',
     },
     {
       name: 'Veo',
@@ -33,7 +33,7 @@ export default function SpotlightSection({ onViewAll }: SpotlightSectionProps) {
       logo: '/logos/runway-movil.webp',
       description: 'Edición de video',
       category: 'Edición de Video',
-      url: 'https://runwayml.com',
+      url: 'https://runway.com',
       pricing: 'Freemium',
     },
     {

--- a/src/components/views/HomeContainer.tsx
+++ b/src/components/views/HomeContainer.tsx
@@ -31,12 +31,15 @@ type HomeContainerProps = {
   initialSearchTerm?: string;
   initialCategory?: string;
   initialSubcategory?: string;
+  /** Contenido renderizado en servidor (SEO) que se coloca antes del footer. */
+  children?: React.ReactNode;
 };
 
 export default function HomeContainer({
   initialSearchTerm = '',
   initialCategory = '',
   initialSubcategory = '',
+  children,
 }: HomeContainerProps) {
   const { activeCategory, setActiveCategory } = useAppContextFromProviders();
   const { activeSubcategory, setActiveSubcategory } = useSubcategoryContextFromProviders();
@@ -219,10 +222,15 @@ export default function HomeContainer({
   }, [activeSubcategory]);
 
   if (!isClient) {
+    // El contenido SEO se renderiza también aquí: es lo que Google lee en el
+    // HTML del servidor, donde la app todavía no se ha hidratado.
     return (
-      <div className="min-h-screen bg-black flex items-center justify-center">
-        <div className="text-white">Cargando...</div>
-      </div>
+      <>
+        <div className="min-h-screen bg-black flex items-center justify-center">
+          <div className="text-white">Cargando...</div>
+        </div>
+        {children}
+      </>
     );
   }
 
@@ -307,7 +315,9 @@ export default function HomeContainer({
           navigateToSubcategory={navigateToSubcategory}
           onSetShowFeedback={setShowFeedback}
           onSetShowBugReport={setShowBugReport}
-        />
+        >
+          {children}
+        </ExploreView>
       </>
     );
   }
@@ -335,6 +345,8 @@ export default function HomeContainer({
       onSubcategoryClick={handleSubcategoryClick}
       onSetShowFeedback={setShowFeedback}
       onSetShowBugReport={setShowBugReport}
-    />
+    >
+      {children}
+    </CategoryView>
   );
 }

--- a/src/components/views/home/CategoryView.tsx
+++ b/src/components/views/home/CategoryView.tsx
@@ -40,6 +40,7 @@ type CategoryViewProps = {
   onSubcategoryClick: (name: string) => void;
   onSetShowFeedback: (v: boolean) => void;
   onSetShowBugReport: (v: boolean) => void;
+  children?: React.ReactNode;
 };
 
 export default function CategoryView({
@@ -64,6 +65,7 @@ export default function CategoryView({
   onSubcategoryClick,
   onSetShowFeedback,
   onSetShowBugReport,
+  children,
 }: CategoryViewProps) {
   return (
     <div className="min-h-screen bg-black">
@@ -99,6 +101,7 @@ export default function CategoryView({
         activeFilter={activeFilter}
         searchTerm={searchTerm}
       />
+      {children}
       <Footer
         setShowFeedback={onSetShowFeedback}
         setShowBugReport={onSetShowBugReport}

--- a/src/components/views/home/ExploreView.tsx
+++ b/src/components/views/home/ExploreView.tsx
@@ -95,6 +95,7 @@ type ExploreViewProps = {
   navigateToSubcategory: (name: string) => void;
   onSetShowFeedback: (v: boolean) => void;
   onSetShowBugReport: (v: boolean) => void;
+  children?: React.ReactNode;
 };
 
 export default function ExploreView({
@@ -122,6 +123,7 @@ export default function ExploreView({
   navigateToSubcategory,
   onSetShowFeedback,
   onSetShowBugReport,
+  children,
 }: ExploreViewProps) {
   return (
     <div className="min-h-screen bg-black">
@@ -319,6 +321,7 @@ export default function ExploreView({
                   }, 100);
                 }}
               />
+              {children}
               <Footer
                 setShowFeedback={onSetShowFeedback}
                 setShowBugReport={onSetShowBugReport}

--- a/src/data/ai-categories.ts
+++ b/src/data/ai-categories.ts
@@ -275,7 +275,7 @@ export const aiCategories = [
     subcategories: [
       {
         name: 'Memoria a largo plazo / contexto extenso',
-        tools: ['MemGPT', 'LTM Agents', 'LongChat'],
+        tools: ['Letta', 'LTM Agents', 'LongChat'],
       },
       {
         name: 'Razonamiento estructurado',
@@ -343,7 +343,7 @@ export const aiCategories = [
     id: 18,
     name: 'Gestión del Conocimiento',
     subcategories: [
-      { name: 'Document QA / RAG', tools: ['ChatPDF', 'AskYourPDF', 'Glean', 'Klu', 'Danswer'] },
+      { name: 'Document QA / RAG', tools: ['ChatPDF', 'AskYourPDF', 'Glean', 'Klu', 'Onyx'] },
       { name: 'Buscadores inteligentes', tools: ['Perplexity', 'You.com', 'Phind'] },
     ],
   },

--- a/src/data/ai-tools.ts
+++ b/src/data/ai-tools.ts
@@ -30,7 +30,7 @@ export const aiCategories: AICategory[] = [
             image: '/images/chatpgt-web.webp',
             description: 'Generador de texto',
             pricing: 'freemium',
-            url: 'https://chat.openai.com',
+            url: 'https://chatgpt.com',
           },
           {
             name: 'Claude',
@@ -280,7 +280,6 @@ export const aiCategories: AICategory[] = [
             image: '/images/play.ht-web.webp',
             description: 'Texto a voz',
             pricing: 'freemium',
-            url: 'https://play.ht',
           },
           {
             name: 'Speechify',
@@ -522,7 +521,7 @@ export const aiCategories: AICategory[] = [
             image: '/images/deepsource-web.webp',
             description: 'Análisis estático',
             pricing: 'freemium',
-            url: 'https://deepsource.io',
+            url: 'https://deepsource.com',
           },
           {
             name: 'LangChain',
@@ -548,7 +547,7 @@ export const aiCategories: AICategory[] = [
             image: '/images/chatpgt-web.webp',
             description: 'Asistente personal',
             pricing: 'freemium',
-            url: 'https://chat.openai.com',
+            url: 'https://chatgpt.com',
           },
           {
             name: 'Gemini',
@@ -665,7 +664,7 @@ export const aiCategories: AICategory[] = [
             image: '/images/einstein-web.webp',
             description: 'Chatbot empresarial',
             pricing: 'paid',
-            url: 'https://www.salesforce.com/products/einstein/',
+            url: 'https://www.salesforce.com/artificial-intelligence/',
           },
           {
             name: 'ChatSpot',
@@ -673,7 +672,7 @@ export const aiCategories: AICategory[] = [
             image: '/images/chatspot-web.webp',
             description: 'Chatbot empresarial',
             pricing: 'freemium',
-            url: 'https://chatspot.ai',
+            url: 'https://www.hubspot.com/products/artificial-intelligence/breeze-ai-assistant',
           },
           {
             name: 'Zendesk',
@@ -726,7 +725,7 @@ export const aiCategories: AICategory[] = [
             image: '/images/metapgt-web.webp',
             description: 'Agente autónomo',
             pricing: 'free',
-            url: 'https://www.deepwisdom.ai',
+            url: 'https://github.com/FoundationAgents/MetaGPT',
           },
           {
             name: 'ChatGPT Agents',
@@ -758,7 +757,7 @@ export const aiCategories: AICategory[] = [
             image: '/images/xaiagents-web.webp',
             description: 'Agente autónomo',
             pricing: 'freemium',
-            url: 'https://xaiagent.io/es/home/',
+            url: 'https://xaiagent.io',
           },
         ],
       },
@@ -816,7 +815,7 @@ export const aiCategories: AICategory[] = [
             image: '/images/manus.webp',
             description: 'Automatización',
             pricing: 'freemium',
-            url: 'https://manus.ai',
+            url: 'https://manus.im',
           },
           {
             name: 'Trigger.dev',
@@ -1004,7 +1003,7 @@ export const aiCategories: AICategory[] = [
             image: '/images/spellbook-web.webp',
             description: 'IA legal',
             pricing: 'paid',
-            url: 'https://www.spellbook.legal',
+            url: 'https://www.spellbook.com',
           },
           {
             name: 'Evisort',
@@ -1012,7 +1011,7 @@ export const aiCategories: AICategory[] = [
             image: '/images/evisort-web.webp',
             description: 'IA legal',
             pricing: 'paid',
-            url: 'https://www.evisort.com',
+            url: 'https://www.workday.com',
           },
           {
             name: 'LawGeex',
@@ -1020,7 +1019,7 @@ export const aiCategories: AICategory[] = [
             image: '/images/lawgeex-web.webp',
             description: 'IA legal',
             pricing: 'paid',
-            url: 'https://www.lawgeex.com',
+            url: 'https://www.superlegal.ai',
           },
         ],
       },
@@ -1136,7 +1135,7 @@ export const aiCategories: AICategory[] = [
             image: '/images/deepsource-web.webp',
             description: 'Análisis estático',
             pricing: 'freemium',
-            url: 'https://deepsource.io',
+            url: 'https://deepsource.com',
           },
           {
             name: 'SonarQube',
@@ -1144,7 +1143,7 @@ export const aiCategories: AICategory[] = [
             image: '/images/sonarqube-web.webp',
             description: 'Análisis estático',
             pricing: 'freemium',
-            url: 'https://www.sonarqube.org',
+            url: 'https://www.sonarsource.com',
           },
           {
             name: 'CodeClimate',
@@ -1202,7 +1201,7 @@ export const aiCategories: AICategory[] = [
             image: '/images/zebra-web.webp',
             description: 'Diagnóstico IA',
             pricing: 'paid',
-            url: 'http://www.zebra-med.com',
+            url: 'https://www.nanox.vision',
           },
           {
             name: 'Lunit',
@@ -1239,7 +1238,7 @@ export const aiCategories: AICategory[] = [
             image: '/images/zebra-web.webp',
             description: 'Imágenes médicas',
             pricing: 'paid',
-            url: 'http://www.zebra-med.com',
+            url: 'https://www.nanox.vision',
           },
           {
             name: 'Lunit',
@@ -1292,7 +1291,7 @@ export const aiCategories: AICategory[] = [
             image: '/images/your.md-web.webp',
             description: 'Triage IA',
             pricing: 'free',
-            url: 'https://your.md',
+            url: 'https://www.livehealthily.com',
           },
         ],
       },
@@ -1321,7 +1320,7 @@ export const aiCategories: AICategory[] = [
             image: '/images/alphamissense-web.webp',
             description: 'Investigación biomédica',
             pricing: 'free',
-            url: 'https://alphamissense.depthmind.com',
+            url: 'https://github.com/google-deepmind/alphamissense',
           },
           {
             name: 'BenevolentAI',
@@ -1363,7 +1362,7 @@ export const aiCategories: AICategory[] = [
             image: '/images/scribe-web.webp',
             description: 'Tutor virtual',
             pricing: 'freemium',
-            url: 'https://scribehow.com/scribe-ai',
+            url: 'https://scribe.com/scribe-ai',
           },
           {
             name: 'MagicSchool AI',
@@ -1442,7 +1441,7 @@ export const aiCategories: AICategory[] = [
             image: '/images/teachmate-web.webp',
             description: 'Asistente docentes',
             pricing: 'freemium',
-            url: 'https://teachmateai.com',
+            url: 'https://www.teachmate.com',
           },
           {
             name: 'Diffit',
@@ -1484,7 +1483,7 @@ export const aiCategories: AICategory[] = [
             image: '/images/numerai-web.webp',
             description: 'Análisis bursátil',
             pricing: 'free',
-            url: 'https://numerai.com',
+            url: 'https://numer.ai',
           },
           {
             name: 'EquBot',
@@ -1671,7 +1670,7 @@ export const aiCategories: AICategory[] = [
             image: '/images/hatchful-web.webp',
             description: 'Branding y logos',
             pricing: 'free',
-            url: 'https://hatchful.shopify.com',
+            url: 'https://www.shopify.com/tools/logo-maker',
           },
         ],
       },
@@ -1684,7 +1683,7 @@ export const aiCategories: AICategory[] = [
             image: '/images/durable-web.webp',
             description: 'Diseño web',
             pricing: 'freemium',
-            url: 'https://durable.co',
+            url: 'https://durable.com',
           },
           {
             name: 'Wix ADI',
@@ -1734,7 +1733,7 @@ export const aiCategories: AICategory[] = [
             image: '/images/cylance-web.webp',
             description: 'Detección amenazas',
             pricing: 'paid',
-            url: 'https://www.cylance.com',
+            url: 'https://arcticwolf.com/cylance',
           },
         ],
       },
@@ -1810,7 +1809,7 @@ export const aiCategories: AICategory[] = [
             image: '/images/predix-web.webp',
             description: 'Automatización industrial',
             pricing: 'paid',
-            url: 'https://www.ge.com/digital/predix',
+            url: 'https://www.gevernova.com/software',
           },
           {
             name: 'Uptake',
@@ -1923,7 +1922,7 @@ export const aiCategories: AICategory[] = [
             image: '/images/chatpgt-web.webp',
             description: 'IA multimodal',
             pricing: 'freemium',
-            url: 'https://chat.openai.com',
+            url: 'https://chatgpt.com',
           },
           {
             name: 'Gemini',
@@ -2089,12 +2088,12 @@ export const aiCategories: AICategory[] = [
         name: 'Memoria a largo plazo',
         tools: [
           {
-            name: 'MemGPT',
+            name: 'Letta',
             logo: '/logos/mempgt-movil.jpeg',
             image: '/images/memgpt-web.webp',
             description: 'Memoria IA',
             pricing: 'free',
-            url: 'https://memgpt.ai',
+            url: 'https://www.letta.com',
           },
           {
             name: 'MemO',
@@ -2363,7 +2362,7 @@ export const aiCategories: AICategory[] = [
             image: '/images/salesforce-web.webp',
             description: 'CRM IA',
             pricing: 'paid',
-            url: 'https://www.salesforce.com/products/einstein/',
+            url: 'https://www.salesforce.com/artificial-intelligence/',
           },
           {
             name: 'ChatSpot',
@@ -2371,7 +2370,7 @@ export const aiCategories: AICategory[] = [
             image: '/images/chatspot-web.webp',
             description: 'CRM IA',
             pricing: 'freemium',
-            url: 'https://chatspot.ai',
+            url: 'https://www.hubspot.com/products/artificial-intelligence/breeze-ai-assistant',
           },
         ],
       },
@@ -2587,12 +2586,12 @@ export const aiCategories: AICategory[] = [
             url: 'https://klu.ai',
           },
           {
-            name: 'Danswer',
+            name: 'Onyx',
             logo: '/logos/danswer-movil.jpg',
             image: '/images/danswer-web.webp',
             description: 'QA documentos',
             pricing: 'free',
-            url: 'https://danswer.ai',
+            url: 'https://onyx.app',
           },
         ],
       },

--- a/src/data/articles.ts
+++ b/src/data/articles.ts
@@ -24,7 +24,7 @@ const allArticles: Article[] = [
     author: 'Peter Yang',
     authorImage: '/images/articulo1autor.webp',
     url: 'https://creatoreconomy.so/p/chatgpt-vs-claude-vs-gemini-the-best-ai-model-for-each-use-case-2025',
-    featured: true,
+    featured: false,
     featuredOrder: 2,
     contentSections: [
       {
@@ -166,7 +166,7 @@ const allArticles: Article[] = [
     readTime: '9 min',
     author: 'Jose Montes',
     authorImage: '/images/articulo2autor.webp',
-    featured: true,
+    featured: false,
     featuredOrder: 1,
     contentSections: [
       // Bloque de texto entre la imagen principal (articulo2) y la imagen articulo2.1
@@ -246,7 +246,7 @@ const allArticles: Article[] = [
     readTime: '4 min',
     author: 'Redacción KeepCoding',
     authorImage: '/images/articulo3autor.webp',
-    featured: true,
+    featured: false,
     featuredOrder: 3,
     contentSections: [
       {
@@ -412,7 +412,7 @@ const allArticles: Article[] = [
     readTime: '4 min',
     author: 'Antonio Cáceres Flores',
     authorImage: '/images/articulo3autor.webp',
-    featured: true,
+    featured: false,
     featuredOrder: 4,
     contentSections: [
       {
@@ -575,7 +575,7 @@ const allArticles: Article[] = [
     readTime: '8 min',
     author: 'Keumars Afifi-Sabet',
     authorImage: '/images/articulo5autor.webp',
-    featured: true,
+    featured: false,
     featuredOrder: 5,
     contentSections: [
       {
@@ -671,6 +671,8 @@ const allArticles: Article[] = [
     category: 'tips',
     categoryLabel: 'Consejos',
     date: '10 Jul 2026',
+    featured: true,
+    featuredOrder: 1,
     readTime: '9 min',
     author: 'AIFinder',
     contentSections: [
@@ -701,7 +703,7 @@ const allArticles: Article[] = [
         title: 'Búsqueda con fuentes: cuando necesitas citas, no prosa',
         paragraphs: [
           'Un chatbot generalista responde de memoria y a veces se equivoce con aplomo. Para preguntas que dependen de datos actuales, es mejor una IA de búsqueda, que localiza páginas, las lee y responde citando de dónde ha sacado cada cosa.',
-          'Perplexity tiene una capa gratuita perfectamente utilizable para consultas diarias, y reserva para el plan de pago las búsquedas más profundas y los modelos más caros. You.com funciona con una lógica parecida. Y para preguntas técnicas, Phind está orientado específicamente a programación, con respuestas acompañadas de fuentes y fragmentos de código.',
+          'Perplexity tiene una capa gratuita perfectamente utilizable para consultas diarias, y reserva para el plan de pago las búsquedas más profundas y los modelos más caros. You.com funciona con una lógica parecida, y para preguntas técnicas de programación ambos responden con fuentes y fragmentos de código.',
           'La ventaja real de estas herramientas no es que sean más listas, sino que te dan enlaces. Puedes comprobar. Cuando una respuesta va a acabar en un trabajo, un informe o una decisión, esa trazabilidad vale más que un párrafo bonito.',
         ],
       },
@@ -826,6 +828,8 @@ const allArticles: Article[] = [
     category: 'comparisons',
     categoryLabel: 'Comparaciones',
     date: '08 Jul 2026',
+    featured: true,
+    featuredOrder: 2,
     readTime: '10 min',
     author: 'AIFinder',
     contentSections: [
@@ -1001,6 +1005,8 @@ const allArticles: Article[] = [
     category: 'comparisons',
     categoryLabel: 'Comparaciones',
     date: '06 Jul 2026',
+    featured: true,
+    featuredOrder: 3,
     readTime: '10 min',
     author: 'AIFinder',
     contentSections: [
@@ -1148,6 +1154,8 @@ const allArticles: Article[] = [
     category: 'tips',
     categoryLabel: 'Consejos',
     date: '03 Jul 2026',
+    featured: true,
+    featuredOrder: 4,
     readTime: '9 min',
     author: 'AIFinder',
     contentSections: [

--- a/src/data/category-content.ts
+++ b/src/data/category-content.ts
@@ -297,7 +297,7 @@ export const categoryContent: CategoryContent[] = [
     cat: 'IA Cognitiva y Razonamiento',
     title: 'IA cognitiva: memoria, razonamiento y agentes avanzados',
     intro:
-      'Un modelo de lenguaje, por defecto, no recuerda nada de una sesión a otra y responde de forma directa aunque el problema requiera varios pasos. Esta categoría reúne las técnicas y herramientas que atacan esas dos limitaciones: sistemas de memoria persistente como MemGPT, MemO o Zep AI, que dan continuidad entre conversaciones; métodos de razonamiento estructurado como Tree-of-Thought, DSPy o GraphGPT, que fuerzan al modelo a descomponer el problema; y frameworks de agentes cognitivos como AutoGen, CrewAI o LangGraph.',
+      'Un modelo de lenguaje, por defecto, no recuerda nada de una sesión a otra y responde de forma directa aunque el problema requiera varios pasos. Esta categoría reúne las técnicas y herramientas que atacan esas dos limitaciones: sistemas de memoria persistente como Letta (antes MemGPT), MemO o Zep AI, que dan continuidad entre conversaciones; métodos de razonamiento estructurado como Tree-of-Thought, DSPy o GraphGPT, que fuerzan al modelo a descomponer el problema; y frameworks de agentes cognitivos como AutoGen, CrewAI o LangGraph.',
     body: 'Es la parte menos madura del ecosistema y conviene entrar con expectativas ajustadas. Si lo que necesitas es que un asistente recuerde preferencias entre sesiones, una capa de memoria bien diseñada aporta mucho con poco. Si lo que buscas es un sistema multiagente que se coordine solo, prepárate para depurar comportamientos difíciles de reproducir. Elige el framework por su capacidad de trazar y controlar el flujo de ejecución: sin observabilidad, cuando algo falla no sabrás por qué.',
     faqs: [
       {
@@ -417,7 +417,7 @@ export const categoryContent: CategoryContent[] = [
     cat: 'Gestión del Conocimiento',
     title: 'IA para buscar y consultar tus documentos',
     intro:
-      'El problema no suele ser que falte información, sino que está repartida entre cientos de PDF, wikis, correos y unidades compartidas donde nadie la encuentra. Esta categoría agrupa las herramientas que resuelven eso: por un lado, las que permiten preguntar directamente a tus documentos y obtener la respuesta con la cita de la página, como ChatPDF, AskYourPDF, Glean, Klu o Danswer. Por otro, los buscadores inteligentes que responden en lenguaje natural con fuentes enlazadas, como Perplexity, You.com o Phind.',
+      'El problema no suele ser que falte información, sino que está repartida entre cientos de PDF, wikis, correos y unidades compartidas donde nadie la encuentra. Esta categoría agrupa las herramientas que resuelven eso: por un lado, las que permiten preguntar directamente a tus documentos y obtener la respuesta con la cita de la página, como ChatPDF, AskYourPDF, Glean, Klu u Onyx. Por otro, los buscadores inteligentes que responden en lenguaje natural con fuentes enlazadas, como Perplexity, You.com o Phind.',
     body: 'Para consultas puntuales sobre un archivo suelto, una herramienta ligera de subir y preguntar es suficiente. Para una empresa, lo determinante es otra cosa: que se conecte a tus fuentes reales —Drive, SharePoint, Confluence, Slack— y, sobre todo, que respete los permisos de cada usuario, porque un buscador que enseña a todos lo que solo debían ver algunos es un incidente de seguridad. Exige también que cite la fuente de cada respuesta: sin cita, no hay forma de comprobar si se lo ha inventado.',
     faqs: [
       {
@@ -797,7 +797,7 @@ export const subcategoryContent: SubcategoryContent[] = [
     sub: 'Memoria a largo plazo',
     title: 'Las mejores herramientas de memoria para IA',
     intro:
-      'Los modelos de lenguaje olvidan todo al cerrar la conversación: solo existen dentro de su ventana de contexto. Estas herramientas añaden la capa que falta. MemGPT gestiona la memoria como un sistema operativo, moviendo información entre el contexto activo y un almacén externo según haga falta; MemO ofrece una capa de memoria persistente para asistentes que deben recordar preferencias y hechos del usuario entre sesiones; y Zep AI mantiene el historial de conversación con recuperación de lo relevante y gestión de la caducidad de los datos.',
+      'Los modelos de lenguaje olvidan todo al cerrar la conversación: solo existen dentro de su ventana de contexto. Estas herramientas añaden la capa que falta. Letta (antes MemGPT) gestiona la memoria como un sistema operativo, moviendo información entre el contexto activo y un almacén externo según haga falta; MemO ofrece una capa de memoria persistente para asistentes que deben recordar preferencias y hechos del usuario entre sesiones; y Zep AI mantiene el historial de conversación con recuperación de lo relevante y gestión de la caducidad de los datos.',
     body: 'Tiene sentido cuando construyes un asistente que se usa de forma continuada y donde repetir el contexto cada vez arruina la experiencia: soporte, tutoría, acompañamiento personal, agentes de trabajo. Al elegir, fíjate en cómo decide qué recordar y qué descartar, porque guardarlo todo encarece cada llamada y ensucia las respuestas. Comprueba también dónde se almacenan esos datos y si puedes borrar la memoria de un usuario concreto: la memoria persistente convierte a tu asistente en un tratamiento de datos personales.',
   },
   {
@@ -901,7 +901,7 @@ export const subcategoryContent: SubcategoryContent[] = [
     sub: 'Preguntas a Documentos',
     title: 'Las mejores IA para preguntar a tus documentos',
     intro:
-      'Buscar un dato dentro de un contrato de doscientas páginas o de una wiki abandonada es un trabajo que nadie quiere hacer. Estas herramientas lo resuelven preguntando. ChatPDF y AskYourPDF permiten subir un documento y consultarlo en lenguaje natural, con la cita de la página donde está la respuesta; Glean indexa todas las fuentes internas de una empresa —Drive, Slack, Confluence— respetando permisos; Klu y Danswer ofrecen búsqueda conversacional sobre el conocimiento de la organización, con opción de autoalojamiento.',
+      'Buscar un dato dentro de un contrato de doscientas páginas o de una wiki abandonada es un trabajo que nadie quiere hacer. Estas herramientas lo resuelven preguntando. ChatPDF y AskYourPDF permiten subir un documento y consultarlo en lenguaje natural, con la cita de la página donde está la respuesta; Glean indexa todas las fuentes internas de una empresa —Drive, Slack, Confluence— respetando permisos; Klu y Onyx (antes Danswer) ofrecen búsqueda conversacional sobre el conocimiento de la organización, con opción de autoalojamiento.',
     body: 'Para un archivo suelto, una herramienta ligera de subir y preguntar sobra. Para una empresa, lo determinante es que se conecte a tus fuentes reales y que respete los permisos de cada usuario: un buscador interno que muestra a cualquiera documentos de recursos humanos o de dirección es un incidente de seguridad, no una funcionalidad. Exige además que cite la fuente de cada afirmación. Sin cita verificable no hay forma de distinguir una respuesta correcta de una inventada con seguridad.',
   },
   {

--- a/src/data/discontinued.ts
+++ b/src/data/discontinued.ts
@@ -26,4 +26,13 @@ export const discontinuedTools: Record<string, DiscontinuedTool> = {
     sourceUrl:
       'https://help.openai.com/en/articles/20001152-what-to-know-about-the-sora-discontinuation',
   },
+  ChatSpot: {
+    note: 'HubSpot retiró ChatSpot como producto independiente en 2024 y lo integró en su plataforma como Breeze, su asistente de IA. El dominio chatspot.ai redirige a la página de Breeze y ya no es posible usar ChatSpot por separado.',
+    sourceUrl: 'https://www.hubspot.com/products/artificial-intelligence/breeze-ai-assistant',
+  },
+  Papercup: {
+    note: 'RWS adquirió la tecnología de Papercup en junio de 2025 y el producto dejó de operar de forma independiente. Su web redirige al servicio de doblaje con IA de RWS, donde continúa la tecnología.',
+    sourceUrl:
+      'https://www.rws.com/localization/services/translation-services/video-and-audio-translation/ai-dubbing-and-vo',
+  },
 };

--- a/src/data/publishing.ts
+++ b/src/data/publishing.ts
@@ -230,7 +230,7 @@ export const toolBatches: string[][] = [
     'IDEFICS',
     'Transformers',
     'OpenLLM',
-    'MemGPT',
+    'Letta',
     'MemO',
     'Zep AI',
     'Tree-of-Thought',
@@ -269,7 +269,7 @@ export const toolBatches: string[][] = [
     'Credo AI',
     'Glean',
     'Klu',
-    'Danswer',
+    'Onyx',
   ],
 ];
 

--- a/src/data/tool-details.ts
+++ b/src/data/tool-details.ts
@@ -9247,11 +9247,11 @@ export const toolDetails: Record<string, ToolDetail> = {
       },
     ],
   },
-  MemGPT: {
-    name: 'MemGPT',
+  Letta: {
+    name: 'Letta',
     tagline: 'Sistema de memoria a largo plazo para agentes de IA con contexto limitado',
     intro:
-      'MemGPT es un proyecto de código abierto que aborda una de las grandes limitaciones de los modelos de lenguaje: la ventana de contexto finita. Propone gestionar la memoria de un agente por niveles, moviendo información entre el contexto activo y un almacenamiento externo, de modo que el asistente recuerde conversaciones y hechos más allá de lo que cabe en un solo prompt. Lo usan desarrolladores que construyen agentes conversacionales persistentes.',
+      'Letta (antes MemGPT) es un proyecto de código abierto que aborda una de las grandes limitaciones de los modelos de lenguaje: la ventana de contexto finita. Propone gestionar la memoria de un agente por niveles, moviendo información entre el contexto activo y un almacenamiento externo, de modo que el asistente recuerde conversaciones y hechos más allá de lo que cabe en un solo prompt. Lo usan desarrolladores que construyen agentes conversacionales persistentes.',
     useCases: [
       'Dotar de memoria persistente a un asistente conversacional',
       'Recordar preferencias del usuario entre sesiones distintas',
@@ -9278,20 +9278,20 @@ export const toolDetails: Record<string, ToolDetail> = {
       'El proyecto ha evolucionado y cambiado de nombre y alcance',
     ],
     pricingNote:
-      'MemGPT nació como proyecto de código abierto y su uso no tiene coste de licencia. Lo que sí supone gasto es el consumo del modelo de lenguaje que utilices por debajo y la base de datos donde guardes la memoria. El proyecto ha ido evolucionando hacia una plataforma con opciones alojadas:',
+      'Letta nació como proyecto de código abierto y su uso no tiene coste de licencia. Lo que sí supone gasto es el consumo del modelo de lenguaje que utilices por debajo y la base de datos donde guardes la memoria. El proyecto ha ido evolucionando hacia una plataforma con opciones alojadas:',
     faqs: [
       {
-        question: '¿Qué es MemGPT?',
+        question: '¿Qué es Letta?',
         answer:
-          'MemGPT es un sistema de código abierto que dota de memoria a largo plazo a los agentes basados en modelos de lenguaje. Gestiona la información por niveles, moviéndola entre el contexto activo y un almacén externo para superar el límite de la ventana de contexto.',
+          'Letta es un sistema de código abierto que dota de memoria a largo plazo a los agentes basados en modelos de lenguaje. Gestiona la información por niveles, moviéndola entre el contexto activo y un almacén externo para superar el límite de la ventana de contexto.',
       },
       {
-        question: '¿Para qué sirve MemGPT?',
+        question: '¿Para qué sirve Letta?',
         answer:
           'Sirve para que un asistente de IA recuerde lo hablado en sesiones anteriores, las preferencias del usuario o los detalles de documentos largos. Sin una capa así, el agente olvida todo lo que no quepa en el prompt de la conversación actual.',
       },
       {
-        question: '¿MemGPT es gratis?',
+        question: '¿Letta es gratis?',
         answer:
           'El proyecto de código abierto puede usarse sin coste de licencia. Aparte pagarás el consumo del modelo de lenguaje y el almacenamiento que uses. Si optas por una versión alojada del proyecto, esta sí puede tener planes de pago; revisa su web.',
       },
@@ -11542,11 +11542,11 @@ export const toolDetails: Record<string, ToolDetail> = {
       },
     ],
   },
-  Danswer: {
-    name: 'Danswer',
+  Onyx: {
+    name: 'Onyx',
     tagline: 'Buscador y asistente de IA de código abierto para el conocimiento interno',
     intro:
-      'Danswer es una plataforma de código abierto que permite hacer preguntas en lenguaje natural sobre el conocimiento interno de una organización. Conecta fuentes como documentación, repositorios, chats o gestores de tickets, indexa su contenido y responde citando los documentos de origen. Al ser open source, puede desplegarse en servidores propios, algo relevante para equipos con requisitos de privacidad.',
+      'Onyx (antes Danswer) es una plataforma de código abierto que permite hacer preguntas en lenguaje natural sobre el conocimiento interno de una organización. Conecta fuentes como documentación, repositorios, chats o gestores de tickets, indexa su contenido y responde citando los documentos de origen. Al ser open source, puede desplegarse en servidores propios, algo relevante para equipos con requisitos de privacidad.',
     useCases: [
       'Consultar la documentación interna en lenguaje natural',
       'Buscar respuestas en chats y tickets de soporte',
@@ -11572,20 +11572,20 @@ export const toolDetails: Record<string, ToolDetail> = {
       'Menos pulido que las alternativas comerciales cerradas',
     ],
     pricingNote:
-      'Danswer es un proyecto de código abierto, por lo que el software puede usarse sin coste de licencia si se autoaloja; los gastos vienen de la infraestructura y de los modelos que se utilicen. Suele existir además una opción gestionada en la nube de pago.',
+      'Onyx es un proyecto de código abierto, por lo que el software puede usarse sin coste de licencia si se autoaloja; los gastos vienen de la infraestructura y de los modelos que se utilicen. Suele existir además una opción gestionada en la nube de pago.',
     faqs: [
       {
-        question: '¿Qué es Danswer?',
+        question: '¿Qué es Onyx?',
         answer:
-          'Danswer es una herramienta de código abierto que permite preguntar en lenguaje natural sobre el conocimiento interno de una organización. Conecta e indexa fuentes como documentación, chats o tickets, y responde citando los documentos en los que se apoya.',
+          'Onyx es una herramienta de código abierto que permite preguntar en lenguaje natural sobre el conocimiento interno de una organización. Conecta e indexa fuentes como documentación, chats o tickets, y responde citando los documentos en los que se apoya.',
       },
       {
-        question: '¿Danswer es gratis?',
+        question: '¿Onyx es gratis?',
         answer:
           'El proyecto es de código abierto y puede usarse sin coste de licencia si lo despliegas en tu propia infraestructura. Eso sí, asumes los gastos de servidores y del uso de modelos. También suele haber una versión gestionada de pago.',
       },
       {
-        question: '¿Se puede autoalojar Danswer?',
+        question: '¿Se puede autoalojar Onyx?',
         answer:
           'Sí, esa es una de sus principales ventajas. Al ser open source, puede instalarse en servidores propios, lo que resulta interesante para organizaciones con requisitos estrictos de privacidad o que prefieren no enviar su documentación interna a servicios externos.',
       },


### PR DESCRIPTION
## Origen

Dos cosas del dueño: el bloque SEO de la portada salía **por debajo del footer**, y la sospecha de que la web, creada hace tiempo, estaba desactualizada. La sospecha se confirmó con una auditoría de 5 pasadas (URLs del catálogo, secciones hardcodeadas, artículos, funcionalidades del footer, textos fechados): **50 hallazgos**, los graves verificados a mano antes de tocar nada.

## Estructura

La sección SEO de la portada ahora entra como `children` de `HomeContainer`: se sigue renderizando en el HTML del servidor (verificado con `next start` en local: H1, categorías y FAQ presentes) y en cliente se coloca **antes** del footer en ambas vistas.

## Roto visible (verificado)

- Tarjeta "Notion" de la home → `/herramienta/notion` = **404 en producción** (slug real: `notion-ai`)
- **Sora** en la sección Video como activa y "Gratis" — cerró en abril; la sustituye Kling
- Footer: **MLOps y Marketing** mapeaban a categorías inexistentes (filtro perdido en silencio) y faltaba Gestión del Conocimiento
- Las 4 "herramientas" del footer eran el mismo botón con 4 etiquetas; quedan **2 enlaces honestos** (Todas las herramientas, Comparador → `/comparativas`)

## Catálogo (cada destino verificado con curl antes de escribirlo)

- **6 URLs muertas corregidas** + Play.ht pierde su `url` (dominio sin DNS, sin sucesor; su ficha ya muestra el aviso de cierre en vez del botón)
- **15 rebrands/redirects actualizados** (ChatSpot→Breeze, Cylance→Arctic Wolf, Evisort→Workday…)
- **2 renombres**: Danswer→**Onyx**, MemGPT→**Letta** — tandas 7-8 sin publicar, cambio de slug sin coste
- ChatSpot y Papercup entran en `discontinued.ts` como absorbidos

## Home y blog

- "Nuevas adiciones" ya no es una lista fija de veteranas con badge NUEVO falso: se deriva del catálogo (8 fichas de la tanda 2, lo último publicado de verdad)
- Secciones alineadas con el catálogo: FLUX (antes apuntaba a un dominio de terceros), Suno, Cursor, Runway, Codium→Qodo, Qwen
- Blog: destacan los 4 artículos de 2026; los 5 de 2025 (GPT-5 "novedad" desde hace un año) pasan a la lista normal. Phind (cerrado en enero) fuera del artículo de julio

## Verificación

- `tsc` limpio · build 391 páginas · **270/270 tests** · 0 errores lint
- Grep final: cero URLs viejas en todo `src/`
- El HTML del servidor de la portada conserva todo el contenido SEO

## Pendientes señalados, no incluidos

- Reescribir los artículos de 2025 (tarea de contenido aparte)
- Socratic (redirige a Google Lens): decidir al publicar la tanda 5
- Los assets huérfanos de YouWrite en `public/`