### PR TITLE
feat(seo): badge de Startup Fame en el footer

### DIFF
--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -520,6 +520,21 @@ export default function Footer({
           {/* Mobile */}
           <div className="md:hidden text-left space-y-2 mb-6">
             <div className="text-zinc-400 text-sm">© {new Date().getFullYear()} AIFinder</div>
+            {/* Badge de Startup Fame: requisito del alta gratuita (verifican que esté en la web) */}
+            <a
+              href="https://startupfa.me/s/aifinder?utm_source=www.aifinder.es"
+              target="_blank"
+              rel="noopener"
+            >
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src="https://startupfa.me/badges/featured/dark-small.webp"
+                alt="AIFinder - Featured on Startup Fame"
+                width={224}
+                height={36}
+                loading="lazy"
+              />
+            </a>
             <div className="space-y-1">
               {legalLinks.map((link) => (
                 <Link
@@ -554,8 +569,22 @@ export default function Footer({
 
           {/* Desktop */}
           <div className="hidden md:flex flex-col md:flex-row justify-between items-center relative">
-            <div className="flex items-center mb-4 md:mb-0">
+            <div className="flex items-center gap-4 mb-4 md:mb-0">
               <span className="text-zinc-400 text-sm">© {new Date().getFullYear()} AIFinder</span>
+              <a
+                href="https://startupfa.me/s/aifinder?utm_source=www.aifinder.es"
+                target="_blank"
+                rel="noopener"
+              >
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src="https://startupfa.me/badges/featured/dark-small.webp"
+                  alt="AIFinder - Featured on Startup Fame"
+                  width={224}
+                  height={36}
+                  loading="lazy"
+                />
+              </a>
             </div>
             <div className="flex items-center space-x-4">
               {legalLinks.map((link) => (


### PR DESCRIPTION
## Qué hace

Añade el badge **Featured on Startup Fame** (variante dark-small, 224×36) junto al © del footer, en los layouts móvil y escritorio.

Es el requisito del alta gratuita en startupfa.me: verifican que el badge esté en la web y a cambio el listado da un **backlink dofollow** a aifinder.es (DR ~80). Enlace con `rel="noopener"` y carga `lazy`; imagen servida desde su CDN (es lo que verifican).

## Verificación

- 22 tests del Footer en verde; lint sin avisos nuevos.