### PR TITLE
fix(newsletter): remitente real y errores de Resend visibles

### DIFF
--- a/src/app/api/send-welcome-email/route.ts
+++ b/src/app/api/send-welcome-email/route.ts
@@ -171,7 +171,8 @@ export async function POST(request: NextRequest) {
 
     // Enviar email de bienvenida
     const result = await resend.emails.send({
-      from: 'AIFinder <newsletter@aifinder.es>',
+      // info@ es un buzón real (newsletter@ no existía): las respuestas llegan.
+      from: 'AIFinder <info@aifinder.es>',
       to: [email],
       subject,
       html: `
@@ -305,6 +306,14 @@ export async function POST(request: NextRequest) {
         </html>
       `,
     });
+
+    // El SDK de Resend no lanza excepción en errores de API: devuelve
+    // { data, error }. Sin esta comprobación, un rechazo (p. ej. 403 por
+    // dominio sin verificar) respondía success: true y se perdía en silencio.
+    if (result.error) {
+      logger.error('Resend rechazó el email de bienvenida', result.error);
+      return NextResponse.json({ error: 'No se pudo enviar el email' }, { status: 502 });
+    }
 
     const ok = NextResponse.json({ success: true, emailId: result.data?.id });
     if (cookieValue)


### PR DESCRIPTION
## Qué arregla

Al investigar por qué no llegaba el email de bienvenida descubrimos en los logs de Resend que **todos los envíos de producción fallan con 403** (dominio sin verificar en el workspace) y el endpoint respondía `success: true` igualmente:

- **Bug**: el SDK de Resend no lanza excepción en errores de API — devuelve `{data, error}` — y [route.ts](src/app/api/send-welcome-email/route.ts) nunca comprobaba `error`. Ahora se loguea y se responde 502.
- **Remitente**: `newsletter@aifinder.es` no existe como buzón (las respuestas de suscriptores se perdían). Ahora se envía como `info@aifinder.es`, buzón real con redirección a Gmail verificada.

La verificación del dominio en Resend va aparte (en curso, es configuración del panel + DNS, no código).

Verificado: lint limpio, 270 tests, build OK (396 páginas).

🤖 Generated with [Claude Code](https://claude.com/claude-code)