### PR TITLE
feat(afiliados): enlace de Murf AI

### DIFF
--- a/src/data/affiliates.ts
+++ b/src/data/affiliates.ts
@@ -14,6 +14,7 @@ export const affiliateLinks: Record<string, AffiliateLink> = {
     url: 'https://www.make.com/en/register?pc=aifinder',
     perk: 'Con este enlace: 1 mes del plan Core gratis, con 10.000 créditos incluidos.',
   },
+  Murf: { url: 'https://get.murf.ai/6cwgu0ao4cvd' },
 };
 
 export function getAffiliateLink(toolName: string): AffiliateLink | undefined {


### PR DESCRIPTION
Murf AI aprobó la solicitud (email de bienvenida del 24-ago a info@aifinder.es). Se añade su enlace de referido a `affiliateLinks`: aparece automáticamente en la ficha de Murf, en sus comparativas (elevenlabs-vs-murf) y en la guía /mejores/mejores-ia-de-voz-en-espanol, con rel="sponsored" y el aviso LSSI ya existentes. Sin perk: el programa no ofrece ventaja para el usuario final, así que no se anuncia ninguna. Tercer programa activo junto a ElevenLabs y Make. Verificado en build.