### PR TITLE
fix(seo): las fichas de pago no emiten oferta sin precio

### DIFF
--- a/src/app/herramienta/[slug]/page.tsx
+++ b/src/app/herramienta/[slug]/page.tsx
@@ -118,13 +118,16 @@ export default async function ToolPage({ params }: Props) {
     operatingSystem: 'Web',
     url: tool.url,
     image: `${baseUrl}${tool.image}`,
-    // Una herramienta cerrada no tiene oferta que anunciar
-    ...(discontinued
+    // Una herramienta cerrada no tiene oferta que anunciar. Las de pago
+    // tampoco emiten oferta: no tienen un precio único que declarar y Google
+    // exige "price" en offers al tipar Product (error en GSC 22-ago-2026);
+    // su precio real va en la tabla visible de la ficha.
+    ...(discontinued || tool.pricing === 'paid'
       ? {}
       : {
           offers: {
             '@type': 'Offer',
-            price: tool.pricing === 'paid' ? undefined : '0',
+            price: '0',
             priceCurrency: 'EUR',
             category: getPricingText(tool.pricing),
             // Requerido por Google al tipar la ficha como Product (aviso en GSC


### PR DESCRIPTION
GSC (22-ago, /herramienta/midjourney): error "Falta el campo price (en offers)" en Fichas de comerciantes y warning equivalente en Fragmentos de productos. Las herramientas de pago emitían Offer sin `price` (no tienen un precio único que declarar). Con el tipado Product del PR #26, Google lo exige. Fix: las fichas de pago dejan de emitir `offers` — el Product sigue siendo válido vía `review`, y el precio real está en la tabla visible. Las gratis/freemium mantienen su oferta con `price: 0` + `availability`. Verificado en build: midjourney sin offers y con reviewRating; chatgpt con oferta completa.