### PR TITLE
feat(seo): nota editorial 1-10 en fichas con Review y pros/contras en el schema

### DIFF
--- a/src/app/herramienta/[slug]/page.tsx
+++ b/src/app/herramienta/[slug]/page.tsx
@@ -12,6 +12,7 @@ import { getComparisonsForTool } from '../../../utils/comparisons';
 import { isToolPublished, NOINDEX_ROBOTS } from '../../../utils/publishing';
 import { getToolPricing, PRICING_LAST_CHECKED } from '../../../utils/pricing';
 import { discontinuedTools } from '../../../data/discontinued';
+import { getToolRating } from '../../../data/tool-ratings';
 import { getAffiliateLink } from '../../../data/affiliates';
 import AffiliateCta from '../../../components/Affiliate/AffiliateCta';
 import AffiliateNotice from '../../../components/Affiliate/AffiliateNotice';
@@ -99,12 +100,17 @@ export default async function ToolPage({ params }: Props) {
   const pricing = getToolPricing(tool.name);
   const discontinued = discontinuedTools[tool.name];
   const affiliate = discontinued ? undefined : getAffiliateLink(tool.name);
+  // Una herramienta cerrada no lleva nota: no tiene sentido puntuar lo que ya no se puede usar.
+  const rating = discontinued ? undefined : getToolRating(tool.name);
   const categorySlug = slugify(tool.category);
   const subcategorySlug = slugify(tool.subcategory);
 
   const appJsonLd = {
     '@context': 'https://schema.org',
-    '@type': 'SoftwareApplication',
+    // Con reseña editorial la entidad se tipa también como Product: los
+    // pros/contras (positiveNotes/negativeNotes) solo son elegibles para
+    // rich results sobre Product, no sobre SoftwareApplication a secas.
+    '@type': rating !== undefined ? ['SoftwareApplication', 'Product'] : 'SoftwareApplication',
     name: tool.name,
     description: detail.intro,
     applicationCategory: 'BusinessApplication',
@@ -123,6 +129,39 @@ export default async function ToolPage({ params }: Props) {
             category: getPricingText(tool.pricing),
           },
         }),
