### PR TITLE
fix(seo): availability en la oferta de las fichas

### DIFF
--- a/src/app/herramienta/[slug]/page.tsx
+++ b/src/app/herramienta/[slug]/page.tsx
@@ -127,6 +127,9 @@ export default async function ToolPage({ params }: Props) {
             price: tool.pricing === 'paid' ? undefined : '0',
             priceCurrency: 'EUR',
             category: getPricingText(tool.pricing),
+            // Requerido por Google al tipar la ficha como Product (aviso en GSC
+            // "Falta el campo availability"): un SaaS operativo está disponible.
+            availability: 'https://schema.org/InStock',
           },
         }),
     // Reseña editorial con autor Organization, no AggregateRating: no hay


### PR DESCRIPTION
GSC avisó el 21-ago en Compras → Fragmentos de productos: "Falta el campo availability (en offers)" en /herramienta/chatgpt — consecuencia esperable de tipar la ficha como Product en el PR #26. Se añade `availability: InStock` a la Offer (un SaaS operativo está disponible; las retiradas no emiten oferta). Verificado en el build. Tras el deploy, Javier pulsa "Validar corrección" en GSC.