### PR TITLE
feat(seo): títulos de ficha que responden a la consulta real y description con la respuesta de precio

### DIFF
--- a/src/app/herramienta/[slug]/page.tsx
+++ b/src/app/herramienta/[slug]/page.tsx
@@ -37,9 +37,22 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   // El año se calcula en build (páginas estáticas); cada deploy lo refresca.
   // "(2026)" en el título sube CTR en búsquedas de precios/comparativas.
   const year = new Date().getFullYear();
-  const title = `${tool.name}: qué es, precios y alternativas (${year})`;
+  // Las consultas reales de Search Console preguntan "X es gratis o se paga":
+  // el título plantea esa pregunta y la description la responde al instante.
+  const title = discontinuedTools[tool.name]
+    ? `${tool.name}: cierre, qué pasó y alternativas (${year})`
+    : `${tool.name}: ¿es gratis? Precios y alternativas (${year})`;
+  const priceAnswer =
+    tool.pricing === 'free'
+      ? `${tool.name} es gratis.`
+      : tool.pricing === 'freemium'
+        ? `${tool.name} tiene versión gratuita y planes de pago.`
+        : tool.pricing === 'paid'
+          ? `${tool.name} es de pago, sin plan gratuito permanente.`
+          : '';
+  const tagline = detail ? detail.tagline.replace(/\.?\s*$/, '.') : '';
   const description = detail
-    ? `${detail.tagline} Guía de ${tool.name}: usos, funciones, ventajas, inconvenientes, precios y alternativas.`
+    ? `${priceAnswer ? `${priceAnswer} ` : ''}${tagline} Precios verificados, ventajas, inconvenientes y alternativas.`
     : `Ficha de ${tool.name}: qué es, para qué sirve, precios y alternativas en ${tool.subcategory}.`;
 
   return {


### PR DESCRIPTION
## Por qué

Auditoría del export de Rendimiento de Search Console (3 meses):

- CTR branded: 15,98% (sano). **CTR no-branded: 0,12%** (17 clics / 13.829 impresiones).
- **La ficha de Midjourney: 8.481 impresiones en posición 4,0 y 2 clics (0,02%)** — el 61% de todo el volumen no-branded desperdiciado en una sola página. Le siguen Adobe Firefly (1.961 imp, 0 clics) y Google Flow (1.862 imp).
- Las consultas reales no son "qué es X": son **"midjourney es gratis o se paga"** (57 imp), **"elevenlabs es gratis o se paga"** (26 imp), "chatgpt vs gemini **precios**" (61 imp)…

## Qué hace

- **Título de ficha**: `X: ¿es gratis? Precios y alternativas (2026)` — plantea exactamente la pregunta que trae las impresiones (formato pregunta: patrón con mejor CTR documentado).
- **Meta description**: la responde al instante con datos del catálogo — "Midjourney es de pago, sin plan gratuito permanente." / "ElevenLabs tiene versión gratuita y planes de pago." — seguida del tagline y la coletilla de precios verificados.
- **Herramientas cerradas**: título propio (`Drift: cierre, qué pasó y alternativas`) en vez de preguntar por el precio de algo que ya no se vende.

## Verificación

- 280 tests, lint y build OK (399 páginas).
- HTML comprobado: títulos y descriptions correctos en Midjourney (de pago), ElevenLabs (freemium), Drift (cerrada) y Zendesk.