### PR TITLE
feat(seo): meta de verificación de Pinterest para reclamar el dominio

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -69,6 +69,10 @@ export const metadata: Metadata = {
   },
   verification: {
     google: process.env.NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION,
+    other: {
+      // Reclamación del sitio en Pinterest (cuenta info@aifinder.es)
+      'p:domain_verify': 'b1009be82d37e1ecc8e1ece7052bae6e',
+    },
   },
   category: 'technology',
   icons: {


### PR DESCRIPTION
Añade la meta-etiqueta `p:domain_verify` de Pinterest al `verification.other` del layout raíz (mismo mecanismo que la de Google). Verificado en el build: la etiqueta sale en el `<head>` del HTML estático. Necesaria para reclamar aifinder.es en la cuenta de Pinterest (atribución de pines + estadísticas).