### PR TITLE
fix(seo): badge de Startup Fame en la home con SSR (el footer no llega al HTML)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -200,6 +200,26 @@ export default function HomePage() {
                 </div>
               ))}
             </div>
+
+            {/* Badge de Startup Fame: requisito del alta gratuita en su directorio.
+                Va aquí y no en el Footer porque el footer solo se monta en cliente
+                y su verificador necesita encontrarlo en el HTML del servidor. */}
+            <p className="mt-12">
+              <a
+                href="https://startupfa.me/s/aifinder?utm_source=www.aifinder.es"
+                target="_blank"
+                rel="noopener"
+              >
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src="https://startupfa.me/badges/featured/dark-small.webp"
+                  alt="AIFinder - Featured on Startup Fame"
+                  width={224}
+                  height={36}
+                  loading="lazy"
+                />
+              </a>
+            </p>
           </div>
         </section>
       </HomeContainer>

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -520,21 +520,6 @@ export default function Footer({
           {/* Mobile */}
           <div className="md:hidden text-left space-y-2 mb-6">
             <div className="text-zinc-400 text-sm">© {new Date().getFullYear()} AIFinder</div>
-            {/* Badge de Startup Fame: requisito del alta gratuita (verifican que esté en la web) */}
-            <a
-              href="https://startupfa.me/s/aifinder?utm_source=www.aifinder.es"
-              target="_blank"
-              rel="noopener"
-            >
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img
-                src="https://startupfa.me/badges/featured/dark-small.webp"
-                alt="AIFinder - Featured on Startup Fame"
-                width={224}
-                height={36}
-                loading="lazy"
-              />
-            </a>
             <div className="space-y-1">
               {legalLinks.map((link) => (
                 <Link
@@ -569,22 +554,8 @@ export default function Footer({
 
           {/* Desktop */}
           <div className="hidden md:flex flex-col md:flex-row justify-between items-center relative">
-            <div className="flex items-center gap-4 mb-4 md:mb-0">
+            <div className="flex items-center mb-4 md:mb-0">
               <span className="text-zinc-400 text-sm">© {new Date().getFullYear()} AIFinder</span>
-              <a
-                href="https://startupfa.me/s/aifinder?utm_source=www.aifinder.es"
-                target="_blank"
-                rel="noopener"
-              >
-                {/* eslint-disable-next-line @next/next/no-img-element */}
-                <img
-                  src="https://startupfa.me/badges/featured/dark-small.webp"
-                  alt="AIFinder - Featured on Startup Fame"
-                  width={224}
-                  height={36}
-                  loading="lazy"
-                />
-              </a>
             </div>
             <div className="flex items-center space-x-4">
               {legalLinks.map((link) => (


### PR DESCRIPTION
## Problema

El badge del #24 está en el Footer, pero **todo el footer se monta solo en cliente**: no aparece en el HTML que sirve Vercel (verificado con curl: ni el badge ni «Política de Privacidad» están en el HTML crudo). El verificador de Startup Fame no ejecuta JS, así que nunca lo encontraría.

## Solución

- Quitar el badge del Footer (revierte el #24).
- Ponerlo al final de la sección SEO de la home (`page.tsx`), que sí se renderiza en servidor — es donde vive «Guías para elegir», que curl sí ve.
- Bonus: queda un único enlace saliente dofollow desde la home en vez de uno en cada una de las 406 páginas.

## Verificación

- 297 tests y build OK; `startupfa.me` presente en `.next/server/app/index.html`.