### PR TITLE
feat(seo): índice del catálogo con SSR en /herramientas

### DIFF
--- a/src/app/herramientas/page.tsx
+++ b/src/app/herramientas/page.tsx
@@ -1,6 +1,68 @@
 import React from 'react';
+import Link from 'next/link';
 import ToolsPage from '../../components/Pages/ToolsPage';
+import { aiCategories } from '../../data/ai-tools';
+import { slugify } from '../../utils/slugify';
+import { getAllTools } from '../../utils/tools';
+import { isToolPublished } from '../../utils/publishing';
 
 export default function HerramientasPage() {
-  return <ToolsPage />;
+  // Índice del catálogo servido desde el servidor: la vista interactiva es de
+  // cliente y sus enlaces no llegan al HTML, así que esta era la única página
+  // del menú que no enlazaba ninguna ficha para Google.
+  const publishedSlugs = new Set(
+    getAllTools()
+      .filter((tool) => isToolPublished(tool.name))
+      .map((tool) => tool.slug),
+  );
+  const index = aiCategories
+    .map((category) => ({
+      name: category.name,
+      tools: category.subcategories
+        .flatMap((sub) => sub.tools)
+        .map((tool) => ({ name: tool.name, slug: slugify(tool.name) }))
+        .filter((tool) => publishedSlugs.has(tool.slug))
+        .filter((tool, position, list) => list.findIndex((t) => t.slug === tool.slug) === position)
+        .sort((a, b) => a.name.localeCompare(b.name, 'es')),
+    }))
+    .filter((category) => category.tools.length > 0);
+
+  const total = index.reduce((acc, category) => acc + category.tools.length, 0);
+
+  return (
+    <ToolsPage>
+      <section className="bg-black text-white border-t border-zinc-800">
+        <div className="max-w-5xl mx-auto px-4 py-12">
+          <h2 className="text-2xl font-bold mb-2">Índice del directorio</h2>
+          <p className="text-zinc-400 mb-8">
+            Las {total} herramientas con ficha publicada, ordenadas por categoría.
+          </p>
+          {index.map((category) => (
+            <div key={category.name} className="mb-8">
+              <h3 className="font-bold mb-3">
+                <Link
+                  href={`/categoria/${slugify(category.name)}`}
+                  className="text-blue-400 hover:underline"
+                >
+                  {category.name}
+                </Link>
+              </h3>
+              <ul className="flex flex-wrap gap-x-3 gap-y-2 list-none p-0 text-sm">
+                {category.tools.map((tool) => (
+                  <li key={tool.slug}>
+                    <Link
+                      href={`/herramienta/${tool.slug}`}
+                      className="text-zinc-300 hover:text-white underline decoration-zinc-700 underline-offset-4"
+                    >
+                      {tool.name}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+      </section>
+    </ToolsPage>
+  );
 }

--- a/src/components/Pages/ToolsPage.tsx
+++ b/src/components/Pages/ToolsPage.tsx
@@ -342,7 +342,12 @@ const toolsGroups: ToolsGroup[] = [
   },
 ];
 
-export default function ToolsPage() {
+/**
+ * `children` es el índice del catálogo que renderiza el servidor: esta vista
+ * es de cliente, así que sus enlaces no llegan al HTML servido y Google no
+ * podía descubrir ninguna ficha desde /herramientas (mismo caso que el footer).
+ */
+export default function ToolsPage({ children }: { children?: React.ReactNode }) {
   const [activeFilter, setActiveFilter] = useState<'all' | 'free' | 'paid'>('all');
   const [activeTab, setActiveTab] = useState<string>(toolsGroups[0].name);
   const [searchTerm, setSearchTerm] = useState('');
@@ -722,6 +727,7 @@ export default function ToolsPage() {
           );
         })}
       </div>
+      {children}
       <Footer setShowFeedback={() => {}} setShowBugReport={() => {}} />
     </div>
   );


### PR DESCRIPTION
## Problema

GSC (Indexación → Páginas) muestra 98 URLs en "Descubierta: actualmente sin indexar", todas con último rastreo N/D — Google nunca las ha visitado. Al revisar de dónde reciben enlaces internos, `curl` a producción revela que **/herramientas servía 0 enlaces a fichas**: `ToolsPage` es un componente de cliente (728 líneas), así que sus tarjetas no llegan al HTML del servidor. Es el mismo caso del footer (PR #24/#25). La página del catálogo está en el menú y en el sitemap con priority 0.9, y no repartía autoridad a ninguna ficha.

## Solución

Índice del catálogo renderizado por el servidor, pasado como `children` a `ToolsPage` (mismo patrón que `HomeContainer` en la home) y renderizado justo antes del footer. Agrupa por categoría las herramientas con ficha publicada, deduplicadas y ordenadas alfabéticamente en español; cada categoría enlaza además a su página.

La vista interactiva (filtros, tarjetas, buscador) no se toca: solo se añade el índice al final.

## Verificación

- HTML generado de /herramientas: **0 → 112 enlaces** a fichas y 16 a categorías.
- Build correcto (406 páginas), 511 tests verdes, typecheck limpio.

## Expectativa

Mejora la señal de enlazado interno hacia las fichas; no garantiza que Google rastree las 98 pendientes — eso depende de autoridad y tiempo (directorios, badge, Pinterest e IndexNow ya en marcha).