### PR TITLE
feat(seo): títulos con año en fichas y comparativas para subir CTR

### DIFF
--- a/src/app/articulos/layout.tsx
+++ b/src/app/articulos/layout.tsx
@@ -33,7 +33,6 @@ export const metadata: Metadata = {
     title: 'Artículos sobre Inteligencia Artificial | AIFinder',
     description:
       'Lee los últimos artículos, comparativas y noticias sobre herramientas de inteligencia artificial.',
-    creator: '@aifinder_es',
   },
 };
 

--- a/src/app/categoria/[slug]/[subcategory]/page.tsx
+++ b/src/app/categoria/[slug]/[subcategory]/page.tsx
@@ -86,7 +86,6 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       card: 'summary_large_image',
       title: `${title} | AIFinder`,
       description,
-      creator: '@aifinder_es',
     },
   };
 }

--- a/src/app/categoria/[slug]/page.tsx
+++ b/src/app/categoria/[slug]/page.tsx
@@ -59,7 +59,6 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       card: 'summary_large_image',
       title: `${title} | AIFinder`,
       description,
-      creator: '@aifinder_es',
     },
   };
 }

--- a/src/app/comparativa/[slug]/page.tsx
+++ b/src/app/comparativa/[slug]/page.tsx
@@ -27,16 +27,18 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
   const baseUrl = getSiteUrl();
   const description = comparison.intro.slice(0, 155);
+  const year = new Date().getFullYear();
+  const title = `${comparison.title} (${year})`;
 
   return {
-    title: comparison.title,
+    title,
     description,
     ...(isComparisonPublished() ? {} : { robots: NOINDEX_ROBOTS }),
     alternates: {
       canonical: `${baseUrl}/comparativa/${slug}`,
     },
     openGraph: {
-      title: `${comparison.title} | AIFinder`,
+      title: `${title} | AIFinder`,
       description,
       url: `${baseUrl}/comparativa/${slug}`,
       type: 'article',
@@ -45,9 +47,8 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     },
     twitter: {
       card: 'summary_large_image',
-      title: `${comparison.title} | AIFinder`,
+      title: `${title} | AIFinder`,
       description,
-      creator: '@aifinder_es',
     },
   };
 }

--- a/src/app/herramienta/[slug]/page.tsx
+++ b/src/app/herramienta/[slug]/page.tsx
@@ -31,7 +31,10 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
   const detail = getToolDetail(tool.name);
   const baseUrl = getSiteUrl();
-  const title = `${tool.name}: qué es, para qué sirve y precios`;
+  // El año se calcula en build (páginas estáticas); cada deploy lo refresca.
+  // "(2026)" en el título sube CTR en búsquedas de precios/comparativas.
+  const year = new Date().getFullYear();
+  const title = `${tool.name}: qué es, precios y alternativas (${year})`;
   const description = detail
     ? `${detail.tagline} Guía de ${tool.name}: usos, funciones, ventajas, inconvenientes, precios y alternativas.`
     : `Ficha de ${tool.name}: qué es, para qué sirve, precios y alternativas en ${tool.subcategory}.`;
@@ -56,7 +59,6 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       card: 'summary_large_image',
       title: `${title} | AIFinder`,
       description,
-      creator: '@aifinder_es',
     },
   };
 }

--- a/src/app/herramientas/layout.tsx
+++ b/src/app/herramientas/layout.tsx
@@ -34,7 +34,6 @@ export const metadata: Metadata = {
     card: 'summary_large_image',
     title: 'Herramientas de IA - Directorio Completo | AIFinder',
     description: 'Explora nuestro directorio completo de herramientas de inteligencia artificial.',
-    creator: '@aifinder_es',
   },
 };
 


### PR DESCRIPTION
## Qué hace

Pasada de títulos orientada a CTR (posición media 8,1, CTR 0,4%):

- **Fichas**: `Midjourney: qué es, precios y alternativas (2026) | AIFinder` — antes `qué es, para qué sirve y precios`. El año se calcula en build; cada deploy lo refresca. En consultas de precios ("midjourney precios", 7,3k impresiones) el año es el gancho de clic más fiable.
- **Comparativas**: año añadido al título existente: `ChatGPT vs Claude: diferencias, precios y cuál elegir (2026)`.
- **Limpieza**: `creator: '@aifinder_es'` (cuenta inexistente) eliminado de los 6 archivos que la PR #12 no cubre. Sin conflictos con ella: archivos disjuntos.

Verificado en el HTML estático del build (396 páginas OK).

🤖 Generated with [Claude Code](https://claude.com/claude-code)