### PR TITLE
feat(seo): enlazar la primera mención de cada herramienta en los artículos a su ficha

### DIFF
--- a/src/app/articles/[slug]/ArticleView.tsx
+++ b/src/app/articles/[slug]/ArticleView.tsx
@@ -6,6 +6,7 @@ import type { Article } from '../../../types/article';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import MobileHeader from '../../../components/Header/MobileHeader';
+import { findToolMention } from '../../../utils/toolMention';
 import {
   useAppContext,
   useSubcategoryContext,
@@ -18,10 +19,47 @@ type ArticleViewProps = {
   /* Solo los slugs: pasar los artículos enteros arrastraría su contenido al payload. */
   prevSlug: string | null;
   nextSlug: string | null;
+  /* Nombre → slug de las herramientas publicadas mencionadas (calculado en servidor). */
+  toolLinks: Record<string, string>;
 };
 
-export default function ArticleView({ article, prevSlug, nextSlug }: ArticleViewProps) {
+/**
+ * Enlaza la primera mención de cada herramienta a su ficha. `linked` es
+ * compartido por todo el artículo: una herramienta solo se enlaza una vez.
+ */
+function linkifyText(
+  text: string,
+  toolLinks: Record<string, string>,
+  linked: Set<string>,
+): React.ReactNode {
+  let best: { name: string; slug: string; index: number } | null = null;
+  for (const [name, slug] of Object.entries(toolLinks)) {
+    if (linked.has(name)) continue;
+    const index = findToolMention(text, name);
+    if (index !== -1 && (!best || index < best.index)) {
+      best = { name, slug, index };
+    }
+  }
+  if (!best) return text;
+
+  linked.add(best.name);
+  const after = text.slice(best.index + best.name.length);
+  return (
+    <>
+      {text.slice(0, best.index)}
+      <Link href={`/herramienta/${best.slug}`} className="text-blue-400 hover:underline">
+        {best.name}
+      </Link>
+      {linkifyText(after, toolLinks, linked)}
+    </>
+  );
+}
+
+export default function ArticleView({ article, prevSlug, nextSlug, toolLinks }: ArticleViewProps) {
   const router = useRouter();
+  // Nuevo por render: el render es una sola pasada descendente, así que la
+  // primera mención del artículo gana siempre y el resultado es determinista.
+  const linkedTools = new Set<string>();
 
   // Contextos necesarios para montar el MobileHeader fijo
   const { activeCategory: _activeCategory, setActiveCategory } = useAppContext();
@@ -213,13 +251,13 @@ export default function ArticleView({ article, prevSlug, nextSlug }: ArticleView
               )}
               {section.paragraphs?.map((p, i) => (
                 <p key={i} className="text-zinc-300 leading-relaxed mb-4">
-                  {p}
+                  {linkifyText(p, toolLinks, linkedTools)}
                 </p>
               ))}
               {section.bullets && section.bullets.length > 0 && (
                 <ul className="list-disc pl-5 space-y-2 text-zinc-300">
                   {section.bullets.map((b, i) => (
-                    <li key={i}>{b}</li>
+                    <li key={i}>{linkifyText(b, toolLinks, linkedTools)}</li>
                   ))}
                 </ul>
               )}

--- a/src/app/articles/[slug]/page.tsx
+++ b/src/app/articles/[slug]/page.tsx
@@ -1,5 +1,6 @@
 import { notFound } from 'next/navigation';
 import { articles } from '../../../data/articles';
+import { getArticleToolLinks } from '../../../utils/articleToolLinks';
 import ArticleView from './ArticleView';
 
 type Props = {
@@ -32,5 +33,12 @@ export default async function ArticleDetailPage({ params }: Props) {
       ? featuredOrdered[idxInFeatured + 1].slug
       : null;
 
-  return <ArticleView article={article} prevSlug={prevSlug} nextSlug={nextSlug} />;
+  return (
+    <ArticleView
+      article={article}
+      prevSlug={prevSlug}
+      nextSlug={nextSlug}
+      toolLinks={getArticleToolLinks(article)}
+    />
+  );
 }

--- a/src/utils/__tests__/articleToolLinks.test.ts
+++ b/src/utils/__tests__/articleToolLinks.test.ts
@@ -1,0 +1,57 @@
+import { findToolMention } from '../toolMention';
+import { getArticleToolLinks } from '../articleToolLinks';
+import type { Article } from '../../types/article';
+
+describe('findToolMention', () => {
+  it('encuentra el nombre con límites de palabra', () => {
+    expect(findToolMention('Prueba ChatGPT hoy', 'ChatGPT')).toBe(7);
+  });
+
+  it('no casa dentro de otra palabra', () => {
+    expect(findToolMention('ChatGPTs no cuenta', 'ChatGPT')).toBe(-1);
+  });
+
+  it('es sensible a mayúsculas (veo ≠ Veo)', () => {
+    expect(findToolMention('ya veo la diferencia', 'Veo')).toBe(-1);
+  });
+
+  it('acepta nombres con puntos', () => {
+    expect(findToolMention('Usa Copy.ai para textos', 'Copy.ai')).toBe(4);
+  });
+
+  it('acepta el nombre seguido de puntuación', () => {
+    expect(findToolMention('Con Claude, todo mejora', 'Claude')).toBe(4);
+  });
+});
+
+describe('getArticleToolLinks', () => {
+  const baseArticle: Article = {
+    id: 'test',
+    slug: 'test',
+    title: 'Test',
+    description: 'desc',
+    image: '/test.webp',
+    category: 'tips',
+    categoryLabel: 'Consejos',
+    date: '19 Ago 2026',
+    readTime: '1 min',
+    contentSections: [
+      {
+        paragraphs: ['ChatGPT y Claude dominan el mercado.'],
+        bullets: ['Midjourney genera imágenes.'],
+      },
+    ],
+  } as Article;
+
+  it('mapea solo herramientas publicadas mencionadas en el cuerpo', () => {
+    const links = getArticleToolLinks(baseArticle);
+    expect(links['ChatGPT']).toBe('chatgpt');
+    expect(links['Claude']).toBe('claude');
+    expect(links['Midjourney']).toBe('midjourney');
+    expect(links['Gemini']).toBeUndefined();
+  });
+
+  it('devuelve vacío sin secciones', () => {
+    expect(getArticleToolLinks({ ...baseArticle, contentSections: undefined })).toEqual({});
+  });
+});

--- a/src/utils/articleToolLinks.ts
+++ b/src/utils/articleToolLinks.ts
@@ -1,0 +1,31 @@
+import type { Article } from '../types/article';
+import { getAllTools } from './tools';
+import { isToolPublished } from './publishing';
+import { findToolMention } from './toolMention';
+
+/**
+ * Mapa nombre → slug de las herramientas publicadas que se mencionan en el
+ * cuerpo del artículo. Se calcula en servidor para que el cliente reciba solo
+ * las pocas entradas de ese artículo, no el catálogo entero.
+ * Los nombres de menos de 3 caracteres (Pi) se excluyen para evitar falsos
+ * positivos con palabras normales.
+ */
+export function getArticleToolLinks(article: Article): Record<string, string> {
+  const texts: string[] = [];
+  article.contentSections?.forEach((section) => {
+    if (section.paragraphs) texts.push(...section.paragraphs);
+    if (section.bullets) texts.push(...section.bullets);
+  });
+  if (texts.length === 0) return {};
+
+  const corpus = texts.join('\n');
+  const links: Record<string, string> = {};
+  for (const tool of getAllTools()) {
+    if (tool.name.length < 3) continue;
+    if (!isToolPublished(tool.name)) continue;
+    if (findToolMention(corpus, tool.name) !== -1) {
+      links[tool.name] = tool.slug;
+    }
+  }
+  return links;
+}

--- a/src/utils/toolMention.ts
+++ b/src/utils/toolMention.ts
@@ -1,0 +1,21 @@
+const isWordChar = (c: string) => /[\p{L}\p{N}]/u.test(c);
+
+/**
+ * Devuelve el índice de la primera mención exacta del nombre (sensible a
+ * mayúsculas y con límites de palabra), o -1. El límite manual en vez de \b
+ * cubre nombres con puntos o símbolos (Copy.ai, DALL·E, Play.ht).
+ */
+export function findToolMention(text: string, name: string): number {
+  let from = 0;
+  while (from <= text.length - name.length) {
+    const idx = text.indexOf(name, from);
+    if (idx === -1) return -1;
+    const prev = idx > 0 ? text[idx - 1] : '';
+    const next = text[idx + name.length] ?? '';
+    if ((!prev || !isWordChar(prev)) && (!next || !isWordChar(next))) {
+      return idx;
+    }
+    from = idx + 1;
+  }
+  return -1;
+}


### PR DESCRIPTION
## Qué hace

Los 13 artículos del blog no tenían **ni un solo enlace** hacia las fichas de /herramienta/ — el gap de enlazado interno detectado en la investigación de crecimiento. Este cambio añade **87 enlaces contextuales** (primera mención de cada herramienta publicada, una vez por artículo) para empujar autoridad hacia las fichas, muchas de ellas en posición 4-15 en Google ("striking distance").

## Cómo

- El servidor (`page.tsx`) calcula el mapa nombre→slug de las herramientas publicadas mencionadas en ese artículo (`getArticleToolLinks`), y pasa solo esas entradas al cliente — sin engordar el payload con el catálogo.
- `ArticleView` enlaza la primera mención de cada herramienta en párrafos y bullets (`linkifyText`, determinista por render).
- `findToolMention`: coincidencia exacta con límites de palabra manuales (cubre `Copy.ai`, `DALL·E`, `Play.ht`), sensible a mayúsculas ("veo" verbo ≠ "Veo" herramienta) y con exclusión de nombres <3 caracteres (`Pi`).
- Solo herramientas **publicadas** (las noindex de tandas futuras no se enlazan).

## Verificación

- 280 tests en verde (7 nuevos del matcher y el mapa), tipos y lint limpios, build OK.
- HTML prerenderizado comprobado: 87 enlaces repartidos en los 13 artículos (p. ej. 6 en el de ChatGPT vs Claude vs Gemini), contexto del enlace a Veo verificado como legítimo ("Veo 3 convierte prompts…").