### PR TITLE
feat(monetizacion): enlaces de afiliado en fichas y comparativas con aviso LSSI

### DIFF
--- a/src/app/comparativa/[slug]/page.tsx
+++ b/src/app/comparativa/[slug]/page.tsx
@@ -8,6 +8,9 @@ import { findToolBySlug, toolSlug } from '../../../utils/tools';
 import { findComparisonBySlug, getAllComparisons } from '../../../utils/comparisons';
 import { isComparisonPublished, NOINDEX_ROBOTS } from '../../../utils/publishing';
 import { discontinuedTools } from '../../../data/discontinued';
+import { getAffiliateLink } from '../../../data/affiliates';
+import AffiliateCta from '../../../components/Affiliate/AffiliateCta';
+import AffiliateNotice from '../../../components/Affiliate/AffiliateNotice';
 
 type Props = {
   params: Promise<{ slug: string }>;
@@ -104,6 +107,13 @@ export default async function ComparisonPage({ params }: Props) {
     .filter((name) => discontinuedTools[name])
     .map((name) => ({ name, note: discontinuedTools[name].note }));
   const stillAlive = discontinuedTools[comparison.a] ? comparison.b : comparison.a;
+
+  const affiliates = [comparison.a, comparison.b]
+    .filter((name) => !discontinuedTools[name])
+    .flatMap((name) => {
+      const link = getAffiliateLink(name);
+      return link ? [{ name, link }] : [];
+    });
 
   return (
     <>
@@ -242,6 +252,24 @@ export default async function ComparisonPage({ params }: Props) {
         <section className="mb-8">
           <h2 className="text-2xl font-bold mb-3">Veredicto</h2>
           <p className="text-zinc-300 leading-relaxed">{comparison.verdict}</p>
+          {affiliates.length > 0 && (
+            <div className="mt-5">
+              <div className="flex flex-wrap gap-3">
+                {affiliates.map(({ name, link }) => (
+                  <AffiliateCta
+                    key={name}
+                    href={link.url}
+                    toolName={name}
+                    source="comparativa"
+                    className="inline-block px-4 py-2 rounded-lg bg-white text-black font-semibold hover:bg-zinc-200 transition-colors"
+                  >
+                    Probar {name} →
+                  </AffiliateCta>
+                ))}
+              </div>
+              <AffiliateNotice />
+            </div>
+          )}
         </section>
 
         <section className="mb-8 grid md:grid-cols-2 gap-4">

--- a/src/app/herramienta/[slug]/page.tsx
+++ b/src/app/herramienta/[slug]/page.tsx
@@ -12,6 +12,9 @@ import { getComparisonsForTool } from '../../../utils/comparisons';
 import { isToolPublished, NOINDEX_ROBOTS } from '../../../utils/publishing';
 import { getToolPricing, PRICING_LAST_CHECKED } from '../../../utils/pricing';
 import { discontinuedTools } from '../../../data/discontinued';
+import { getAffiliateLink } from '../../../data/affiliates';
+import AffiliateCta from '../../../components/Affiliate/AffiliateCta';
+import AffiliateNotice from '../../../components/Affiliate/AffiliateNotice';
 
 type Props = {
   params: Promise<{ slug: string }>;
@@ -82,6 +85,7 @@ export default async function ToolPage({ params }: Props) {
   const toolComparisons = getComparisonsForTool(tool.name);
   const pricing = getToolPricing(tool.name);
   const discontinued = discontinuedTools[tool.name];
+  const affiliate = discontinued ? undefined : getAffiliateLink(tool.name);
   const categorySlug = slugify(tool.category);
   const subcategorySlug = slugify(tool.subcategory);
 
@@ -229,6 +233,19 @@ export default async function ToolPage({ params }: Props) {
               </a>{' '}
               o baja hasta las alternativas.
             </p>
+          </div>
+        ) : affiliate ? (
+          <div className="mb-8">
+            <AffiliateCta
+              href={affiliate.url}
+              toolName={tool.name}
+              source="ficha"
+              className="inline-block px-4 py-2 rounded-lg bg-white text-black font-semibold hover:bg-zinc-200 transition-colors"
+            >
+              Probar {tool.name} →
+            </AffiliateCta>
+            {affiliate.perk && <p className="text-emerald-300/90 text-sm mt-2">{affiliate.perk}</p>}
+            <AffiliateNotice />
           </div>
         ) : (
           tool.url && (

--- a/src/app/sobre/page.tsx
+++ b/src/app/sobre/page.tsx
@@ -45,7 +45,10 @@ export default function SobrePage() {
           </li>
           <li>
             <strong className="text-white">Sin patrocinios en el listado</strong>: ninguna
-            herramienta paga por aparecer, por su posición ni por el tono de su ficha.
+            herramienta paga por aparecer, por su posición ni por el tono de su ficha. Algunos
+            enlaces salientes son de afiliado y están señalados como tales: si contratas a través de
+            ellos, AIFinder recibe una comisión sin coste extra para ti. Eso no altera qué
+            herramientas se listan ni cómo se valoran.
           </li>
           <li>
             <strong className="text-white">Cada comparativa tiene veredicto</strong>, con casos

--- a/src/components/Affiliate/AffiliateCta.tsx
+++ b/src/components/Affiliate/AffiliateCta.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+declare global {
+  interface Window {
+    gtag?: (...args: unknown[]) => void;
+  }
+}
+
+type Props = {
+  href: string;
+  toolName: string;
+  source: 'ficha' | 'comparativa';
+  className?: string;
+  children: React.ReactNode;
+};
+
+export default function AffiliateCta({ href, toolName, source, className, children }: Props) {
+  const handleClick = () => {
+    window.gtag?.('event', 'affiliate_click', {
+      tool: toolName,
+      source,
+    });
+  };
+
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="sponsored nofollow noopener"
+      onClick={handleClick}
+      className={className}
+    >
+      {children}
+    </a>
+  );
+}

--- a/src/components/Affiliate/AffiliateNotice.tsx
+++ b/src/components/Affiliate/AffiliateNotice.tsx
@@ -1,0 +1,8 @@
+export default function AffiliateNotice() {
+  return (
+    <p className="text-zinc-500 text-xs mt-2">
+      Enlace de afiliado: si contratas a través de él, AIFinder recibe una comisión. A ti no te
+      cuesta nada extra y no cambia cómo valoramos la herramienta.
+    </p>
+  );
+}

--- a/src/data/affiliates.ts
+++ b/src/data/affiliates.ts
@@ -1,0 +1,21 @@
+export type AffiliateLink = {
+  url: string;
+  perk?: string;
+};
+
+/**
+ * Enlaces de afiliado por herramienta. Solo programas activos con enlace en mano;
+ * las herramientas sin entrada siguen enlazando a su web oficial normal.
+ * Todo enlace de afiliado se marca con rel="sponsored" y aviso visible (LSSI art. 20).
+ */
+export const affiliateLinks: Record<string, AffiliateLink> = {
+  ElevenLabs: { url: 'https://try.elevenlabs.io/rh6ijma1zo1l' },
+  Make: {
+    url: 'https://www.make.com/en/register?pc=aifinder',
+    perk: 'Con este enlace: 1 mes del plan Core gratis, con 10.000 créditos incluidos.',
+  },
+};
+
+export function getAffiliateLink(toolName: string): AffiliateLink | undefined {
+  return affiliateLinks[toolName];
+}


### PR DESCRIPTION
## Qué hace

- Nuevo `src/data/affiliates.ts` con los enlaces de afiliado activos (ElevenLabs y Make); añadir los siguientes (Speechify, Murf, Gamma) será una línea por programa.
- **Ficha de herramienta**: el botón principal pasa a "Probar X →" con el enlace de afiliado, `rel="sponsored nofollow noopener"`, la promo visible cuando existe (1 mes de Core gratis de Make) y el aviso de afiliación debajo (LSSI art. 20). Las herramientas sin programa siguen mostrando el enlace normal a su web.
- **Comparativas**: CTA tras el veredicto cuando alguno de los dos contendientes tiene programa activo (hoy: `elevenlabs-vs-murf`, `elevenlabs-vs-playht`, `zapier-vs-make`, `make-vs-n8n`). Las herramientas descatalogadas nunca muestran CTA.
- **Tracking**: evento GA4 `affiliate_click` con herramienta y origen (ficha/comparativa), solo si hay consentimiento de analítica (gtag opcional).
- **/sobre**: el criterio "Sin patrocinios en el listado" divulga ahora los enlaces de afiliado sin dejar de ser cierto.

## Verificación

- 273 tests en verde, lint limpio, build de producción OK.
- HTML prerenderizado comprobado: enlaces y `rel="sponsored"` presentes en fichas y comparativas afectadas; el JSON-LD sigue usando la URL oficial (no la de afiliado).
- Revisión adversarial en 3 lentes (técnica, legal/SEO, datos): un único hallazgo — terminología del perk de Make ("operaciones" → "créditos") — corregido.