+    // Reseña editorial con autor Organization, no AggregateRating: no hay
+    // valoraciones de usuarios y simularlas incumple las políticas de review
+    // snippets de Google. Nota y pros/contras son los mismos que se ven en la página.
+    ...(rating !== undefined
+      ? {
+          review: {
+            '@type': 'Review',
+            author: { '@type': 'Organization', name: 'AIFinder', url: baseUrl },
+            reviewRating: {
+              '@type': 'Rating',
+              ratingValue: rating,
+              bestRating: 10,
+              worstRating: 1,
+            },
+            positiveNotes: {
+              '@type': 'ItemList',
+              itemListElement: detail.pros.map((pro, index) => ({
+                '@type': 'ListItem',
+                position: index + 1,
+                name: pro,
+              })),
+            },
+            negativeNotes: {
+              '@type': 'ItemList',
+              itemListElement: detail.cons.map((con, index) => ({
+                '@type': 'ListItem',
+                position: index + 1,
+                name: con,
+              })),
+            },
+          },
+        }
+      : {}),
   };
 
   const breadcrumbJsonLd = {
@@ -224,6 +263,25 @@ export default async function ToolPage({ params }: Props) {
                 {tool.subcategory}
               </span>
             </div>
+            {rating !== undefined && (
+              <div className="flex flex-wrap items-center gap-3 mt-4">
+                <span className="inline-flex items-baseline gap-1 rounded-lg bg-white text-black px-3 py-1.5">
+                  <span className="text-2xl font-extrabold leading-none">
+                    {rating.toLocaleString('es-ES', {
+                      minimumFractionDigits: 1,
+                      maximumFractionDigits: 1,
+                    })}
+                  </span>
+                  <span className="text-sm font-semibold">/10</span>
+                </span>
+                <span className="text-zinc-400 text-sm">
+                  Nota editorial de AIFinder ·{' '}
+                  <Link href="/sobre#como-puntuamos" className="text-blue-400 hover:underline">
+                    cómo puntuamos
+                  </Link>
+                </span>
+              </div>
+            )}
           </div>
         </header>
 

--- a/src/app/sobre/page.tsx
+++ b/src/app/sobre/page.tsx
@@ -56,6 +56,40 @@ export default function SobrePage() {
           </li>
         </ul>
 
+        <h2 id="como-puntuamos" className="text-2xl font-bold mb-4">
+          Cómo puntuamos
+        </h2>
+        <p className="text-zinc-300 leading-relaxed mb-4">
+          Cada herramienta publicada lleva una{' '}
+          <strong className="text-white">nota editorial</strong> del 1 al 10. La asigna la redacción
+          de AIFinder — no es una media de valoraciones de usuarios ni un cálculo automático —
+          guiada por cuatro criterios:
+        </p>
+        <ul className="space-y-3 text-zinc-300 leading-relaxed list-disc pl-5 mb-4">
+          <li>
+            <strong className="text-white">Capacidades y resultados</strong>: qué hace y cómo de
+            bien resuelve el caso de uso para el que está pensada.
+          </li>
+          <li>
+            <strong className="text-white">Facilidad de uso</strong>: cuánto cuesta empezar y
+            sacarle partido sin ser experto.
+          </li>
+          <li>
+            <strong className="text-white">Precio frente a lo que ofrece</strong>: con los precios
+            verificados de la ficha, incluido si el plan gratuito sirve para algo real.
+          </li>
+          <li>
+            <strong className="text-white">Limitaciones</strong>: la gravedad de los inconvenientes
+            que documentamos en la propia ficha.
+          </li>
+        </ul>
+        <p className="text-zinc-300 leading-relaxed mb-8">
+          Como referencia: un 9 o más señala un referente de su categoría, un 8 una herramienta muy
+          sólida, un 7 una buena opción con peros y un 6 una herramienta correcta con limitaciones
+          serias. Las herramientas retiradas no llevan nota. Los enlaces de afiliado no influyen en
+          la puntuación, y revisamos la nota cuando una herramienta cambia de forma relevante.
+        </p>
+
         <h2 className="text-2xl font-bold mb-4">Contacto</h2>
         <p className="text-zinc-300 leading-relaxed mb-8">
           ¿Falta una herramienta, hay un precio desactualizado o algo no cuadra? Escríbenos a{' '}

--- a/src/data/__tests__/tool-ratings.test.ts
+++ b/src/data/__tests__/tool-ratings.test.ts
@@ -1,0 +1,40 @@
+import { toolRatings } from '../tool-ratings';
+import { discontinuedTools } from '../discontinued';
+import { getAllTools, getToolDetail } from '../../utils/tools';
+import { isToolPublished } from '../../utils/publishing';
+
+const ratedNames = Object.keys(toolRatings);
+
+describe('toolRatings', () => {
+  it.each(ratedNames)('%s existe en el catálogo y tiene ficha', (name) => {
+    expect(getAllTools().some((tool) => tool.name === name)).toBe(true);
+    expect(getToolDetail(name)).toBeDefined();
+  });
+
+  it.each(ratedNames)('%s tiene nota entre 1 y 10 con un decimal como mucho', (name) => {
+    const rating = toolRatings[name];
+    expect(rating).toBeGreaterThanOrEqual(1);
+    expect(rating).toBeLessThanOrEqual(10);
+    expect(Math.round(rating * 10)).toBeCloseTo(rating * 10);
+  });
+
+  it('las herramientas retiradas no llevan nota', () => {
+    for (const name of Object.keys(discontinuedTools)) {
+      expect(toolRatings[name]).toBeUndefined();
+    }
+  });
+
+  // Al abrir una tanda nueva en publishing.ts hay que puntuar sus herramientas.
+  it('toda herramienta publicada con ficha (y no retirada) tiene nota', () => {
+    const missing = getAllTools()
+      .filter(
+        (tool) =>
+          isToolPublished(tool.name) &&
+          getToolDetail(tool.name) !== undefined &&
+          !discontinuedTools[tool.name] &&
+          toolRatings[tool.name] === undefined,
+      )
+      .map((tool) => tool.name);
+    expect(missing).toEqual([]);
+  });
+});

--- a/src/data/tool-ratings.ts
+++ b/src/data/tool-ratings.ts
@@ -1,0 +1,134 @@
+/**
+ * Nota editorial de AIFinder por herramienta (1-10, un decimal), keyed por
+ * el `name` exacto del catálogo, igual que tool-details.ts.
+ *
+ * Cómo se puntúa (la metodología pública está en /sobre#como-puntuamos):
+ * la nota es una valoración editorial global guiada por cuatro criterios,
+ * no una media aritmética:
+ *   - Capacidades y resultados en su caso de uso (useCases/features/pros de la ficha)
+ *   - Facilidad de uso y adopción
+ *   - Precio frente a lo que ofrece (tool-pricing.ts cuando hay precios verificados)
+ *   - Gravedad de las limitaciones documentadas (cons de la ficha)
+ *
+ * Bandas orientativas: 9+ referente de su categoría; 8-8,9 muy sólida;
+ * 7-7,9 buena con peros; 6-6,9 correcta con limitaciones serias; <6 difícil
+ * de recomendar frente a sus alternativas. Nada por debajo de 5: lo que no
+ * llega ahí no entra en el directorio (ver /directrices).
+ *
+ * Mantenimiento: al abrir una tanda nueva en publishing.ts hay que puntuar
+ * sus herramientas (hay un test que lo exige). Las herramientas retiradas
+ * (discontinued.ts) no llevan nota. Si una ficha cambia de forma relevante
+ * (precios, capacidades), revisar su nota.
+ */
+export const toolRatings: Record<string, number> = {
+  Ada: 7.2,
+  'Adobe Firefly': 8.2,
+  AgentGPT: 6.3,
+  Alexa: 7.8,
+  AskTheCode: 6.5,
+  AskYourPDF: 7.0,
+  Assistant: 7.5,
+  AudioCraft: 6.8,
+  Aurora: 7.0,
+  AutoGen: 7.8,
+  AutoGPT: 6.6,
+  BioGPT: 6.4,
+  Bolt: 7.9,
+  Brandmark: 7.3,
+  'Canva Magic Studio': 8.3,
+  ChatGPT: 9.3,
+  'ChatGPT Agents': 8.0,
+  ChatPDF: 7.0,
+  Claude: 9.1,
+  Codium: 7.2,
+  Colossyan: 7.1,
+  'Copilot Agents': 7.4,
+  'Copy.ai': 6.2,
+  CrewAI: 7.9,
+  CrowdStrike: 8.6,
+  Cursor: 8.9,
+  'DALL·E': 8.0,
+  Darktrace: 7.8,
+  DeepL: 8.8,
+  DeepSeek: 8.4,
+  DeepSource: 7.4,
+  Descript: 8.3,
+  Diffblue: 7.0,
+  Dubverse: 6.9,
+  Einstein: 7.5,
+  ElevenLabs: 9.0,
+  Falcon: 6.7,
+  Fliki: 6.9,
+  FLUX: 8.5,
+  Gamma: 8.4,
+  Gemini: 8.8,
+  'GitHub Copilot': 8.7,
+  'Google Flow': 8.1,
+  'Google Translate': 8.2,
+  Grammarly: 7.4,
+  Grok: 8.0,
+  Haystack: 7.7,
+  HeyGen: 8.4,
+  Ideogram: 8.0,
+  IFTTT: 7.3,
+  Imagen: 8.0,
+  Intercom: 8.2,
+  InVideo: 6.8,
+  Jasper: 7.2,
+  Jules: 7.4,
+  Kling: 7.5,
+  LangChain: 7.8,
+  'LangChain Agents': 7.6,
+  LangGraph: 8.1,
+  'Leonardo AI': 8.0,
+  LivePerson: 7.0,
+  LLaMA: 8.3,
+  Looka: 7.2,
+  Make: 8.6,
+  Manus: 7.8,
+  MetaGPT: 7.0,
+  'Microsoft 365 Copilot': 7.9,
+  Midjourney: 8.8,
+  MiniMax: 7.1,
+  Mistral: 8.2,
+  Murf: 7.9,
+  n8n: 8.5,
+  'Notion AI': 7.6,
+  Perplexity: 8.6,
+  Pi: 6.6,
+  'Pika Labs': 7.6,
+  'Playground AI': 7.1,
+  'Power Automate': 7.7,
+  'Power BI': 8.6,
+  Qwen: 8.0,
+  Recraft: 8.1,
+  Replika: 6.3,
+  'Resemble AI': 7.6,
+  Runway: 8.4,
+  Seedream: 7.6,
+  SentinelOne: 8.4,
+  Siri: 7.2,
+  Speechify: 7.8,
+  'Stable Diffusion': 8.7,
+  Sudowrite: 7.3,
+  Suno: 8.5,
+  Synthesia: 8.3,
+  Tableau: 8.2,
+  Tabnine: 7.1,
+  Testim: 7.4,
+  'Trigger.dev': 7.7,
+  'Vectra AI': 7.7,
+  Veo: 8.4,
+  'Voice.ai': 6.5,
+  Voicemod: 7.4,
+  Writable: 6.4,
+  Writesonic: 7.0,
+  'xAI Agents': 7.0,
+  'You.com': 7.4,
+  Zapier: 8.5,
+  Zendesk: 8.3,
+};
+
+export function getToolRating(toolName: string): number | undefined {
+  return toolRatings[toolName];
+}


### PR DESCRIPTION
## Qué hace

- **106 herramientas publicadas puntuadas a mano** (1-10, un decimal) en `src/data/tool-ratings.ts`, asignadas una a una a partir de los pros/contras, precios verificados y posición de mercado de cada ficha. Rango real: 6,2 (Copy.ai) a 9,3 (ChatGPT); media ~7,7.
- **Bloque visible en la ficha**: la nota junto al encabezado ("8,4/10 · Nota editorial de AIFinder") con enlace a la metodología.
- **JSON-LD**: reseña editorial `Review` con autor `Organization` y `reviewRating` (1-10) anidada en el schema de la ficha. La entidad pasa a `["SoftwareApplication","Product"]` cuando lleva reseña para que los pros/contras de la ficha (ya visibles) entren como `positiveNotes`/`negativeNotes`, elegibles para el rich result de pros y contras.
- **`/sobre#como-puntuamos`**: metodología pública (4 criterios, bandas de referencia, independencia de afiliados).
- **Test de integridad** (214 casos): claves existentes en catálogo y ficha, rango y decimales, retiradas sin nota, y toda publicada con ficha debe tener nota — al abrir una tanda nueva el test obliga a puntuarla.

## Por qué Review y no AggregateRating

AggregateRating declara valoraciones agregadas de usuarios, que no tenemos; simularlas (aunque sea con ratingCount=1) incumple las políticas de review snippets de Google y arriesga acción manual. La reseña editorial con autor Organization es el markup correcto para un directorio y también es elegible para estrellas en el snippet.

## Decisiones

- Las 6 herramientas retiradas publicadas (ChatSpot, Drift, Lovo, Phind, Play.ht, Sora) **no llevan nota** ni reseña: no tiene sentido puntuar lo que no se puede usar.
- Nota **asignada, no calculada**: una fórmula sobre el nº de pros/contras daría notas clónicas y sin criterio real. La rúbrica está documentada en el header del archivo de datos y en /sobre.
- Los afiliados no salen favorecidos por patrón: ElevenLabs 9,0 y Make 8,6 (líderes reales), pero Murf 7,9, Speechify 7,8 y Gamma 8,4.

## Verificación

- 511 tests verdes (25 suites), lint sin errores nuevos.
- Build SSG: `reviewRating`, doble tipo y `positiveNotes` presentes en el HTML estático (elevenlabs, notion-ai); Sora (retirada) sin rating; ancla de /sobre en su HTML.